### PR TITLE
[fix] Make signal handler optional

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -82,6 +82,18 @@ namespace crow
             return router_.new_rule_tagged<Tag>(std::move(rule));
         }
 
+        self_t& signal_clear()
+        {
+            signals_.clear();
+            return *this;
+        }
+
+        self_t& signal_add(int signal_number)
+        {
+            signals_.push_back(signal_number);
+            return *this;
+        }
+
         ///Set the port that Crow will handle requests on
         self_t& port(std::uint16_t port)
         {
@@ -191,6 +203,11 @@ namespace crow
             {
                 server_ = std::move(std::unique_ptr<server_t>(new server_t(this, bindaddr_, port_, server_name_, &middlewares_, concurrency_, nullptr)));
                 server_->set_tick_function(tick_interval_, tick_function_);
+                server_->signal_clear();
+                for (auto snum : signals_)
+                {
+                    server_->signal_add(snum);
+                }
                 notify_server_start();
                 server_->run();
             }
@@ -331,6 +348,8 @@ namespace crow
         std::unique_ptr<ssl_server_t> ssl_server_;
 #endif
         std::unique_ptr<server_t> server_;
+
+        std::vector<int> signals_{SIGINT, SIGTERM};
 
         bool server_started_{false};
         std::condition_variable cv_started_;

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -173,6 +173,16 @@ namespace crow
                 io_service->stop();
         }
 
+        void signal_clear()
+        {
+            signals_.clear();
+        }
+
+        void signal_add(int signal_number)
+        {
+            signals_.add(signal_number);
+        }
+
     private:
         asio::io_service& pick_io_service()
         {


### PR DESCRIPTION
- follow up from https://github.com/ipkn/crow/pull/390
- crow app has a built in signal handler which may interfere with another signal handler
- solution: add ability to remove crow's handlers, and to add them back
    - to remove: app.signal_clear().port(<port>).multithreaded().run()
    - to add back: app.signal_add(int signal_number) 
- credit: @ilejn (I just put up a pr for his suggested patch)