### PR TITLE
Improving CMakeLists.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ html/
 *.cxxflags
 *.files
 *.includes
+
+#VS-Code
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
-# Generate the compile_commands.json file
-set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
-
 if (NOT CMAKE_BUILD_TYPE)
 	message(STATUS "No build type selected, default to Release")
 	set(CMAKE_BUILD_TYPE "Release")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,19 @@
 cmake_minimum_required(VERSION 3.15)
-project (crow_all)
+project (crow_all LANGUAGES CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
+# Set required C++ Standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+# Generate the compile_commands.json file
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+
+option(BUILD_EXAMPLES "Builds the examples in the project" OFF)
+option(BUILD_TESTING  "Builds the tests in the project"    ON)
+
 find_package(Tcmalloc)
 find_package(Threads)
-find_package(OpenSSL)
-
-if(OPENSSL_FOUND)
-	include_directories(${OPENSSL_INCLUDE_DIR})
-endif()
 
 find_program(CCACHE_FOUND ccache)
 if(CCACHE_FOUND)
@@ -29,7 +33,7 @@ if (MSVC)
 	set(Boost_USE_STATIC_LIBS "On")
 	find_package( Boost 1.52 COMPONENTS system thread regex REQUIRED )
 else()
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++14 -pedantic -Wextra")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra")
 	find_package( Boost 1.52 COMPONENTS system thread REQUIRED )
 endif()
 
@@ -43,26 +47,32 @@ include_directories("${PROJECT_INCLUDE_DIR}")
 include_directories("${PROJECT_SOURCE_DIR}")
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")  # To include crow_all.h
 
-add_subdirectory(examples)
+if(BUILD_EXAMPLES)
+  # OpenSSL is required at runtime dynamically
+  find_package(OpenSSL)
+  if(OPENSSL_FOUND)
+    include_directories(${OPENSSL_INCLUDE_DIR})
+  endif()
+ 
+  add_subdirectory(examples)
+endif()
 
-if (MSVC)
-else()
+if (NOT MSVC AND BUILD_TESTING)
 	add_subdirectory(tests)
 
 	enable_testing()
 	add_test(NAME crow_test COMMAND ${CMAKE_CURRENT_BINARY_DIR}/tests/unittest)
 	add_test(NAME template_test COMMAND ${CMAKE_CURRENT_BINARY_DIR}/tests/template/test.py WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests/template)
