### PR TITLE
recast 64-bit size_t to 32-bit int to remove warnings

### DIFF
--- a/include/crow/dumb_timer_queue.h
+++ b/include/crow/dumb_timer_queue.h
@@ -26,7 +26,7 @@ namespace crow
                 if (!self)
                     return;
 
-                unsigned int index = (unsigned int)(k.second - self->step_);
+                unsigned int index = static_cast<unsigned>(k.second - self->step_);
                 if (index < self->dq_.size())
                     self->dq_[index].second = nullptr;
             }

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -317,7 +317,7 @@ namespace crow
                 res.is_alive_helper_ = [this]()->bool{ return adaptor_.is_open(); };
 
                 ctx_ = detail::context<Middlewares...>();
-                req.middleware_context = (void*)&ctx_;
+                req.middleware_context = static_cast<void*>(&ctx_);
                 req.io_service = &adaptor_.get_io_service();
                 detail::middleware_call_helper<0, decltype(ctx_), decltype(*middlewares_), Middlewares...>(*middlewares_, req, res, ctx_);
 
@@ -351,7 +351,7 @@ namespace crow
 
                 // call all after_handler of middlewares
                 detail::after_handlers_call_helper<
-                    ((int)sizeof...(Middlewares)-1),
+                    (static_cast<int>(sizeof...(Middlewares))-1),
                     decltype(ctx_),
                     decltype(*middlewares_)>
                 (*middlewares_, ctx_, req_, res);

--- a/include/crow/http_parser_merged.h
+++ b/include/crow/http_parser_merged.h
@@ -1234,7 +1234,7 @@ static const int8_t unhex[256] =
           goto error;
         }
 
-        parser->method = (enum http_method) 0;
+        parser->method = static_cast<http_method>(0);
         parser->index = 1;
         switch (ch) {
           case 'C': parser->method = HTTP_CONNECT; /* or COPY, CHECKOUT */ break;
@@ -1357,7 +1357,7 @@ static const int8_t unhex[256] =
           parser->state = s_req_server_start;
         }
 
