### PR TITLE
Added Catchall route to Crow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 # Define Targets
 #####################################
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/crow_all.h
-	COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/scripts/merge_all.py
+	COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/scripts/merge_all.py
 	${CMAKE_CURRENT_SOURCE_DIR}/include
 	${CMAKE_CURRENT_BINARY_DIR}/crow_all.h
 	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/docs/guides/routes.md
+++ b/docs/guides/routes.md
@@ -46,7 +46,7 @@ Alternatively, you can define the response in the body and return it (`#!cpp ([]
 
 For more information on `crow::response` go [here](../../reference/structcrow_1_1response.html).<br><br>
 
-###return statement
+###Return statement
 A `crow::response` is very strictly tied to a route. If you can have something in a response constructor, you can return it in a handler.<br><br>
 The main return type is `std::string`. although you could also return a `crow::json::wvalue` or `crow::multipart::message` directly.<br><br>
 For more information on the specific constructors for a `crow::response` go [here](../../reference/structcrow_1_1response.html).
@@ -71,3 +71,6 @@ class a : public crow::returnable
     }
 }
 ```
+
+##Catchall routes
+By default, any request that Crow can't find a route for will return a simple 404 response. You can change that to return a default route using the `CROW_CATCHALL_ROUTE(app)` macro. Defining it is identical to a normal route, even when it comes to the `const crow::request&` and `crow::response&` parameters being optional.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -65,6 +65,10 @@ else ()
   target_compile_options(example_chat PRIVATE "${compiler_options}")
   target_link_libraries(example_chat PUBLIC ${REQUIRED_LIBRARIES})
 
+  add_executable(example_catchall example_catchall.cpp)
+  target_compile_options(example_catchall PRIVATE "${compiler_options}")
+  target_link_libraries(example_catchall PUBLIC ${REQUIRED_LIBRARIES})
+
   add_custom_command(OUTPUT example_chat.html
     COMMAND ${CMAKE_COMMAND} -E
     copy ${PROJECT_SOURCE_DIR}/example_chat.html ${CMAKE_CURRENT_BINARY_DIR}/example_chat.html

--- a/examples/example_catchall.cpp
+++ b/examples/example_catchall.cpp
@@ -1,32 +1,5 @@
-// compile with g++ example_catchall.cpp -lpthread -lz -I../crow
-
-#define CROW_CATCHALL
 #define CROW_MAIN
 #include <crow.h>
-
-
-void catch_all_func( const crow::request& req_crow, crow::response& res_crow )
-{
-    res_crow.body = "No action found for url: '" + req_crow.raw_url + "'!";
-    res_crow.code = 404;
-}
-
-
-
-class Catcher
-{
-public:
-    void catch_all_member( const crow::request& req_crow, crow::response& res_crow )
-    {
-        catch_all_func( req_crow, res_crow );
-    }
-
-    static void catch_all_static( const crow::request& req_crow, crow::response& res_crow )
-    {
-        catch_all_func( req_crow, res_crow );
-    }
-
-};
 
 
 
@@ -34,17 +7,14 @@ int main()
 {
     crow::SimpleApp app;
 
-#if 1 // use member function
-    using namespace std::placeholders;
-    Catcher c;
-    crow::catch_all_func_t fn = std::bind( &Catcher::catch_all_member, c, _1, _2);
-    app.catchall_handler( fn );
-#elif 1 // use static class function
-    app.catchall_handler( Catcher::catch_all_static );
-#else // use ordinary function
-    app.catchall_handler( catch_all_func );
-#endif
+    CROW_ROUTE(app, "/")([](){return "Hello";});
 
-    app.port( 12345 ).run();
-    return 0;
+    //Setting a custom route for any URL that isn't defined, instead of a simple 404.
+    CROW_CATCHALL_ROUTE(app)
+            ([](crow::response& res) {
+                res.body = "The URL does not seem to be correct.";
+                res.end();
+            });
+
+    app.port(18080).run();
 }

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -26,7 +26,7 @@
 #else
 #define CROW_ROUTE(app, url) app.route<crow::black_magic::get_parameter_tag(url)>(url)
 #endif
-#define CROW_CATCHALL_ROUTE(app) (*(app.catchall_route()))
+#define CROW_CATCHALL_ROUTE(app) app.catchall_route()
 
 namespace crow
 {
@@ -88,7 +88,7 @@ namespace crow
         }
 
         ///Create a route for any requests without a proper route (**Use CROW_CATCHALL_ROUTE instead**)
-        CatchallRule* catchall_route()
+        CatchallRule& catchall_route()
         {
             return router_.catchall_rule();
         }

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -26,6 +26,7 @@
 #else
 #define CROW_ROUTE(app, url) app.route<crow::black_magic::get_parameter_tag(url)>(url)
 #endif
+#define CROW_CATCHALL_ROUTE(app) (*(app.catchall_route()))
 
 namespace crow
 {
@@ -84,6 +85,12 @@ namespace crow
             -> typename std::result_of<decltype(&Router::new_rule_tagged<Tag>)(Router, std::string&&)>::type
         {
             return router_.new_rule_tagged<Tag>(std::move(rule));
+        }
+
+        ///Create a route for any requests without a proper route (**Use CROW_CATCHALL_ROUTE instead**)
+        CatchallRule* catchall_route()
+        {
+            return router_.catchall_rule();
         }
 
         self_t& signal_clear()
@@ -347,13 +354,7 @@ namespace crow
                 return;
             cv_started_.wait(lock);
         }
-#ifdef CROW_CATCHALL
-    public:
-        void catchall_handler( catch_all_func_t func )
-        {
-            router_.set_catchall( func );
-        }
-#endif
+
     private:
         uint16_t port_ = 80;
         uint16_t concurrency_ = 1;

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -282,7 +282,7 @@ namespace crow
         operator()(Func&& f)
         {
             static_assert(!std::is_same<void, decltype(f())>::value,
-                "Handler function cannot have void return type; valid return types: string, int, crow::resposne, crow::json::wvalue");
+                "Handler function cannot have void return type; valid return types: string, int, crow::response, crow::returnable");
 
             handler_ = (
 #ifdef CROW_CAN_USE_CPP14
@@ -305,7 +305,7 @@ namespace crow
         operator()(Func&& f)
         {
             static_assert(!std::is_same<void, decltype(f(std::declval<crow::request>()))>::value,
-                "Handler function cannot have void return type; valid return types: string, int, crow::resposne, crow::json::wvalue");
+                "Handler function cannot have void return type; valid return types: string, int, crow::response, crow::returnable");
 
             handler_ = (
 #ifdef CROW_CAN_USE_CPP14
@@ -582,7 +582,7 @@ namespace crow
                 black_magic::CallHelper<Func, black_magic::S<crow::request, Args...>>::value ,
                 "Handler type is mismatched with URL parameters");
             static_assert(!std::is_same<void, decltype(f(std::declval<Args>()...))>::value,
-                "Handler function cannot have void return type; valid return types: string, int, crow::resposne, crow::json::wvalue");
+                "Handler function cannot have void return type; valid return types: string, int, crow::response, crow::returnable");
 
             handler_ = (
 #ifdef CROW_CAN_USE_CPP14
@@ -607,7 +607,7 @@ namespace crow
                 black_magic::CallHelper<Func, black_magic::S<crow::request, Args...>>::value,
                 "Handler type is mismatched with URL parameters");
             static_assert(!std::is_same<void, decltype(f(std::declval<crow::request>(), std::declval<Args>()...))>::value,
-                "Handler function cannot have void return type; valid return types: string, int, crow::resposne, crow::json::wvalue");
+                "Handler function cannot have void return type; valid return types: string, int, crow::response, crow::returnable");
 
             handler_ = (
 #ifdef CROW_CAN_USE_CPP14

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -1057,7 +1057,7 @@ namespace crow
             return *ruleObject;
         }
 
-        CatchallRule* catchall_rule()
+        CatchallRule& catchall_rule()
         {
             return catchall_rule_;
         }
@@ -1260,10 +1260,10 @@ namespace crow
                     }
                 }
 
-                if (catchall_rule_->has_handler())
+                if (catchall_rule_.has_handler())
                 {
                     CROW_LOG_DEBUG << "Cannot match rules " << req.url << ". Redirecting to Catchall rule";
-                    catchall_rule_->handler_(req, res);
+                    catchall_rule_.handler_(req, res);
                 }
                 else
                 {
@@ -1328,7 +1328,7 @@ namespace crow
         }
 
     private:
-        CatchallRule* catchall_rule_ = new CatchallRule();
+        CatchallRule catchall_rule_;
 
         struct PerMethod
         {


### PR DESCRIPTION
Based on @Tibbel's work in #121 and #122. Main differences are:
- Functionality is no longer enabled by a macro.
- A macro similar to `CROW_ROUTE` is used (`CROW_CATCHALL_ROUTE`).
- The lambda used can have no parameters, only request, only response, or both (similar to `CROW_ROUTE`).
- Example is (in my opinion) simpler and gets compiled with the rest of the examples (using Cmake).
- Added UnitTest.
- Added Reference and Guide documentation.

Thanks again to @Tibbel for suggesting the idea and creating the first implementation.

closes #123