### PR TITLE
`HEAD` and `OPTIONS` handling

### DIFF
--- a/docs/guides/routes.md
+++ b/docs/guides/routes.md
@@ -23,6 +23,10 @@ you can see the first `<int>` is defined as `a` and the second as `b`. If you we
 ##Methods
 You can change the HTTP methods the route uses from just the default `GET` by using `method()`, your route macro should look like `CROW_ROUTE(app, "/add/<int>/<int>").methods(crow::HTTPMethod::GET, crow::HTTPMethod::PATCH)` or `CROW_ROUTE(app, "/add/<int>/<int>").methods("GET"_method, "PATCH"_method)`.
 
+!!! note
+
+    Crow handles `HEAD` and `OPTIONS` methods automatically. So adding those to your handler has no effect.
+
 ##Handler
 Basically a piece of code that gets executed whenever the client calls the associated route, usually in the form of a [lambda expression](https://en.cppreference.com/w/cpp/language/lambda). It can be as simple as `#!cpp ([](){return "Hello World"})`.<br><br>
 

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -195,7 +195,7 @@ namespace crow
         {
 #ifndef CROW_DISABLE_STATIC_DIR
             route<crow::black_magic::get_parameter_tag(CROW_STATIC_ENDPOINT)>(CROW_STATIC_ENDPOINT)
-            ([](const crow::request&, crow::response& res, std::string file_path_partial)
+            ([](crow::response& res, std::string file_path_partial)
             {
               res.set_static_file_info(CROW_STATIC_DIRECTORY + file_path_partial);
               res.end();

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -357,6 +357,11 @@ namespace crow
                 (*middlewares_, ctx_, req_, res);
             }
 
+            if (res.head)
+            {
+                res.body = "";
+            }
+
             std::string accept_encoding = req_.get_header_value("Accept-Encoding");
             if (!accept_encoding.empty() && res.compressed)
             {

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -357,11 +357,6 @@ namespace crow
                 (*middlewares_, ctx_, req_, res);
             }
 
-            if (res.no_body)
-            {
-                res.body = "";
-            }
-
             std::string accept_encoding = req_.get_header_value("Accept-Encoding");
             if (!accept_encoding.empty() && res.compressed)
             {

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -472,7 +472,7 @@ namespace crow
 
             }
 
-            if (!res.no_body && !res.headers.count("content-length"))
+            if (!res.no_length && !res.headers.count("content-length"))
             {
                 content_length_ = std::to_string(res.body.size());
                 static std::string content_length_tag = "Content-Length: ";

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -472,7 +472,7 @@ namespace crow
 
             }
 
-            if (!res.no_length && !res.headers.count("content-length"))
+            if (!res.manual_length_header && !res.headers.count("content-length"))
             {
                 content_length_ = std::to_string(res.body.size());
                 static std::string content_length_tag = "Content-Length: ";

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -357,7 +357,7 @@ namespace crow
                 (*middlewares_, ctx_, req_, res);
             }
 
-            if (res.head)
+            if (res.no_body)
             {
                 res.body = "";
             }
@@ -477,7 +477,7 @@ namespace crow
 
             }
 
-            if (!res.headers.count("content-length"))
+            if (!res.no_body && !res.headers.count("content-length"))
             {
                 content_length_ = std::to_string(res.body.size());
                 static std::string content_length_tag = "Content-Length: ";

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -148,7 +148,10 @@ namespace crow
             if (!completed_)
             {
                 completed_ = true;
-
+                if (no_body)
+                {
+                    body = "";
+                }
                 if (complete_request_handler_)
                 {
                     complete_request_handler_();

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -29,7 +29,7 @@ namespace crow
         std::string body; ///< The actual payload containing the response data.
         ci_map headers; ///< HTTP headers.
         bool compressed = true; ///< If compression is enabled and this is false, the individual response will not be compressed.
-        bool head = false; ///< Whether this is a response to a HEAD request
+        bool no_body = false; ///< Whether this is a response to a HEAD or OPTIONS request. (or anything not meant to have a body)
 
         /// Set the value of an existing header in the response.
         void set_header(std::string key, std::string value)

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -29,7 +29,8 @@ namespace crow
         std::string body; ///< The actual payload containing the response data.
         ci_map headers; ///< HTTP headers.
         bool compressed = true; ///< If compression is enabled and this is false, the individual response will not be compressed.
-        bool no_body = false; ///< Whether this is a response to a HEAD or OPTIONS request. (or anything not meant to have a body)
+        bool head = false; ///< Whether this is a response to a HEAD request.
+        bool no_length = false; ///< Whether Crow should automatically add a "Content-Length" header.
 
         /// Set the value of an existing header in the response.
         void set_header(std::string key, std::string value)
@@ -148,9 +149,11 @@ namespace crow
             if (!completed_)
             {
                 completed_ = true;
-                if (no_body)
+                if (head)
                 {
+                    set_header("Content-Length", std::to_string(body.size()));
                     body = "";
+                    no_length = true;
                 }
                 if (complete_request_handler_)
                 {

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -29,8 +29,8 @@ namespace crow
         std::string body; ///< The actual payload containing the response data.
         ci_map headers; ///< HTTP headers.
         bool compressed = true; ///< If compression is enabled and this is false, the individual response will not be compressed.
-        bool head = false; ///< Whether this is a response to a HEAD request.
-        bool no_length = false; ///< Whether Crow should automatically add a "Content-Length" header.
+        bool is_head_response = false; ///< Whether this is a response to a HEAD request.
+        bool manual_length_header = false; ///< Whether Crow should automatically add a "Content-Length" header.
 
         /// Set the value of an existing header in the response.
         void set_header(std::string key, std::string value)
@@ -149,11 +149,11 @@ namespace crow
             if (!completed_)
             {
                 completed_ = true;
-                if (head)
+                if (is_head_response)
                 {
                     set_header("Content-Length", std::to_string(body.size()));
                     body = "";
-                    no_length = true;
+                    manual_length_header = true;
                 }
                 if (complete_request_handler_)
                 {

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -29,6 +29,7 @@ namespace crow
         std::string body; ///< The actual payload containing the response data.
         ci_map headers; ///< HTTP headers.
         bool compressed = true; ///< If compression is enabled and this is false, the individual response will not be compressed.
+        bool head = false; ///< Whether this is a response to a HEAD request
 
         /// Set the value of an existing header in the response.
         void set_header(std::string key, std::string value)

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -1075,8 +1075,15 @@ public:
 
         void handle(const request& req, response& res)
         {
+            HTTPMethod method_actual = req.method;
             if (req.method >= HTTPMethod::InternalMethodCount)
                 return;
+            else if (req.method == HTTPMethod::HEAD)
+            {
+                method_actual = HTTPMethod::GET;
+                res.head = true;
+            }
+
             auto& per_method = per_methods_[(int)req.method];
             auto& trie = per_method.trie;
             auto& rules = per_method.rules;

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -1119,7 +1119,7 @@ namespace crow
                             allow += method_name((HTTPMethod)i) + ", ";
                         }
                     }
-                    if (allow.size() > 0)
+                    if (allow != "OPTIONS, HEAD, ")
                     {
                         allow = allow.substr(0, allow.size()-2);
                         res = response(204);

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -1138,7 +1138,7 @@ namespace crow
                 }
             }
 
-            auto& per_method = per_methods_[static_cast<int>(int)method_actual];
+            auto& per_method = per_methods_[static_cast<int>(method_actual)];
             auto& trie = per_method.trie;
             auto& rules = per_method.rules;
 

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -1088,7 +1088,7 @@ namespace crow
             else if (req.method == HTTPMethod::HEAD)
             {
                 method_actual = HTTPMethod::GET;
-                res.head = true;
+                res.is_head_response = true;
             }
             else if (req.method == HTTPMethod::OPTIONS)
             {
@@ -1106,7 +1106,7 @@ namespace crow
                         allow = allow.substr(0, allow.size()-2);
                         res = response(204);
                         res.set_header("Allow", allow);
-                        res.no_length = true;
+                        res.manual_length_header = true;
                         res.end();
                         return;
                 }
@@ -1124,7 +1124,7 @@ namespace crow
                         allow = allow.substr(0, allow.size()-2);
                         res = response(204);
                         res.set_header("Allow", allow);
-                        res.no_length = true;
+                        res.manual_length_header = true;
                         res.end();
                         return;
                     }

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -1088,7 +1088,7 @@ namespace crow
             else if (req.method == HTTPMethod::HEAD)
             {
                 method_actual = HTTPMethod::GET;
-                res.no_body = true;
+                res.head = true;
             }
             else if (req.method == HTTPMethod::OPTIONS)
             {
@@ -1106,7 +1106,7 @@ namespace crow
                         allow = allow.substr(0, allow.size()-2);
                         res = response(204);
                         res.set_header("Allow", allow);
-                        res.no_body = true;
+                        res.no_length = true;
                         res.end();
                         return;
                 }
@@ -1124,7 +1124,7 @@ namespace crow
                         allow = allow.substr(0, allow.size()-2);
                         res = response(204);
                         res.set_header("Allow", allow);
-                        res.no_body = true;
+                        res.no_length = true;
                         res.end();
                         return;
                     }

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -378,6 +378,54 @@ TEST_CASE("http_method")
 
     CHECK(405 == res.code);
   }
+
+  {
+    request req;
+    response res;
+
+    req.url = "/get_only";
+    req.method = "HEAD"_method;
+    app.handle(req, res);
+
+    CHECK(200 == res.code);
+    CHECK("" == res.body);
+  }
+
+  {
+    request req;
+    response res;
+
+    req.url = "/";
+    req.method = "OPTIONS"_method;
+    app.handle(req, res);
+
+    CHECK(204 == res.code);
+    CHECK("OPTIONS, HEAD, GET, POST" == res.get_header_value("Allow"));
+  }
+
+  {
+    request req;
+    response res;
+
+    req.url = "/does_not_exist";
+    req.method = "OPTIONS"_method;
+    app.handle(req, res);
+
+    CHECK(404 == res.code);
+  }
+
+  {
+    request req;
+    response res;
+
+    req.url = "/*";
+    req.method = "OPTIONS"_method;
+    app.handle(req, res);
+
+    CHECK(204 == res.code);
+    CHECK("OPTIONS, HEAD, GET, POST, PATCH, PURGE" == res.get_header_value("Allow"));
+
+  }
 }
 
 TEST_CASE("server_handling_error_request")


### PR DESCRIPTION
This PR adds support for crow to automatically handle `HEAD` and `OPTIONS` methods.

`HEAD` returns the same result as get, except the body is missing.
`OPTIONS` returns a 204 response with an Allow header containing all the methods the specific route can use (or all the methods the *server* can use if the url is `http://myserver.etc/*`).

closes #26 