### PR TITLE
IDE DEBUG symbol

### DIFF
--- a/include/crow/logging.h
+++ b/include/crow/logging.h
@@ -14,11 +14,13 @@ namespace crow
     enum class LogLevel
     {
 #ifndef ERROR
+#ifndef DEBUG
         DEBUG = 0,
         INFO,
         WARNING,
         ERROR,
         CRITICAL,
+#endif
 #endif
 
         Debug = 0,

--- a/scripts/merge_all.py
+++ b/scripts/merge_all.py
@@ -89,4 +89,7 @@ for header in order:
     build.append(re_depends.sub(lambda x: '\n', d))
     build.append('\n')
 
-open(output_path, 'w').write('\n'.join(build))
+ofile = open(output_path, 'w')
+ofile.write('#ifdef DEBUG\n#undef DEBUG\n#define XCODE_DEBUG\n#endif\n')
+ofile.write('\n'.join(build))
+ofile.write('\n#ifdef XCODE_DEBUG\n#undef XCODE_DEBUG\n#define DEBUG\n#endif\n')

--- a/scripts/merge_all.py
+++ b/scripts/merge_all.py
@@ -89,7 +89,4 @@ for header in order:
     build.append(re_depends.sub(lambda x: '\n', d))
     build.append('\n')
 
-ofile = open(output_path, 'w')
-ofile.write('#ifdef DEBUG\n#undef DEBUG\n#define XCODE_DEBUG\n#endif\n')
-ofile.write('\n'.join(build))
-ofile.write('\n#ifdef XCODE_DEBUG\n#undef XCODE_DEBUG\n#define DEBUG\n#endif\n')
+open(output_path, 'w').write('\n'.join(build))


### PR DESCRIPTION
This little change allows crow to be used together with IDEs (like Xcode) that create their own DEBUG symbol during compilation. Else including crow_all.h will make compiling fail because it defines a DEBUG in an enum.