-
-
-	add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/crow_all.h
-		COMMAND python ${PROJECT_SOURCE_DIR}/scripts/merge_all.py
-		${PROJECT_SOURCE_DIR}/include
-		${CMAKE_CURRENT_BINARY_DIR}/crow_all.h
-		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-		DEPENDS ${PROJECT_SOURCE_DIR}/include/*.h ${PROJECT_SOURCE_DIR}/include/crow/*.h ${PROJECT_SOURCE_DIR}/include/crow/middlewares/*.h
-  )
-
-	add_custom_target(amalgamation ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/crow_all.h)
 endif()
+
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/crow_all.h
+	COMMAND python ${PROJECT_SOURCE_DIR}/scripts/merge_all.py
+	${PROJECT_SOURCE_DIR}/include
+	${CMAKE_CURRENT_BINARY_DIR}/crow_all.h
+	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+	DEPENDS ${PROJECT_SOURCE_DIR}/include/*.h ${PROJECT_SOURCE_DIR}/include/crow/*.h ${PROJECT_SOURCE_DIR}/include/crow/middlewares/*.h
+)
+
+add_custom_target(amalgamation ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/crow_all.h)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/crow_all.h DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,8 @@ option(BUILD_TESTING  "Builds the tests in the project"    OFF)
 #####################################
 # Define CMake Module Imports
 #####################################
-include(${CMAKE_SOURCE_DIR}/cmake/compiler_options.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/dependencies.cmake)
+include(${CMAKE_SOURCE_DIR}/cmake/compiler_options.cmake)
 
 #####################################
 # Define project-wide imports

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,70 +1,55 @@
-cmake_minimum_required(VERSION 3.15)
+#####################################
+# Define Project-Wide Settings
+#####################################
+cmake_minimum_required(VERSION 3.15.0 FATAL_ERROR)
+
+# Define the Project Name and Description
 project (crow_all LANGUAGES CXX)
 
+# Define the module path
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
 # Set required C++ Standard
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+
 # Generate the compile_commands.json file
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
-
-option(BUILD_EXAMPLES "Builds the examples in the project" OFF)
-option(BUILD_TESTING  "Builds the tests in the project"    ON)
-
-find_package(Tcmalloc)
-find_package(Threads)
-
-find_program(CCACHE_FOUND ccache)
-if(CCACHE_FOUND)
-  message("Found ccache ${CCACHE_FOUND}")
-  message("Using ccache to speed up compilation")
-  set(ENV{CCACHE_CPP2} "yes")
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-endif(CCACHE_FOUND)
 
 if (NOT CMAKE_BUILD_TYPE)
 	message(STATUS "No build type selected, default to Release")
 	set(CMAKE_BUILD_TYPE "Release")
 endif()
 
-if (MSVC)
-	set(Boost_USE_STATIC_LIBS "On")
-	find_package( Boost 1.52 COMPONENTS system thread regex REQUIRED )
-else()
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra")
-	find_package( Boost 1.52 COMPONENTS system thread REQUIRED )
+#####################################
+# Define Options
+#####################################
+option(BUILD_EXAMPLES "Builds the examples in the project" OFF)
+option(BUILD_TESTING  "Builds the tests in the project"    OFF)
+
+#####################################
+# Define CMake Module Imports
+#####################################
+include(${CMAKE_SOURCE_DIR}/cmake/compiler_options.cmake)
+include(${CMAKE_SOURCE_DIR}/cmake/dependencies.cmake)
+
+#####################################
+# Define project-wide imports
+#####################################
+# this can be alternatively (and as recommended way) done with target_include_directories()
+if(BUILD_EXAMPLES OR BUILD_TESTING)
+	set(PROJECT_INCLUDE_DIR
+		${PROJECT_SOURCE_DIR}/include
+	)
+
+	include_directories("${PROJECT_INCLUDE_DIR}")
+	include_directories("${PROJECT_SOURCE_DIR}")
+	include_directories("${CMAKE_CURRENT_BINARY_DIR}")  # To include crow_all.h
 endif()
 
-include_directories(${Boost_INCLUDE_DIR})
-
-set(PROJECT_INCLUDE_DIR
-  ${PROJECT_SOURCE_DIR}/include
-)
-
-include_directories("${PROJECT_INCLUDE_DIR}")
-include_directories("${PROJECT_SOURCE_DIR}")
-include_directories("${CMAKE_CURRENT_BINARY_DIR}")  # To include crow_all.h
-
-if(BUILD_EXAMPLES)
-  # OpenSSL is required at runtime dynamically
-  find_package(OpenSSL)
-  if(OPENSSL_FOUND)
-    include_directories(${OPENSSL_INCLUDE_DIR})
-  endif()
- 
-  add_subdirectory(examples)
-endif()
-
-if (NOT MSVC AND BUILD_TESTING)
-	add_subdirectory(tests)
-
-	enable_testing()
-	add_test(NAME crow_test COMMAND ${CMAKE_CURRENT_BINARY_DIR}/tests/unittest)
-	add_test(NAME template_test COMMAND ${CMAKE_CURRENT_BINARY_DIR}/tests/template/test.py WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests/template)
-endif()
-
+#####################################
+# Define Targets
+#####################################
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/crow_all.h
 	COMMAND python ${PROJECT_SOURCE_DIR}/scripts/merge_all.py
 	${PROJECT_SOURCE_DIR}/include
@@ -73,6 +58,23 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/crow_all.h
 	DEPENDS ${PROJECT_SOURCE_DIR}/include/*.h ${PROJECT_SOURCE_DIR}/include/crow/*.h ${PROJECT_SOURCE_DIR}/include/crow/middlewares/*.h
 )
 
+# Amalgamation
 add_custom_target(amalgamation ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/crow_all.h)
 
+# Examples
+if(BUILD_EXAMPLES)
+	add_subdirectory(examples)
+endif()
+
+# Tests
+if (NOT MSVC AND BUILD_TESTING)
+	add_subdirectory(tests)
+	enable_testing()
+	add_test(NAME crow_test COMMAND ${CMAKE_CURRENT_BINARY_DIR}/tests/unittest)
+	add_test(NAME template_test COMMAND ${CMAKE_CURRENT_BINARY_DIR}/tests/template/test.py WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tests/template)
+endif()
+
+#####################################
+# Install Files
+#####################################
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/crow_all.h DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,11 +39,11 @@ include(${CMAKE_SOURCE_DIR}/cmake/dependencies.cmake)
 # this can be alternatively (and as recommended way) done with target_include_directories()
 if(BUILD_EXAMPLES OR BUILD_TESTING)
 	set(PROJECT_INCLUDE_DIR
-		${PROJECT_SOURCE_DIR}/include
+		${CMAKE_SOURCE_DIR}/include
 	)
 
 	include_directories("${PROJECT_INCLUDE_DIR}")
-	include_directories("${PROJECT_SOURCE_DIR}")
+	include_directories("${CMAKE_SOURCE_DIR}")
 	include_directories("${CMAKE_CURRENT_BINARY_DIR}")  # To include crow_all.h
 endif()
 
@@ -51,11 +51,11 @@ endif()
 # Define Targets
 #####################################
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/crow_all.h
-	COMMAND python ${PROJECT_SOURCE_DIR}/scripts/merge_all.py
-	${PROJECT_SOURCE_DIR}/include
+	COMMAND python ${CMAKE_SOURCE_DIR}/scripts/merge_all.py
+	${CMAKE_SOURCE_DIR}/include
 	${CMAKE_CURRENT_BINARY_DIR}/crow_all.h
 	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-	DEPENDS ${PROJECT_SOURCE_DIR}/include/*.h ${PROJECT_SOURCE_DIR}/include/crow/*.h ${PROJECT_SOURCE_DIR}/include/crow/middlewares/*.h
+	DEPENDS ${CMAKE_SOURCE_DIR}/include/*.h ${CMAKE_SOURCE_DIR}/include/crow/*.h ${CMAKE_SOURCE_DIR}/include/crow/middlewares/*.h
 )
 
 # Amalgamation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,8 @@ endif()
 #####################################
 # Define Options
 #####################################
-option(BUILD_EXAMPLES "Builds the examples in the project" OFF)
-option(BUILD_TESTING  "Builds the tests in the project"    OFF)
+option(BUILD_EXAMPLES "Builds the examples in the project" ON)
+option(BUILD_TESTING  "Builds the tests in the project"    ON)
 
 #####################################
 # Define CMake Module Imports

--- a/cmake/compiler_options.cmake
+++ b/cmake/compiler_options.cmake
@@ -1,0 +1,28 @@
+# Compiler options with hardening flags
+
+if(MSVC)
+
+  list(APPEND compiler_options 
+    /W4
+    /permissive-
+    $<$<CONFIG:RELEASE>:/O2 /Ob2 >
+    $<$<CONFIG:MINSIZEREL>:/O1 /Ob1>
+    $<$<CONFIG:RELWITHDEBINFO>:/Zi /O2 /Ob1>
+    $<$<CONFIG:DEBUG>:/Zi /Ob0 /Od /RTC1>)
+
+else(MSVC)
+
+  list(APPEND compiler_options 
+    -Wall
+    -Wextra
+    -Wpedantic
+    $<$<CONFIG:RELEASE>:-O2>
+    $<$<CONFIG:DEBUG>:-O0>
+    $<$<CONFIG:DEBUG>:-g>
+    $<$<CONFIG:DEBUG>:-p>
+    $<$<CONFIG:DEBUG>:-pg>)
+
+endif()
+
+# This can also be done with target_compile_options() [recommended]
+set(CMAKE_CXX_FLAGS "${compiler_options}")

--- a/cmake/compiler_options.cmake
+++ b/cmake/compiler_options.cmake
@@ -5,7 +5,7 @@ if(MSVC)
   list(APPEND compiler_options 
     /W4
     /permissive-
-    $<$<CONFIG:RELEASE>:/O2 /Ob2 >
+    $<$<CONFIG:RELEASE>:/O2 /Ob2>
     $<$<CONFIG:MINSIZEREL>:/O1 /Ob1>
     $<$<CONFIG:RELWITHDEBINFO>:/Zi /O2 /Ob1>
     $<$<CONFIG:DEBUG>:/Zi /Ob0 /Od /RTC1>)
@@ -23,6 +23,3 @@ else(MSVC)
     $<$<CONFIG:DEBUG>:-pg>)
 
 endif()
-
-# This can also be done with target_compile_options() [recommended]
-set(CMAKE_CXX_FLAGS "${compiler_options}")

--- a/cmake/compiler_options.cmake
+++ b/cmake/compiler_options.cmake
@@ -17,9 +17,6 @@ else(MSVC)
     -Wextra
     -Wpedantic
     $<$<CONFIG:RELEASE>:-O2>
-    $<$<CONFIG:DEBUG>:-O0>
-    $<$<CONFIG:DEBUG>:-g>
-    $<$<CONFIG:DEBUG>:-p>
-    $<$<CONFIG:DEBUG>:-pg>)
+    $<$<CONFIG:DEBUG>:-O0 -g -p -pg>)
 
 endif()

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -10,14 +10,14 @@ if(BUILD_EXAMPLES OR BUILD_TESTING)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
   endif(CCACHE_FOUND)
 
-	find_package(Tcmalloc)
+  find_package(Tcmalloc)
   find_package(Threads)
 
   if (MSVC)
     set(Boost_USE_STATIC_LIBS ON)
-    find_package( Boost 1.52 COMPONENTS system thread regex REQUIRED )
+    find_package( Boost 1.64.0 COMPONENTS system thread regex REQUIRED )
   else()
-    find_package( Boost 1.52 COMPONENTS system thread REQUIRED )
+    find_package( Boost 1.64.0 COMPONENTS system thread REQUIRED )
   endif()
 
   if(Boost_FOUND)
@@ -26,7 +26,8 @@ if(BUILD_EXAMPLES OR BUILD_TESTING)
 endif()
 
 if(BUILD_EXAMPLES)
-  # OpenSSL is required at runtime dynamically by examples
+  # OpenSSL is needed at runtime dynamically by some examples
+  # if it isn't installed, the examples won't be built
   find_package(OpenSSL)
   if(OPENSSL_FOUND)
     include_directories(${OPENSSL_INCLUDE_DIR})

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,9 +1,6 @@
 # Dependencies
 
 if(BUILD_EXAMPLES OR BUILD_TESTING)
-	find_package(Tcmalloc)
-  find_package(Threads)
-
   find_program(CCACHE_FOUND ccache)
   if(CCACHE_FOUND)
     message("Found ccache ${CCACHE_FOUND}")
@@ -12,6 +9,9 @@ if(BUILD_EXAMPLES OR BUILD_TESTING)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
   endif(CCACHE_FOUND)
+
+	find_package(Tcmalloc)
+  find_package(Threads)
 
   if (MSVC)
     set(Boost_USE_STATIC_LIBS ON)
@@ -32,5 +32,4 @@ if(BUILD_EXAMPLES)
   if(OPENSSL_FOUND)
     include_directories(${OPENSSL_INCLUDE_DIR})
   endif()
-
 endif()

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -23,7 +23,6 @@ if(BUILD_EXAMPLES OR BUILD_TESTING)
   if(Boost_FOUND)
     include_directories(${Boost_INCLUDE_DIR})
   endif()
-
 endif()
 
 if(BUILD_EXAMPLES)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,0 +1,36 @@
+# Dependencies
+
+if(BUILD_EXAMPLES OR BUILD_TESTING)
+	find_package(Tcmalloc)
+  find_package(Threads)
+
+  find_program(CCACHE_FOUND ccache)
+  if(CCACHE_FOUND)
+    message("Found ccache ${CCACHE_FOUND}")
+    message("Using ccache to speed up compilation")
+    set(ENV{CCACHE_CPP2} "yes")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+  endif(CCACHE_FOUND)
+
+  if (MSVC)
+    set(Boost_USE_STATIC_LIBS ON)
+    find_package( Boost 1.52 COMPONENTS system thread regex REQUIRED )
+  else()
+    find_package( Boost 1.52 COMPONENTS system thread REQUIRED )
+  endif()
+
+  if(Boost_FOUND)
+    include_directories(${Boost_INCLUDE_DIR})
+  endif()
+
+endif()
+
+if(BUILD_EXAMPLES)
+  # OpenSSL is required at runtime dynamically by examples
+  find_package(OpenSSL)
+  if(OPENSSL_FOUND)
+    include_directories(${OPENSSL_INCLUDE_DIR})
+  endif()
+
+endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,59 +1,60 @@
 cmake_minimum_required(VERSION 3.15)
 project (crow_examples)
 
+# Define Required libraries 
+list(APPEND REQUIRED_LIBRARIES 
+  ${Boost_LIBRARIES}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
+
 if (MSVC)
   add_executable(example_vs example_vs.cpp)
-  target_link_libraries(example_vs ${Boost_LIBRARIES})
-  target_link_libraries(example_vs ${CMAKE_THREAD_LIBS_INIT})
+  target_link_libraries(example_vs )
 else ()
   add_executable(helloworld helloworld.cpp)
-  target_link_libraries(helloworld ${Boost_LIBRARIES})
-  target_link_libraries(helloworld ${CMAKE_THREAD_LIBS_INIT})
+  target_link_libraries(helloworld PUBLIC ${REQUIRED_LIBRARIES})
 
-if (OPENSSL_FOUND)
-  add_executable(example_ssl ssl/example_ssl.cpp)
-  target_link_libraries(example_ssl ${Boost_LIBRARIES})
-  target_link_libraries(example_ssl ${CMAKE_THREAD_LIBS_INIT} ${OPENSSL_LIBRARIES})
-endif()
+  if (OPENSSL_FOUND)
+    add_executable(example_ssl ssl/example_ssl.cpp)
+    target_link_libraries(example_ssl PUBLIC ${REQUIRED_LIBRARIES} ${OPENSSL_LIBRARIES})
+  endif()
 
-add_executable(example_websocket websocket/example_ws.cpp)
-target_link_libraries(example_websocket ${Boost_LIBRARIES})
-target_link_libraries(example_websocket ${CMAKE_THREAD_LIBS_INIT} ${OPENSSL_LIBRARIES})
-add_custom_command(OUTPUT ws.html
-  COMMAND ${CMAKE_COMMAND} -E
-  copy ${PROJECT_SOURCE_DIR}/websocket/templates/ws.html ${CMAKE_CURRENT_BINARY_DIR}/templates/ws.html
-  DEPENDS ${PROJECT_SOURCE_DIR}/websocket/templates/ws.html
-)
-add_custom_target(example_ws_copy ALL DEPENDS ws.html)
+  add_executable(example_websocket websocket/example_ws.cpp)
+  target_link_libraries(example_websocket )
+  target_link_libraries(example_websocket PUBLIC ${REQUIRED_LIBRARIES})
+  add_custom_command(OUTPUT ws.html
+    COMMAND ${CMAKE_COMMAND} -E
+    copy ${PROJECT_SOURCE_DIR}/websocket/templates/ws.html ${CMAKE_CURRENT_BINARY_DIR}/templates/ws.html
+    DEPENDS ${PROJECT_SOURCE_DIR}/websocket/templates/ws.html
+  )
+  add_custom_target(example_ws_copy ALL DEPENDS ws.html)
 
-add_executable(basic_example example.cpp)
-target_link_libraries(basic_example ${Boost_LIBRARIES})
-target_link_libraries(basic_example ${CMAKE_THREAD_LIBS_INIT})
+  add_executable(basic_example example.cpp)
+  target_link_libraries(basic_example PUBLIC ${REQUIRED_LIBRARIES})
 
-if (Tcmalloc_FOUND)
-  target_link_libraries(basic_example ${Tcmalloc_LIBRARIES})
-endif(Tcmalloc_FOUND)
+  if (Tcmalloc_FOUND)
+    target_link_libraries(basic_example ${Tcmalloc_LIBRARIES})
+  endif(Tcmalloc_FOUND)
 
-add_executable(example_with_all example_with_all.cpp)
-add_dependencies(example_with_all amalgamation)
-target_link_libraries(example_with_all ${Boost_LIBRARIES})
-target_link_libraries(example_with_all ${CMAKE_THREAD_LIBS_INIT})
+  add_executable(example_with_all example_with_all.cpp)
+  add_dependencies(example_with_all amalgamation)
+  target_link_libraries(example_with_all PUBLIC ${REQUIRED_LIBRARIES})
 
-add_custom_command(OUTPUT example_test.py
-  COMMAND ${CMAKE_COMMAND} -E
-  copy ${PROJECT_SOURCE_DIR}/example_test.py ${CMAKE_CURRENT_BINARY_DIR}/example_test.py
-  DEPENDS ${PROJECT_SOURCE_DIR}/example_test.py 
-)
-add_custom_target(example_copy ALL DEPENDS example_test.py)
+  add_custom_command(OUTPUT example_test.py
+    COMMAND ${CMAKE_COMMAND} -E
+    copy ${PROJECT_SOURCE_DIR}/example_test.py ${CMAKE_CURRENT_BINARY_DIR}/example_test.py
+    DEPENDS ${PROJECT_SOURCE_DIR}/example_test.py 
+  )
+  add_custom_target(example_copy ALL DEPENDS example_test.py)
 
-add_executable(example_chat example_chat.cpp)
-target_link_libraries(example_chat ${Boost_LIBRARIES})
-target_link_libraries(example_chat ${CMAKE_THREAD_LIBS_INIT})
-add_custom_command(OUTPUT example_chat.html
-  COMMAND ${CMAKE_COMMAND} -E
-  copy ${PROJECT_SOURCE_DIR}/example_chat.html ${CMAKE_CURRENT_BINARY_DIR}/example_chat.html
-  DEPENDS ${PROJECT_SOURCE_DIR}/example_chat.html 
-)
-add_custom_target(example_chat_copy ALL DEPENDS example_chat.html)
+  add_executable(example_chat example_chat.cpp)
+  target_link_libraries(example_chat PUBLIC ${REQUIRED_LIBRARIES})
+
+  add_custom_command(OUTPUT example_chat.html
+    COMMAND ${CMAKE_COMMAND} -E
+    copy ${PROJECT_SOURCE_DIR}/example_chat.html ${CMAKE_CURRENT_BINARY_DIR}/example_chat.html
+    DEPENDS ${PROJECT_SOURCE_DIR}/example_chat.html 
+  )
+  add_custom_target(example_chat_copy ALL DEPENDS example_chat.html)
 
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,6 +16,7 @@ else ()
   target_compile_options(helloworld PRIVATE "${compiler_options}")
   target_link_libraries(helloworld PUBLIC ${REQUIRED_LIBRARIES})
 
+  # If OpenSSL is not found, the example won't be built
   if (OPENSSL_FOUND)
     add_executable(example_ssl ssl/example_ssl.cpp)
     target_compile_options(example_ssl PRIVATE "${compiler_options}")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,6 +21,8 @@ else ()
     add_executable(example_ssl ssl/example_ssl.cpp)
     target_compile_options(example_ssl PRIVATE "${compiler_options}")
     target_link_libraries(example_ssl PUBLIC ${REQUIRED_LIBRARIES} ${OPENSSL_LIBRARIES})
+  else()
+    message(STATUS "example_ssl Example deactivated - OpenSSL was not found")
   endif()
 
   add_executable(example_websocket websocket/example_ws.cpp)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,17 +9,21 @@ list(APPEND REQUIRED_LIBRARIES
 
 if (MSVC)
   add_executable(example_vs example_vs.cpp)
+  target_compile_options(example_vs PRIVATE "${compiler_options}")
   target_link_libraries(example_vs )
 else ()
   add_executable(helloworld helloworld.cpp)
+  target_compile_options(helloworld PRIVATE "${compiler_options}")
   target_link_libraries(helloworld PUBLIC ${REQUIRED_LIBRARIES})
 
   if (OPENSSL_FOUND)
     add_executable(example_ssl ssl/example_ssl.cpp)
+    target_compile_options(example_ssl PRIVATE "${compiler_options}")
     target_link_libraries(example_ssl PUBLIC ${REQUIRED_LIBRARIES} ${OPENSSL_LIBRARIES})
   endif()
 
   add_executable(example_websocket websocket/example_ws.cpp)
+  target_compile_options(example_websocket PRIVATE "${compiler_options}")
   target_link_libraries(example_websocket )
   target_link_libraries(example_websocket PUBLIC ${REQUIRED_LIBRARIES})
   add_custom_command(OUTPUT ws.html
@@ -30,6 +34,7 @@ else ()
   add_custom_target(example_ws_copy ALL DEPENDS ws.html)
 
   add_executable(basic_example example.cpp)
+  target_compile_options(basic_example PRIVATE "${compiler_options}")
   target_link_libraries(basic_example PUBLIC ${REQUIRED_LIBRARIES})
 
   if (Tcmalloc_FOUND)
@@ -38,6 +43,7 @@ else ()
 
   add_executable(example_with_all example_with_all.cpp)
   add_dependencies(example_with_all amalgamation)
+  target_compile_options(example_with_all PRIVATE "${compiler_options}")
   target_link_libraries(example_with_all PUBLIC ${REQUIRED_LIBRARIES})
 
   add_custom_command(OUTPUT example_test.py
@@ -48,6 +54,7 @@ else ()
   add_custom_target(example_copy ALL DEPENDS example_test.py)
 
   add_executable(example_chat example_chat.cpp)
+  target_compile_options(example_chat PRIVATE "${compiler_options}")
   target_link_libraries(example_chat PUBLIC ${REQUIRED_LIBRARIES})
 
   add_custom_command(OUTPUT example_chat.html

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,9 +6,9 @@ set(TEST_SRCS
 )
 
 add_executable(unittest ${TEST_SRCS})
-target_link_libraries(unittest ${Boost_LIBRARIES})
-target_link_libraries(unittest ${CMAKE_THREAD_LIBS_INIT})
-set_target_properties(unittest PROPERTIES COMPILE_FLAGS "-Wall -Werror -std=c++14")
+target_link_libraries(unittest ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+# set target compile options as defined in the cmake/compiler_options.cmake Module
+target_compile_options(unittest PRIVATE ${compiler_options})
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set_target_properties(unittest PROPERTIES COMPILE_FLAGS "--coverage -fprofile-arcs -ftest-coverage")

--- a/tests/template/CMakeLists.txt
+++ b/tests/template/CMakeLists.txt
@@ -10,8 +10,7 @@ set(TEST_SRCS
 )
 
 add_executable(mustachetest ${TEST_SRCS})
-set_target_properties(mustachetest PROPERTIES COMPILE_FLAGS "-Wall -Werror -std=c++14")
-
+target_compile_options(mustachetest PRIVATE "${compiler_options}")
 file(COPY DIRECTORY . DESTINATION ${CMAKE_CURRENT_BINARY_DIR} FILES_MATCHING PATTERN "*.json")
 
 add_custom_command(OUTPUT test.py


### PR DESCRIPTION
Hello

as suggested by Conan team, I've made some changes to the CMakeLists to make it better supported by conan recipes (but also by other package managers as well), using only what's needed and enabling/disabling tests and examples.

Here's a short list of what I'm trying to change upstream:

- Added options BUILD_EXAMPLES and BUILD_TESTING to switch examples on/off during compilation: examples are not built by default, Tests are
- Using standard CMake variable `CMAKE_CXX_STANDARD` to set the C++ Standard, independently from the compiler
- Using OpenSSL only if BUILD_EXAMPLES are activated, since it's required by Boost ASIO only at runtime as dynamic library

The Conan recipe is going under review here: https://github.com/conan-io/conan-center-index/pull/4085

If this change is merged in the master branch, I'd kindly ask you to make a new Release tag, so it can be used in the Conan recipe as well.
