### PR TITLE
Fix error in examples/CMakeLists.txt

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -46,7 +46,7 @@ else ()
   target_link_libraries(basic_example PUBLIC ${REQUIRED_LIBRARIES})
 
   if (Tcmalloc_FOUND)
-    target_link_libraries(basic_example ${Tcmalloc_LIBRARIES})
+    target_link_libraries(basic_example PRIVATE ${Tcmalloc_LIBRARIES})
   endif(Tcmalloc_FOUND)
 
   add_executable(example_with_all example_with_all.cpp)


### PR DESCRIPTION
cmake 3.19 complained about inconsistent use of target_link_libraries (with and without they keyword PRIVATE/PUBLIC/INTERFACE) in examples/CMakeLists.txt. This PR fixes that.

> CMake Error at examples/CMakeLists.txt:49 (target_link_libraries):
>   The keyword signature for target_link_libraries has already been used with
>     the target "basic_example".  All uses of target_link_libraries with a
>       target must be either all-keyword or all-plain.
>
>   The uses of the keyword signature are here:
>
>    * examples/CMakeLists.txt:46 (target_link_libraries)