### PR TITLE
Fix constness on json dump method #133

### DIFF
--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -1606,14 +1606,14 @@ namespace crow
 
         private:
 
-            inline void dump_string(const std::string& str, std::string& out)
+            inline void dump_string(const std::string& str, std::string& out) const
             {
                 out.push_back('"');
                 escape(str, out);
                 out.push_back('"');
             }
 
-            inline void dump_internal(const wvalue& v, std::string& out)
+            inline void dump_internal(const wvalue& v, std::string& out) const
             {
                 switch(v.t_)
                 {
@@ -1689,7 +1689,7 @@ namespace crow
             }
 
         public:
-            std::string dump()
+            std::string dump() const
             {
                 std::string ret;
                 ret.reserve(estimate_length());

--- a/include/crow/multipart.h
+++ b/include/crow/multipart.h
@@ -45,7 +45,7 @@ namespace crow
             }
 
             ///Represent all parts as a string (**does not include message headers**)
-            std::string dump() override
+            std::string dump() const override
             {
                 std::stringstream str;
                 std::string delimiter = dd + boundary;
@@ -60,7 +60,7 @@ namespace crow
             }
 
             ///Represent an individual part as a string
-            std::string dump(int part_)
+            std::string dump(int part_) const
             {
                 std::stringstream str;
                 part item = parts[part_];
@@ -92,7 +92,7 @@ namespace crow
 
           private:
 
-            std::string get_boundary(const std::string& header)
+            std::string get_boundary(const std::string& header) const
             {
                 size_t found = header.find("boundary=");
                 if (found)
@@ -181,14 +181,14 @@ namespace crow
                 }
             }
 
-            inline std::string trim (std::string& string, const char& excess = '"')
+            inline std::string trim (std::string& string, const char& excess = '"') const
             {
                 if (string.length() > 1 && string[0] == excess && string[string.length()-1] == excess)
                     return string.substr(1, string.length()-2);
                 return string;
             }
 
-            inline std::string pad (std::string& string, const char& padding = '"')
+            inline std::string pad (std::string& string, const char& padding = '"') const
             {
                     return (padding + string + padding);
             }

--- a/include/crow/returnable.h
+++ b/include/crow/returnable.h
@@ -8,7 +8,7 @@ namespace crow
 struct returnable
 {
     std::string content_type;
-    virtual std::string dump() = 0;
+    virtual std::string dump() const = 0;
 
     returnable(std::string ctype) : content_type {ctype}
     {}


### PR DESCRIPTION
Hi!
As discussed in #133 I added the relevant `const` qualifiers for the json dump method. It builds properly and passes the tests.