### PR TITLE
Allow handlers to return more than just strings or JSON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,10 @@ endif()
 
 if (MSVC)
 	set(Boost_USE_STATIC_LIBS "On")
-	find_package( Boost 1.52 COMPONENTS system thread regex REQUIRED )
+	find_package( Boost 1.70 COMPONENTS system thread regex REQUIRED )
 else()
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++14 -pedantic -Wextra")
-	find_package( Boost 1.52 COMPONENTS system thread REQUIRED )
+	find_package( Boost 1.70 COMPONENTS system thread REQUIRED )
 endif()
 
 include_directories(${Boost_INCLUDE_DIR})

--- a/docs/guides/routes.md
+++ b/docs/guides/routes.md
@@ -19,6 +19,10 @@ CROW_ROUTE(app, "/add/<int>/<int>")
 });
 ```
 you can see the first `<int>` is defined as `a` and the second as `b`. If you were to run this and call `http://example.com/add/1/2`, the result would be a page with `3`. Exciting!
+
+##Methods
+You can change the HTTP methods the route uses from just the default `GET` by using `method()`, your route macro should look like `CROW_ROUTE(app, "/add/<int>/<int>").methods(crow::HTTPMethod::GET, crow::HTTPMethod::PATCH)` or `CROW_ROUTE(app, "/add/<int>/<int>").methods("GET"_method, "PATCH"_method)`.
+
 ##Handler
 Basically a piece of code that gets executed whenever the client calls the associated route, usually in the form of a [lambda expression](https://en.cppreference.com/w/cpp/language/lambda). It can be as simple as `#!cpp ([](){return "Hello World"})`.<br><br>
 
@@ -40,5 +44,26 @@ For more information on `crow::response` go [here](../../reference/structcrow_1_
 
 ###return statement
 A `crow::response` is very strictly tied to a route. If you can have something in a response constructor, you can return it in a handler.<br><br>
-The main return type is `std::string`. although you could also return a `crow::json::wvalue` directly. ***(Support for more data types including third party libraries is coming soon)***<br><br>
+The main return type is `std::string`. although you could also return a `crow::json::wvalue` or `crow::multipart::message` directly.<br><br>
 For more information on the specific constructors for a `crow::response` go [here](../../reference/structcrow_1_1response.html).
+
+##Returning custom classes
+If you have your own class you want to return (without converting it to string and returning that), you can use the `crow::returnable` class.<br>
+to use the returnable class, you only need your class to publicly extend `crow::returnable`, add a `dump()` method that returns your class as an `std::string`, and add a constructor that has a `Content-Type` header as a string argument.<br><br>
+
+your class should look like the following:
+```cpp
+class a : public crow::returnable 
+{
+    a() : returnable("text/plain"){};
+
+    ...
+    ...
+    ...
+
+    std::string dump() override
+    {
+        return this.as_string();
+    }
+}
+```

--- a/examples/example_chat.cpp
+++ b/examples/example_chat.cpp
@@ -14,7 +14,7 @@ void broadcast(const string& msg)
     crow::json::wvalue x;
     x["msgs"][0] = msgs.back();
     x["last"] = msgs.size();
-    string body = crow::json::dump(x);
+    string body = x.dump();
     for(auto p : ress)
     {
         auto* res = p.first;
@@ -57,7 +57,7 @@ int main()
                 x["msgs"][i-after] = msgs[i];
             x["last"] = msgs.size();
 
-            res.write(crow::json::dump(x));
+            res.write(x.dump());
             res.end();
         }
         else

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -412,11 +412,6 @@ namespace crow
             buffers_.clear();
             buffers_.reserve(4*(res.headers.size()+5)+3);
 
-            if (res.body.empty() && res.json_value.t() != json::type::Null)
-            {
-                res.body = json::dump(res.json_value);
-            }
-
             if (!statusCodes.count(res.code))
                 res.code = 500;
             {

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -20,6 +20,7 @@ namespace crow
     template <typename Adaptor, typename Handler, typename ... Middlewares>
     class Connection;
 
+    /// An abstract class that allows any other class to be returned by a handler.
     struct returnable
     {
         std::string content_type;

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -1160,7 +1160,7 @@ namespace crow
         ///
         /// Value can mean any json value, including a JSON object.
         /// Write means this class is used to primarily assemble JSON objects using keys and values and export those into a string.
-        class wvalue
+        class wvalue //TODO attempting to make this returnable resulted in a linker error, any help is appreciated
         {
             friend class crow::mustache::template_t;
         public:

--- a/include/crow/multipart.h
+++ b/include/crow/multipart.h
@@ -1,9 +1,11 @@
 #pragma once
+
 #include <string>
 #include <vector>
 #include <sstream>
+
 #include "crow/http_request.h"
-#include "crow/http_response.h"
+#include "crow/returnable.h"
 
 namespace crow
 {

--- a/include/crow/multipart.h
+++ b/include/crow/multipart.h
@@ -31,7 +31,7 @@ namespace crow
         };
 
         ///The parsed multipart request/response
-        struct message
+        struct message : public returnable
         {
             ci_map headers;
             std::string boundary; ///< The text boundary that separates different `parts`
@@ -43,7 +43,7 @@ namespace crow
             }
 
             ///Represent all parts as a string (**does not include message headers**)
-            const std::string dump()
+            std::string dump() override
             {
                 std::stringstream str;
                 std::string delimiter = dd + boundary;
@@ -58,7 +58,7 @@ namespace crow
             }
 
             ///Represent an individual part as a string
-            const std::string dump(int part_)
+            std::string dump(int part_)
             {
                 std::stringstream str;
                 part item = parts[part_];
@@ -78,11 +78,12 @@ namespace crow
 
             ///Default constructor using default values
             message(const ci_map& headers, const std::string& boundary, const std::vector<part>& sections)
-              : headers(headers), boundary(boundary), parts(sections){}
+              : returnable("multipart/form-data"), headers(headers), boundary(boundary), parts(sections){}
 
             ///Create a multipart message from a request data
             message(const request& req)
-              : headers(req.headers),
+              : returnable("multipart/form-data"),
+                headers(req.headers),
                 boundary(get_boundary(get_header_value("Content-Type"))),
                 parts(parse_body(req.body))
             {}

--- a/include/crow/mustache.h
+++ b/include/crow/mustache.h
@@ -206,7 +206,7 @@ namespace crow
                                 switch(ctx.t())
                                 {
                                     case json::type::Number:
-                                        out += json::dump(ctx);
+                                        out += ctx.dump();
                                         break;
                                     case json::type::String:
                                         if (action.t == ActionType::Tag)

--- a/include/crow/returnable.h
+++ b/include/crow/returnable.h
@@ -12,5 +12,7 @@ struct returnable
 
     returnable(std::string ctype) : content_type {ctype}
     {}
+
+    virtual ~returnable(){};
 };
 }

--- a/include/crow/returnable.h
+++ b/include/crow/returnable.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+namespace crow
+{
+/// An abstract class that allows any other class to be returned by a handler.
+struct returnable
+{
+    std::string content_type;
+    virtual std::string dump() = 0;
+
+    returnable(std::string ctype) : content_type {ctype}
+    {}
+};
+}

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -620,35 +620,35 @@ TEST_CASE("json_write")
 {
   json::wvalue x;
   x["message"] = "hello world";
-  CHECK(R"({"message":"hello world"})" == json::dump(x));
+  CHECK(R"({"message":"hello world"})" == x.dump());
   x["message"] = std::string("string value");
-  CHECK(R"({"message":"string value"})" == json::dump(x));
+  CHECK(R"({"message":"string value"})" == x.dump());
   x["message"]["x"] = 3;
-  CHECK(R"({"message":{"x":3}})" == json::dump(x));
+  CHECK(R"({"message":{"x":3}})" == x.dump());
   x["message"]["y"] = 5;
-  CHECK((R"({"message":{"x":3,"y":5}})" == json::dump(x) ||
-           R"({"message":{"y":5,"x":3}})" == json::dump(x)));
+  CHECK((R"({"message":{"x":3,"y":5}})" == x.dump() ||
+           R"({"message":{"y":5,"x":3}})" == x.dump()));
   x["message"] = 5.5;
-  CHECK(R"({"message":5.5})" == json::dump(x));
+  CHECK(R"({"message":5.5})" == x.dump());
   x["message"] = 1234567890;
-  CHECK(R"({"message":1234567890})" == json::dump(x));
+  CHECK(R"({"message":1234567890})" == x.dump());
 
   json::wvalue y;
   y["scores"][0] = 1;
   y["scores"][1] = "king";
   y["scores"][2] = 3.5;
-  CHECK(R"({"scores":[1,"king",3.5]})" == json::dump(y));
+  CHECK(R"({"scores":[1,"king",3.5]})" == y.dump());
 
   y["scores"][2][0] = "real";
   y["scores"][2][1] = false;
   y["scores"][2][2] = true;
-  CHECK(R"({"scores":[1,"king",["real",false,true]]})" == json::dump(y));
+  CHECK(R"({"scores":[1,"king",["real",false,true]]})" == y.dump());
 
   y["scores"]["a"]["b"]["c"] = nullptr;
-  CHECK(R"({"scores":{"a":{"b":{"c":null}}}})" == json::dump(y));
+  CHECK(R"({"scores":{"a":{"b":{"c":null}}}})" == y.dump());
 
   y["scores"] = std::vector<int>{1, 2, 3};
-  CHECK(R"({"scores":[1,2,3]})" == json::dump(y));
+  CHECK(R"({"scores":[1,2,3]})" == y.dump());
 }
 
 TEST_CASE("json_copy_r_to_w_to_r")
@@ -657,7 +657,7 @@ TEST_CASE("json_copy_r_to_w_to_r")
       R"({"smallint":2,"bigint":2147483647,"fp":23.43,"fpsc":2.343e1,"str":"a string","trueval":true,"falseval":false,"nullval":null,"listval":[1,2,"foo","bar"],"obj":{"member":23,"other":"baz"}})");
   json::wvalue w{r};
   json::rvalue x =
-      json::load(json::dump(w));  // why no copy-ctor wvalue -> rvalue?
+      json::load(w.dump());  // why no copy-ctor wvalue -> rvalue?
   CHECK(2 == x["smallint"]);
   CHECK(2147483647 == x["bigint"]);
   CHECK(23.43 == x["fp"]);


### PR DESCRIPTION
Created an abstract `returnable` class which can be extended by any class the user wants to return in a handler.

closes #66