### PR TITLE
Template documentation fix + log when template is not found

### DIFF
--- a/docs/guides/templating.md
+++ b/docs/guides/templating.md
@@ -10,7 +10,7 @@ There are 2 components of a mustache template implementation:
 - Context
 
 ###Page
-The HTML page (including the mustache tags). It is usually loaded into `crow::mustache::template_t`. It needs to be placed in `templates` directory (relative to where the crow executable is).<br><br>
+The HTML page (including the mustache tags). It is usually loaded into `crow::mustache::template_t`. It needs to be placed in the *templates directory* which should be directly inside the current working directory of the crow executable.<br><br>
 
 For more information on how to formulate a template, see [this mustache manual](http://mustache.github.io/mustache.5.html).
 

--- a/include/crow/mustache.h
+++ b/include/crow/mustache.h
@@ -5,6 +5,7 @@
 #include <iterator>
 #include <functional>
 #include "crow/json.h"
+#include "crow/logging.h"
 namespace crow
 {
     namespace mustache
@@ -556,7 +557,10 @@ namespace crow
             path += filename;
             std::ifstream inf(path);
             if (!inf)
+            {
+                CROW_LOG_WARNING << "Template \"" << filename << "\" not found.";
                 return {};
+            }
             return {std::istreambuf_iterator<char>(inf), std::istreambuf_iterator<char>()};
         }
 


### PR DESCRIPTION
Updated templating documentation to mention "working directory" rather than "executable directory".
Added Warning log when a template is not found.

closes #100 