-        parser->state = parse_url_char((enum state)parser->state, ch);
+        parser->state = parse_url_char(static_cast<state>(parser->state), ch);
         if (parser->state == s_dead) {
           CROW_SET_ERRNO(HPE_INVALID_URL);
           goto error;
@@ -1379,7 +1379,7 @@ static const int8_t unhex[256] =
             CROW_SET_ERRNO(HPE_INVALID_URL);
             goto error;
           default:
-            parser->state = parse_url_char((enum state)parser->state, ch);
+            parser->state = parse_url_char(static_cast<state>(parser->state), ch);
             if (parser->state == s_dead) {
               CROW_SET_ERRNO(HPE_INVALID_URL);
               goto error;
@@ -1412,7 +1412,7 @@ static const int8_t unhex[256] =
             CROW_CALLBACK_DATA(url);
             break;
           default:
-            parser->state = parse_url_char((enum state)parser->state, ch);
+            parser->state = parse_url_char(static_cast<state>(parser->state), ch);
             if (parser->state == s_dead) {
               CROW_SET_ERRNO(HPE_INVALID_URL);
               goto error;
@@ -2086,7 +2086,7 @@ static const int8_t unhex[256] =
         assert(parser->nread == 1);
         assert(parser->flags & F_CHUNKED);
 
-        unhex_val = unhex[(unsigned char)ch];
+        unhex_val = unhex[static_cast<unsigned char>(ch)];
         if (unhex_val == -1) {
           CROW_SET_ERRNO(HPE_INVALID_CHUNK_SIZE);
           goto error;
@@ -2108,7 +2108,7 @@ static const int8_t unhex[256] =
           break;
         }
 
-        unhex_val = unhex[(unsigned char)ch];
+        unhex_val = unhex[static_cast<unsigned char>(ch)];
 
         if (unhex_val == -1) {
           if (ch == ';' || ch == ' ') {
@@ -2567,7 +2567,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
       return 1;
     }
 
-    u->port = (uint16_t) v;
+    u->port = static_cast<uint16_t>(v);
   }
 
   return 0;

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -172,7 +172,7 @@ namespace crow
                 uint8_t owned_{0};
                 friend std::ostream& operator << (std::ostream& os, const r_string& s)
                 {
-                    os << (std::string)s;
+                    os << static_cast<std::string>(s);
                     return os;
                 }
             private:
@@ -292,7 +292,7 @@ namespace crow
 
             explicit operator int() const
             {
-                return (int)i();
+                return static_cast<int>(i());
             }
 
             /// The type of the JSON value.
@@ -522,7 +522,7 @@ namespace crow
 #ifndef CROW_JSON_NO_ERROR_CHECK
                 if (t() != type::List)
                     throw std::runtime_error("value is not a list");
-                if (index >= (int)lsize_ || index < 0)
+                if (index >= static_cast<int>(lsize_) || index < 0)
                     throw std::runtime_error("list out of bound");
 #endif
                 return l_[index];
@@ -905,7 +905,7 @@ namespace crow
                         switch(*data)
                         {
                             case '0':
-                                state = (NumberParsingState)"\2\2\7\3\4\6\6"[state];
+                                state = static_cast<NumberParsingState>("\2\2\7\3\4\6\6"[state]);
                                 /*if (state == NumberParsingState::Minus || state == NumberParsingState::AfterMinus)
                                 {
                                     state = NumberParsingState::ZeroFirst;
@@ -926,7 +926,7 @@ namespace crow
                             case '1': case '2': case '3': 
                             case '4': case '5': case '6': 
                             case '7': case '8': case '9':
-                                state = (NumberParsingState)"\3\3\7\3\4\6\6"[state];
+                                state = static_cast<NumberParsingState>("\3\3\7\3\4\6\6"[state]);
                                 while(*(data+1) >= '0' && *(data+1) <= '9') data++;
                                 /*if (state == NumberParsingState::Minus || state == NumberParsingState::AfterMinus)
                                 {
@@ -946,7 +946,7 @@ namespace crow
                                     return {};*/
                                 break;
                             case '.':
-                                state = (NumberParsingState)"\7\7\4\4\7\7\7"[state];
+                                state = static_cast<NumberParsingState>("\7\7\4\4\7\7\7"[state]);
                                 /*
                                 if (state == NumberParsingState::Digits || state == NumberParsingState::ZeroFirst)
                                 {
@@ -957,7 +957,7 @@ namespace crow
                                 */
                                 break;
                             case '-':
-                                state = (NumberParsingState)"\1\7\7\7\7\6\7"[state];
+                                state = static_cast<NumberParsingState>("\1\7\7\7\7\6\7"[state]);
                                 /*if (state == NumberParsingState::Minus)
                                 {
                                     state = NumberParsingState::AfterMinus;
@@ -970,7 +970,7 @@ namespace crow
                                     return {};*/
                                 break;
                             case '+':
-                                state = (NumberParsingState)"\7\7\7\7\7\6\7"[state];
+                                state = static_cast<NumberParsingState>("\7\7\7\7\7\6\7"[state]);
                                 /*if (state == NumberParsingState::E)
                                 {
                                     state = NumberParsingState::DigitsAfterE;
@@ -979,7 +979,7 @@ namespace crow
                                     return {};*/
                                 break;
                             case 'e': case 'E':
-                                state = (NumberParsingState)"\7\7\7\5\5\7\7"[state];
+                                state = static_cast<NumberParsingState>("\7\7\7\5\5\7\7"[state]);
                                 /*if (state == NumberParsingState::Digits || 
                                     state == NumberParsingState::DigitsAfterPoints)
                                 {

--- a/include/crow/logging.h
+++ b/include/crow/logging.h
@@ -108,7 +108,7 @@ namespace crow
             //
             static LogLevel& get_log_level_ref()
             {
-                static LogLevel current_level = (LogLevel)CROW_LOG_LEVEL;
+                static LogLevel current_level = static_cast<LogLevel>(CROW_LOG_LEVEL);
                 return current_level;
             }
             static ILogHandler*& get_handler_ref()

--- a/include/crow/mustache.h
+++ b/include/crow/mustache.h
@@ -44,8 +44,8 @@ namespace crow
             int end;
             int pos;
             ActionType t;
-            Action(ActionType t, int start, int end, int pos = 0) 
-                : start(start), end(end), pos(pos), t(t)
+            Action(ActionType t, size_t start, size_t end, size_t pos = 0) 
+                : start((int)start), end((int)end), pos((int)pos), t(t)
             {}
         };
 
@@ -347,11 +347,11 @@ namespace crow
                     size_t idx = body_.find(tag_open, current);
                     if (idx == body_.npos)
                     {
-                        fragments_.emplace_back(current, body_.size());
+                        fragments_.emplace_back((int)current, (int)body_.size());
                         actions_.emplace_back(ActionType::Ignore, 0, 0);
                         break;
                     }
-                    fragments_.emplace_back(current, idx);
+                    fragments_.emplace_back((int)current, (int)idx);
 
                     idx += tag_open.size();
                     size_t endIdx = body_.find(tag_close, idx);
@@ -371,7 +371,7 @@ namespace crow
                             idx++;
                             while(body_[idx] == ' ') idx++;
                             while(body_[endIdx-1] == ' ') endIdx--;
-                            blockPositions.emplace_back(actions_.size());
+                            blockPositions.emplace_back((int)actions_.size());
                             actions_.emplace_back(ActionType::OpenBlock, idx, endIdx);
                             break;
                         case '/':
@@ -396,7 +396,7 @@ namespace crow
                             idx++;
                             while(body_[idx] == ' ') idx++;
                             while(body_[endIdx-1] == ' ') endIdx--;
-                            blockPositions.emplace_back(actions_.size());
+                            blockPositions.emplace_back((int)actions_.size());
                             actions_.emplace_back(ActionType::ElseBlock, idx, endIdx);
                             break;
                         case '!':

--- a/include/crow/mustache.h
+++ b/include/crow/mustache.h
@@ -45,7 +45,7 @@ namespace crow
             int pos;
             ActionType t;
             Action(ActionType t, size_t start, size_t end, size_t pos = 0) 
-                : start((int)start), end((int)end), pos((int)pos), t(t)
+                : start(static_cast<int>(start)), end(static_cast<int>(end)), pos(static_cast<int>(pos)), t(t)
             {}
         };
 
@@ -75,7 +75,7 @@ namespace crow
                 empty_str = "";
 
                 int dotPosition = name.find(".");
-                if (dotPosition == (int)name.npos)
+                if (dotPosition == static_cast<int>(name.npos))
                 {
                     for(auto it = stack.rbegin(); it != stack.rend(); ++it)
                     {
@@ -90,7 +90,7 @@ namespace crow
                 {
                     std::vector<int> dotPositions;
                     dotPositions.push_back(-1);
-                    while(dotPosition != (int)name.npos)
+                    while(dotPosition != static_cast<int>(name.npos))
                     {
                         dotPositions.push_back(dotPosition);
                         dotPosition = name.find(".", dotPosition+1);
@@ -98,7 +98,7 @@ namespace crow
                     dotPositions.push_back(name.size());
                     std::vector<std::string> names;
                     names.reserve(dotPositions.size()-1);
-                    for(int i = 1; i < (int)dotPositions.size(); i ++)
+                    for(int i = 1; i < static_cast<int>(dotPositions.size()); i ++)
                         names.emplace_back(name.substr(dotPositions[i-1]+1, dotPositions[i]-dotPositions[i-1]-1));
 
                     for(auto it = stack.rbegin(); it != stack.rend(); ++it)
@@ -215,7 +215,7 @@ namespace crow
                                             out += ctx.s;
                                         break;
                                     default:
-                                        throw std::runtime_error("not implemented tag type" + boost::lexical_cast<std::string>((int)ctx.t()));
+                                        throw std::runtime_error("not implemented tag type" + boost::lexical_cast<std::string>(static_cast<int>(ctx.t())));
                                 }
                             }
                             break;
@@ -281,7 +281,7 @@ namespace crow
                                         current = action.pos;
                                         break;
                                     default:
-                                        throw std::runtime_error("{{#: not implemented context type: " + boost::lexical_cast<std::string>((int)ctx.t()));
+                                        throw std::runtime_error("{{#: not implemented context type: " + boost::lexical_cast<std::string>(static_cast<int>(ctx.t())));
                                         break;
                                 }
                                 break;
@@ -290,7 +290,7 @@ namespace crow
                             stack.pop_back();
                             break;
                         default:
-                            throw std::runtime_error("not implemented " + boost::lexical_cast<std::string>((int)action.t));
+                            throw std::runtime_error("not implemented " + boost::lexical_cast<std::string>(static_cast<int>(action.t)));
                     }
                     current++;
                 }
@@ -304,7 +304,7 @@ namespace crow
                     for(int i = fragment.first; i < fragment.second; i ++)
                     {
                         out += body_[i];
-                        if (body_[i] == '\n' && i+1 != (int)body_.size())
+                        if (body_[i] == '\n' && i+1 != static_cast<int>(body_.size()))
                             out.insert(out.size(), indent, ' ');
                     }
                 }
@@ -347,11 +347,11 @@ namespace crow
                     size_t idx = body_.find(tag_open, current);
                     if (idx == body_.npos)
                     {
-                        fragments_.emplace_back((int)current, (int)body_.size());
+                        fragments_.emplace_back(static_cast<int>(current), static_cast<int>(body_.size()));
                         actions_.emplace_back(ActionType::Ignore, 0, 0);
                         break;
                     }
-                    fragments_.emplace_back((int)current, (int)idx);
+                    fragments_.emplace_back(static_cast<int>(current), static_cast<int>(idx));
 
                     idx += tag_open.size();
                     size_t endIdx = body_.find(tag_close, idx);
@@ -371,7 +371,7 @@ namespace crow
                             idx++;
                             while(body_[idx] == ' ') idx++;
                             while(body_[endIdx-1] == ' ') endIdx--;
-                            blockPositions.emplace_back((int)actions_.size());
+                            blockPositions.emplace_back(static_cast<int>(actions_.size()));
                             actions_.emplace_back(ActionType::OpenBlock, idx, endIdx);
                             break;
                         case '/':
@@ -396,7 +396,7 @@ namespace crow
                             idx++;
                             while(body_[idx] == ' ') idx++;
                             while(body_[endIdx-1] == ' ') endIdx--;
-                            blockPositions.emplace_back((int)actions_.size());
+                            blockPositions.emplace_back(static_cast<int>(actions_.size()));
                             actions_.emplace_back(ActionType::ElseBlock, idx, endIdx);
                             break;
                         case '!':
@@ -480,7 +480,7 @@ namespace crow
                         continue;
                     auto& fragment_before = fragments_[i];
                     auto& fragment_after = fragments_[i+1];
-                    bool is_last_action = i == (int)actions_.size()-2;
+                    bool is_last_action = i == static_cast<int>(actions_.size())-2;
                     bool all_space_before = true;
                     int j, k;
                     for(j = fragment_before.second-1;j >= fragment_before.first;j--)
@@ -496,7 +496,7 @@ namespace crow
                     if (!all_space_before && body_[j] != '\n')
                         continue;
                     bool all_space_after = true;
-                    for(k = fragment_after.first; k < (int)body_.size() && k < fragment_after.second; k ++)
+                    for(k = fragment_after.first; k < static_cast<int>(body_.size()) && k < fragment_after.second; k ++)
                     {
                         if (body_[k] != ' ')
                         {
@@ -511,7 +511,7 @@ namespace crow
                                 body_[k] == '\n' 
                             || 
                                 (body_[k] == '\r' && 
-                                k + 1 < (int)body_.size() && 
+                                k + 1 < static_cast<int>(body_.size()) && 
                                 body_[k+1] == '\n')))
                         continue;
                     if (actions_[i].t == ActionType::Partial)

--- a/include/crow/parser.h
+++ b/include/crow/parser.h
@@ -145,7 +145,7 @@ namespace crow
         /// Take the parsed HTTP request data and convert it to a \ref crow.request
         request to_request() const
         {
-            return request{(HTTPMethod)method, std::move(raw_url), std::move(url), std::move(url_params), std::move(headers), std::move(body)};
+            return request{static_cast<HTTPMethod>(method), std::move(raw_url), std::move(url), std::move(url_params), std::move(headers), std::move(body)};
         }
 
 		bool is_upgrade() const

--- a/include/crow/query_string.h
+++ b/include/crow/query_string.h
@@ -55,8 +55,8 @@ inline int qs_strncmp(const char * s, const char * qs, size_t n)
 
     while(n-- > 0)
     {
-        u1 = (unsigned char) *s++;
-        u2 = (unsigned char) *qs++;
+        u1 = static_cast<unsigned char>(*s++);
+        u2 = static_cast<unsigned char>(*qs++);
 
         if ( ! CROW_QS_ISQSCHR(u1) ) {  u1 = '\0';  }
         if ( ! CROW_QS_ISQSCHR(u2) ) {  u2 = '\0';  }
@@ -64,8 +64,8 @@ inline int qs_strncmp(const char * s, const char * qs, size_t n)
         if ( u1 == '+' ) {  u1 = ' ';  }
         if ( u1 == '%' ) // easier/safer than scanf
         {
-            unyb = (unsigned char) *s++;
-            lnyb = (unsigned char) *s++;
+            unyb = static_cast<unsigned char>(*s++);
+            lnyb = static_cast<unsigned char>(*s++);
             if ( CROW_QS_ISHEX(unyb) && CROW_QS_ISHEX(lnyb) )
                 u1 = (CROW_QS_HEX2DEC(unyb) * 16) + CROW_QS_HEX2DEC(lnyb);
             else
@@ -75,8 +75,8 @@ inline int qs_strncmp(const char * s, const char * qs, size_t n)
         if ( u2 == '+' ) {  u2 = ' ';  }
         if ( u2 == '%' ) // easier/safer than scanf
         {
-            unyb = (unsigned char) *qs++;
-            lnyb = (unsigned char) *qs++;
+            unyb = static_cast<unsigned char>(*qs++);
+            lnyb = static_cast<unsigned char>(*qs++);
             if ( CROW_QS_ISHEX(unyb) && CROW_QS_ISHEX(lnyb) )
                 u2 = (CROW_QS_HEX2DEC(unyb) * 16) + CROW_QS_HEX2DEC(lnyb);
             else

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -63,7 +63,7 @@ namespace crow
         template <typename F>
         void foreach_method(F f)
         {
-            for(uint32_t method = 0, method_bit = 1; method < (uint32_t)HTTPMethod::InternalMethodCount; method++, method_bit<<=1)
+            for(uint32_t method = 0, method_bit = 1; method < static_cast<uint32_t>(HTTPMethod::InternalMethodCount); method++, method_bit<<=1)
             {
                 if (methods_ & method_bit)
                     f(method);
@@ -73,7 +73,7 @@ namespace crow
         const std::string& rule() { return rule_; }
 
     protected:
-        uint32_t methods_{1<<(int)HTTPMethod::Get};
+        uint32_t methods_{1<<static_cast<int>(HTTPMethod::Get)};
 
         std::string rule_;
         std::string name_;
@@ -357,29 +357,29 @@ namespace crow
         using self_t = T;
         WebSocketRule& websocket()
         {
-            auto p =new WebSocketRule(((self_t*)this)->rule_);
-            ((self_t*)this)->rule_to_upgrade_.reset(p);
+            auto p =new WebSocketRule(static_cast<self_t*>(this)->rule_);
+            static_cast<self_t*>(this)->rule_to_upgrade_.reset(p);
             return *p;
         }
 
         self_t& name(std::string name) noexcept
         {
-            ((self_t*)this)->name_ = std::move(name);
-            return (self_t&)*this;
+            static_cast<self_t*>(this)->name_ = std::move(name);
+            return static_cast<self_t&>(*this);
         }
 
         self_t& methods(HTTPMethod method)
         {
-            ((self_t*)this)->methods_ = 1 << (int)method;
-            return (self_t&)*this;
+            static_cast<self_t*>(this)->methods_ = 1 << static_cast<int>(method);
+            return static_cast<self_t&>(*this);
         }
 
         template <typename ... MethodArgs>
         self_t& methods(HTTPMethod method, MethodArgs ... args_method)
         {
             methods(args_method...);
-            ((self_t*)this)->methods_ |= 1 << (int)method;
-            return (self_t&)*this;
+            static_cast<self_t*>(this)->methods_ |= 1 << static_cast<int>(method);
+            return static_cast<self_t&>(*this);
         }
 
     };
@@ -606,7 +606,7 @@ namespace crow
         struct Node
         {
             unsigned rule_index{};
-            std::array<unsigned, (int)ParamType::MAX> param_childrens{};
+            std::array<unsigned, static_cast<int>(ParamType::MAX)> param_childrens{};
             std::unordered_map<std::string, unsigned> children;
 
             bool IsSimpleNode() const
@@ -706,7 +706,7 @@ public:
                 }
             };
 
-            if (node->param_childrens[(int)ParamType::INT])
+            if (node->param_childrens[static_cast<int>(ParamType::INT)])
             {
                 char c = req_url[pos];
                 if ((c >= '0' && c <= '9') || c == '+' || c == '-')
@@ -717,14 +717,14 @@ public:
                     if (errno != ERANGE && eptr != req_url.data()+pos)
                     {
                         params->int_params.push_back(value);
-                        auto ret = find(req_url, &nodes_[node->param_childrens[(int)ParamType::INT]], eptr - req_url.data(), params);
+                        auto ret = find(req_url, &nodes_[node->param_childrens[static_cast<int>(ParamType::INT)]], eptr - req_url.data(), params);
                         update_found(ret);
                         params->int_params.pop_back();
                     }
                 }
             }
 
-            if (node->param_childrens[(int)ParamType::UINT])
+            if (node->param_childrens[static_cast<int>(ParamType::UINT)])
             {
                 char c = req_url[pos];
                 if ((c >= '0' && c <= '9') || c == '+')
@@ -735,14 +735,14 @@ public:
                     if (errno != ERANGE && eptr != req_url.data()+pos)
                     {
                         params->uint_params.push_back(value);
-                        auto ret = find(req_url, &nodes_[node->param_childrens[(int)ParamType::UINT]], eptr - req_url.data(), params);
+                        auto ret = find(req_url, &nodes_[node->param_childrens[static_cast<int>(ParamType::UINT)]], eptr - req_url.data(), params);
                         update_found(ret);
                         params->uint_params.pop_back();
                     }
                 }
             }
 
-            if (node->param_childrens[(int)ParamType::DOUBLE])
+            if (node->param_childrens[static_cast<int>(ParamType::DOUBLE)])
             {
                 char c = req_url[pos];
                 if ((c >= '0' && c <= '9') || c == '+' || c == '-' || c == '.')
@@ -753,14 +753,14 @@ public:
                     if (errno != ERANGE && eptr != req_url.data()+pos)
                     {
                         params->double_params.push_back(value);
-                        auto ret = find(req_url, &nodes_[node->param_childrens[(int)ParamType::DOUBLE]], eptr - req_url.data(), params);
+                        auto ret = find(req_url, &nodes_[node->param_childrens[static_cast<int>(ParamType::DOUBLE)]], eptr - req_url.data(), params);
                         update_found(ret);
                         params->double_params.pop_back();
                     }
                 }
             }
 
-            if (node->param_childrens[(int)ParamType::STRING])
+            if (node->param_childrens[static_cast<int>(ParamType::STRING)])
             {
                 size_t epos = pos;
                 for(; epos < req_url.size(); epos ++)
@@ -772,20 +772,20 @@ public:
                 if (epos != pos)
                 {
                     params->string_params.push_back(req_url.substr(pos, epos-pos));
-                    auto ret = find(req_url, &nodes_[node->param_childrens[(int)ParamType::STRING]], epos, params);
+                    auto ret = find(req_url, &nodes_[node->param_childrens[static_cast<int>(ParamType::STRING)]], epos, params);
                     update_found(ret);
                     params->string_params.pop_back();
                 }
             }
 
-            if (node->param_childrens[(int)ParamType::PATH])
+            if (node->param_childrens[static_cast<int>(ParamType::PATH)])
             {
                 size_t epos = req_url.size();
 
                 if (epos != pos)
                 {
                     params->string_params.push_back(req_url.substr(pos, epos-pos));
-                    auto ret = find(req_url, &nodes_[node->param_childrens[(int)ParamType::PATH]], epos, params);
+                    auto ret = find(req_url, &nodes_[node->param_childrens[static_cast<int>(ParamType::PATH)]], epos, params);
                     update_found(ret);
                     params->string_params.pop_back();
                 }
@@ -834,12 +834,12 @@ public:
                     {
                         if (url.compare(i, x.name.size(), x.name) == 0)
                         {
-                            if (!nodes_[idx].param_childrens[(int)x.type])
+                            if (!nodes_[idx].param_childrens[static_cast<int>(x.type)])
                             {
                                 auto new_node_idx = new_node();
-                                nodes_[idx].param_childrens[(int)x.type] = new_node_idx;
+                                nodes_[idx].param_childrens[static_cast<int>(x.type)] = new_node_idx;
                             }
-                            idx = nodes_[idx].param_childrens[(int)x.type];
+                            idx = nodes_[idx].param_childrens[static_cast<int>(x.type)];
                             i += x.name.size();
                             break;
                         }
@@ -865,12 +865,12 @@ public:
     private:
         void debug_node_print(Node* n, int level)
         {
-            for(int i = 0; i < (int)ParamType::MAX; i ++)
+            for(int i = 0; i < static_cast<int>(ParamType::MAX); i ++)
             {
                 if (n->param_childrens[i])
                 {
                     CROW_LOG_DEBUG << std::string(2*level, ' ') /*<< "("<<n->param_childrens[i]<<") "*/;
-                    switch((ParamType)i)
+                    switch(static_cast<ParamType>(i))
                     {
                         case ParamType::INT:
                             CROW_LOG_DEBUG << "<int>";
@@ -1006,7 +1006,7 @@ public:
             if (req.method >= HTTPMethod::InternalMethodCount)
                 return;
 
-            auto& per_method = per_methods_[(int)req.method];
+            auto& per_method = per_methods_[static_cast<int>(req.method)];
             auto& rules = per_method.rules;
             unsigned rule_index = per_method.trie.find(req.url).first;
 
@@ -1050,7 +1050,7 @@ public:
                 return;
             }
 
-            CROW_LOG_DEBUG << "Matched rule (upgrade) '" << rules[rule_index]->rule_ << "' " << (uint32_t)req.method << " / " << rules[rule_index]->get_methods();
+            CROW_LOG_DEBUG << "Matched rule (upgrade) '" << rules[rule_index]->rule_ << "' " << static_cast<uint32_t>(req.method) << " / " << rules[rule_index]->get_methods();
 
             // any uncaught exceptions become 500s
             try
@@ -1077,7 +1077,7 @@ public:
         {
             if (req.method >= HTTPMethod::InternalMethodCount)
                 return;
-            auto& per_method = per_methods_[(int)req.method];
+            auto& per_method = per_methods_[static_cast<int>(req.method)];
             auto& trie = per_method.trie;
             auto& rules = per_method.rules;
 
@@ -1125,7 +1125,7 @@ public:
                 return;
             }
 
-            CROW_LOG_DEBUG << "Matched rule '" << rules[rule_index]->rule_ << "' " << (uint32_t)req.method << " / " << rules[rule_index]->get_methods();
+            CROW_LOG_DEBUG << "Matched rule '" << rules[rule_index]->rule_ << "' " << static_cast<uint32_t>(req.method) << " / " << rules[rule_index]->get_methods();
 
             // any uncaught exceptions become 500s
             try
@@ -1150,9 +1150,9 @@ public:
 
         void debug_print()
         {
-            for(int i = 0; i < (int)HTTPMethod::InternalMethodCount; i ++)
+            for(int i = 0; i < static_cast<int>(HTTPMethod::InternalMethodCount); i ++)
             {
-                CROW_LOG_DEBUG << method_name((HTTPMethod)i);
+                CROW_LOG_DEBUG << method_name(static_cast<HTTPMethod>(i));
                 per_methods_[i].trie.debug_print();
             }
         }
@@ -1166,7 +1166,7 @@ public:
             // rule index 0, 1 has special meaning; preallocate it to avoid duplication.
             PerMethod() : rules(2) {}
         };
-        std::array<PerMethod, (int)HTTPMethod::InternalMethodCount> per_methods_;
+        std::array<PerMethod, static_cast<int>(HTTPMethod::InternalMethodCount)> per_methods_;
         std::vector<std::unique_ptr<BaseRule>> all_rules_;
     };
 }

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -510,29 +510,29 @@ template <typename F, typename Set>
             auto it = ret.begin();
             while(size >= 3)
             {
-                *it++ = key[(((unsigned char)*data)&0xFC)>>2];
-                unsigned char h = (((unsigned char)*data++) & 0x03) << 4;
-                *it++ = key[h|((((unsigned char)*data)&0xF0)>>4)];
-                h = (((unsigned char)*data++) & 0x0F) << 2;
-                *it++ = key[h|((((unsigned char)*data)&0xC0)>>6)];
-                *it++ = key[((unsigned char)*data++)&0x3F];
+                *it++ = key[(static_cast<unsigned char>(*data)&0xFC)>>2];
+                unsigned char h = (static_cast<unsigned char>(*data++) & 0x03) << 4;
+                *it++ = key[h|((static_cast<unsigned char>(*data)&0xF0)>>4)];
+                h = (static_cast<unsigned char>(*data++) & 0x0F) << 2;
+                *it++ = key[h|((static_cast<unsigned char>(*data)&0xC0)>>6)];
+                *it++ = key[static_cast<unsigned char>(*data++)&0x3F];
 
                 size -= 3;
             }
             if (size == 1)
             {
-                *it++ = key[(((unsigned char)*data)&0xFC)>>2];
-                unsigned char h = (((unsigned char)*data++) & 0x03) << 4;
+                *it++ = key[(static_cast<unsigned char>(*data)&0xFC)>>2];
+                unsigned char h = (static_cast<unsigned char>(*data++) & 0x03) << 4;
                 *it++ = key[h];
                 *it++ = '=';
                 *it++ = '=';
             }
             else if (size == 2)
             {
-                *it++ = key[(((unsigned char)*data)&0xFC)>>2];
-                unsigned char h = (((unsigned char)*data++) & 0x03) << 4;
-                *it++ = key[h|((((unsigned char)*data)&0xF0)>>4)];
-                h = (((unsigned char)*data++) & 0x0F) << 2;
+                *it++ = key[(static_cast<unsigned char>(*data)&0xFC)>>2];
+                unsigned char h = (static_cast<unsigned char>(*data++) & 0x03) << 4;
+                *it++ = key[h|((static_cast<unsigned char>(*data)&0xF0)>>4)];
+                h = (static_cast<unsigned char>(*data++) & 0x0F) << 2;
                 *it++ = key[h];
                 *it++ = '=';
             }

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -200,7 +200,7 @@ namespace crow
                     else if (size < 0x10000)
                     {
                         buf[1] += 126;
-                        *(uint16_t*)(buf+2) = htons((uint16_t)size);
+                        *(uint16_t*)(buf+2) = htons(static_cast<uint16_t>(size));
                         return {buf, buf+4};
                     }
                     else
@@ -344,7 +344,7 @@ namespace crow
                                         ) 
                                     {
                                         is_reading = false;
-                                        remaining_length_ = ((1==ntohl(1)) ? (remaining_length_) : ((uint64_t)ntohl((remaining_length_) & 0xFFFFFFFF) << 32) | ntohl((remaining_length_) >> 32));
+                                        remaining_length_ = ((1==ntohl(1)) ? (remaining_length_) : (static_cast<uint64_t>(ntohl((remaining_length_) & 0xFFFFFFFF)) << 32) | ntohl((remaining_length_) >> 32));
 #ifdef CROW_ENABLE_DEBUG
                                         if (!ec && bytes_transferred != 8)
                                         {


### PR DESCRIPTION
There are many things defined as `int` accepting size_t arguments.

You could change those things to accept `size_t` arguments, or you can silence the warnings.

I have provided a solution for the latter, since it's not my place to change your structures.

With all my PRs and the two response callbacks that return `void` removed, this project will now compile without errors or warnings.