### PR TITLE
Removing some warnings

### DIFF
--- a/include/crow/logging.h
+++ b/include/crow/logging.h
@@ -32,6 +32,7 @@ namespace crow
 
     class ILogHandler {
         public:
+            virtual ~ILogHandler() {}
             virtual void log(std::string message, LogLevel level) = 0;
     };
 

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -36,7 +36,8 @@ namespace crow
                     static_assert( N >= 1, "not a string literal");
                 }
             constexpr char operator[]( unsigned i ) const { 
-                return requires_in_range(i, size_), begin_[i]; 
+                requires_in_range(i, size_);
+                return begin_[i]; 
             }
 
             constexpr operator const char *() const { 


### PR DESCRIPTION
Xcode (clang) constantly creates annoying warnings:
logging.h l. 35: "has virtual functions but non-virtual destructors"
utility.h l. 39: "Possible misuse of comma operator here"
This pull request makes them silent.