### PR TITLE
cmake install rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,3 +64,5 @@ else()
 
 	add_custom_target(amalgamation ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/crow_all.h)
 endif()
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/crow_all.h DESTINATION include)

--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -98,6 +98,18 @@ make
 ```
 Running Cmake will create `crow_all.h` file and place it in the build directory.
 
+##Installing Crow
+
+if you wish to use crow globally without copying `crow_all.h` in your projects, you can install `crow` on your machine by using `make install` command instead of `make` after `cmake..`. Thus, the procedure will look like
+
+```
+mkdir build
+cd build
+cmake ..
+make install
+```
+`make install` will copy `crow_all.h` automatically in your `/usr/local/include` thus making it available globally for use.<br>
+
 You can run tests with following commands:
 ```
 ctest -V

--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -105,7 +105,7 @@ ctest -V
 
 ##Installing Crow
 
-if you wish to use crow globally without copying `crow_all.h` in your projects, you can install Crow on your machine with the procedure below.
+if you wish to use Crow globally without copying `crow_all.h` in your projects, you can install Crow on your machine with the procedure below.
 
 ```
 mkdir build

--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -98,14 +98,14 @@ make
 ```
 Running Cmake will create `crow_all.h` file and place it in the build directory.<br>
 
-You can run tests with following commands:
+You can run tests with following command:
 ```
 ctest -V
 ```
 
 ##Installing Crow
 
-if you wish to use crow globally without copying `crow_all.h` in your projects, you can install `Crow` on your machine with the following procedure below.
+if you wish to use crow globally without copying `crow_all.h` in your projects, you can install Crow on your machine with the procedure below.
 
 ```
 mkdir build

--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -96,11 +96,16 @@ cd build
 cmake ..
 make
 ```
-Running Cmake will create `crow_all.h` file and place it in the build directory.
+Running Cmake will create `crow_all.h` file and place it in the build directory.<br>
+
+You can run tests with following commands:
+```
+ctest -V
+```
 
 ##Installing Crow
 
-if you wish to use crow globally without copying `crow_all.h` in your projects, you can install `crow` on your machine by using `make install` command instead of `make` after `cmake..`. Thus, the procedure will look like
+if you wish to use crow globally without copying `crow_all.h` in your projects, you can install `Crow` on your machine with the following procedure below.
 
 ```
 mkdir build
@@ -109,8 +114,3 @@ cmake ..
 make install
 ```
 `make install` will copy `crow_all.h` automatically in your `/usr/local/include` thus making it available globally for use.<br>
-
-You can run tests with following commands:
-```
-ctest -V
-```


### PR DESCRIPTION
closes #68
To install *crow*  globally, one should run `make install` instead of `make` after `cmake ..` this will automatically copy `crow_all.h` to `/usr/local/include`. Thus making it available gloablly