### PR TITLE
Deploy crow_all.h to the releases section on every travis run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,3 +53,22 @@ after_success:
   - if [ "$PUSH_COVERAGE" == "ON" ]; then coveralls -i include --exclude-pattern .*/http_parser_merged.h --exclude-pattern .*/TinySHA1.hpp --gcov-options '\-lp'; fi
   - chmod +x scripts/generateDocumentationAndDeploy.sh
   - if [ "$TRAVIS_BUILD_DOCS" == "ON" ]; then ./scripts/generateDocumentationAndDeploy.sh; fi
+  
+  before_deploy:
+  - git config --local user.name "Travis CI"
+  - git config --local user.email "travis@travis-ci.org"
+  - git fetch --tags -f
+  - git tag -d Nightly-CD
+  - git tag -fa Nightly-CD -m "new deploy on $(date +"%Y-%m-%d %T")"
+  - git push https://${GH_REPO_TOKEN}@${GH_REPO_REF} --tags -f
+deploy:
+  provider: releases
+  api_key:
+    secure: "CQRYHWlg/WDu5DBUeDwGo+rPeOofN08DhiLUNlLtZjMWaRyP0Cop1qVaFs8ESOkYiWek2MdpvjZud+7hL+yx2ogvNx4SfHpUMCDKYgcX+YQ9MmYwabvoKq8N6KVXE3lbPp549TonHdDuNCWNKRniNjYtrij5J+IiIiT8/6Txo2p9RWk6YSUTdXJ9YrfuWMtRuF5uo9SHGyujv8pOJKedrwWoSBbHT44jnwfHMVe/C8jgjwlrJ9N3iXOtsG6sj+UTS8vOpL+jpBONEbBfHgSFU57I7IFNdPQbSObpVwG9geOAHT7IQQyQ9hp2AJoFxxVURB5SzqztDDpQ0XIF76vuH9tA/fF2pwDsLRmcLR8JU1TCmQgvnlYD0+Or9S1Dq0tQME5AP+21Hk2zVcGdbgQP7XWix758F0vpOXa4PXw8TmAjP2jKyAMHlzR3icr3+OmKSK3uXMMt2HSMOJQ+JvFxr//DM493i/VGyeY25/zu3A9RstiE+1d82Fi9xKOmMf4smvSkjOgT0b727jqNbNe6CvEKQUmqHabzYRQzUVz6WPVDHBxZP7AiKmZIVQXYnDsVXywStkSoxxY5En6XKpq0GR3bIVtUMORgZPoZi7Jni+/4EckcYH8g9mpsQf9tPRcOZ2WIvt5gqp2MZuwBLBRcbxihuECfBscqdeA0oDU5AZw="
+  file: "build/crow_all.h"
+  skip_cleanup: true
+  overwrite: true
+  prerelease: true
+  on:
+    branch: master
+    condition: $TRAVIS_BUILD_DOCS = ON


### PR DESCRIPTION
This will use the same tag (Nightly-CD) but update the message, commit, and crow_all.h file.

I tested this on my own repo, it worked (only the release creation date didn't change).

Closes #53 