### PR TITLE
static_assert to assist in diagnosis of incorrect response funcs

### DIFF
--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -176,6 +176,12 @@ namespace crow
                     !std::is_same<typename std::tuple_element<0, std::tuple<Args..., void>>::type, const request&>::value
                 , int>::type = 0)
                 {
+#ifdef _MSC_VER
+                    static_assert(
+                        std::is_convertible<typename std::result_of<Func(Args...)>::type,
+                                crow::response>::value,
+                        "supplied callback must return type that can be cast to crow::response and cannot be void");
+#endif
                     handler_ = (
 #ifdef CROW_CAN_USE_CPP14
                         [f = std::move(f)]


### PR DESCRIPTION
As previously mentioned, code such as this:

```cpp
    app.route_dynamic("/add/<int>/<int>")
    ([](crow::response& res, int a, int b){
        std::ostringstream os;
        os << a+b;
        res.write(os.str());
        res.end();
    });
```

Triggers an unhelpful error relating to crow::response not accepting `void` as a valid type.  Though I would have assumed this would affect all compilers, I can only assume this is not the case else it would have been dealt with.

I'm not entirely sure how could actually fix this so that a void return was acceptable, I am tempted to suggest adding an explicit constructor, but 

    response(void)  {}

seems a little silly when you already have

    response() {}

It is certainly silly enough to be a MSVC issue.   

This patch merely provides an explicit indication of why the code will not compile (note: this does break your unit tests).
