### PR TITLE
Make Zlib dependency optional

### DIFF
--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -3,21 +3,36 @@ This page explains how to set Crow up for use with your project.
 
 ##Requirements
  - C++ compiler with C++14 support.
-    - Continuous Testing on g++-9.3 and clang-7.0, AMD64 (x86_64) and Arm64 v8
+    - Crow's CI uses g++-9.3 and clang-7.0 running on AMD64 (x86_64) and ARM64v8
  - boost library (1.70 or later).
- - (optional) CMake and Python3 to build tests and/or examples.
- - (optional) Linking with jemalloc/tcmalloc is recommended for speed.
+ - **(optional)** ZLib for HTTP Compression.
+ - **(optional)** CMake and Python3 to build tests and/or examples.
+ - **(optional)** Linking with jemalloc/tcmalloc is recommended for speed.
+!!!note
+    
+    While using Boost 1.70 or later is recommended, it may be possible to compile a Crow application with version 1.64
+    
 <br><br>
 
 ##Installing Requirements
+!!! note
+
+    The Linux requirements are for developing and compiling a Crow application. Running a built application requires the actual libraries rather than just the development headers.
+
 ###Ubuntu
-`sudo apt-get install libboost-all-dev`
+`sudo apt-get install build-essential libboost-all-dev`
+
+###Non Debian based GNU/Linux
+Use your package manager to install the following:
+ - GCC and G++ (or Clang and Clang++)
+ - Boost Development headers (sometimes part of the Boost package itself)
+
 
 ###OSX
 `brew install boost`
 
 ###Windows
-Download boost from [here](https://www.boost.org/) and install it
+Microsoft Visual Studio 2019 (older versions not tested)
 
 ##Downloading
 Either run `git clone https://github.com/crowcpp/crow.git` or download `crow_all.h` from the releases section. You can also download a zip of the project on github.
@@ -29,7 +44,7 @@ Either run `git clone https://github.com/crowcpp/crow.git` or download `crow_all
 <br><br>
 
 ##Single header file
-If you've downloaded `crow_all.h`, you can skip to step 4.
+If you've downloaded `crow_all.h`, you can skip to step **4**.
 
 1. Make sure you have python 3 installed. 
 2. Open a terminal (or `cmd.exe`) instance in `/path/to/crow/scripts`.
@@ -44,16 +59,18 @@ If you've downloaded `crow_all.h`, you can skip to step 4.
 To build a crow Project, do the following:
 
 ###GCC (G++)
- - Release: `g++ main.cpp -lpthread -lboost_system -lz`.
- - Debug: `g++ main.cpp -ggdb -lpthread -lboost_system -lz -D CROW_ENABLE_DEBUG`.
- - SSL: `g++ main.cpp -lssl -lcrypto -lpthread -lboost_system -lz -D CROW_ENABLE_SSL`.
+ - Release: `g++ main.cpp -lpthread -lboost_system`.
+ - Debug: `g++ main.cpp -ggdb -lpthread -lboost_system -DCROW_ENABLE_DEBUG`.
+ - SSL: `g++ main.cpp -lssl -lcrypto -lpthread -lboost_system -DCROW_ENABLE_SSL`.
 
 ###Clang
- - Release: `clang++ main.cpp -lpthread -lboost_system -lz`.
- - Debug: `clang++ main.cpp -g -lpthread -lboost_system -lz -DCROW_ENABLE_DEBUG`.
- - SSL: `clang++ main.cpp -lssl -lcrypto -lpthread -lboost_system -lz -DCROW_ENABLE_SSL`.
+ - Release: `clang++ main.cpp -lpthread -lboost_system`.
+ - Debug: `clang++ main.cpp -g -lpthread -lboost_system -DCROW_ENABLE_DEBUG`.
+ - SSL: `clang++ main.cpp -lssl -lcrypto -lpthread -lboost_system -DCROW_ENABLE_SSL`.
 
-###Microsoft Visual Studio 2019 (`example_with_all.cpp`)
+###Microsoft Visual Studio 2019
+The following guide will use `example_with_all.cpp` as the Crow application for demonstration purposes.
+
 1. Generate `crow_all.h` following [Single header file](#single-header-file).
 2. `git clone https://github.com/microsoft/vcpkg.git`
 3. `.\vcpkg\bootstrap-vcpkg.bat`
@@ -97,7 +114,9 @@ set(PROJECT_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include)
 
 include_directories("${PROJECT_INCLUDE_DIR}")
 ```
-**Note**: The last 2 lines are unnecessary if you're using `crow_all.h`.
+!!!note
+
+    The last 2 lines are unnecessary if you're using `crow_all.h`.
 
 ##Building Crow tests and examples
 Out-of-source build with CMake is recommended.

--- a/docs/guides/compression.md
+++ b/docs/guides/compression.md
@@ -1,0 +1,18 @@
+Crow supports Zlib compression using Gzip or Deflate algorithms.
+
+## HTTP Compression
+HTTP compression is by default disabled in crow. Do the following to enable it: <br>
+1. Add `#!cpp #define CROW_ENABLE_COMPRESSION` to the top of your main source file.
+2. Call `#!cpp use_compression(crow::compression::algorithm)` on your crow app.
+3. When compiling your application, make sure that ZLIB is included as a dependency. Either through `-lz` argument or `find_package(ZLIB)` in CMake.
+
+!!! note
+
+    step 3 is not needed for MSVC since `vcpckg.json` already includes zlib as a dependency by default
+
+For the compression algorim you can use `crow::compression::algorithm::DEFLATE` or `crow::compression::algorithm::GZIP`.<br>
+And now your HTTP responses will be compressed.
+
+## Websocket Compression
+Crow currently does not support Websocket compression.<br>
+Feel free to discuss the subject with us on Github if you're feeling adventurous and want to try to implement it. We appreciate all the help.

--- a/docs/guides/ssl.md
+++ b/docs/guides/ssl.md
@@ -7,4 +7,6 @@ To enable SSL, first your application needs to define either a `.crt` and `.key`
 
 You can also set your own SSL context (by using `boost::asio::ssl::context ctx`) and then applying it via the `#!cpp app.ssl(ctx)` method.<br><br>
 
-**IMPORTANT NOTICE**: If you plan on using a proxy like Nginx or Apache2, **DO NOT** use SSL in crow, instead define it in your proxy instead and keep the connection between the proxy and Crow non-SSL.
+!!! warning
+    
+    If you plan on using a proxy like Nginx or Apache2, **DO NOT** use SSL in crow, instead define it in your proxy and keep the connection between the proxy and Crow non-SSL.

--- a/examples/example_compression.cpp
+++ b/examples/example_compression.cpp
@@ -1,4 +1,5 @@
 #define CROW_MAIN
+#define CROW_ENABLE_COMPRESSION
 #include "crow.h"
 #include "crow/compression.h"
 

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -18,8 +18,9 @@
 #include "crow/http_request.h"
 #include "crow/http_server.h"
 #include "crow/dumb_timer_queue.h"
+#ifdef CROW_ENABLE_COMPRESSION
 #include "crow/compression.h"
-
+#endif
 
 #ifdef CROW_MSVC_WORKAROUND
 #define CROW_ROUTE(app, url) app.route_dynamic(url)
@@ -171,6 +172,7 @@ namespace crow
             return *this;
         }
 
+#ifdef CROW_ENABLE_COMPRESSION
         self_t& use_compression(compression::algorithm algorithm)
         {
             comp_algorithm_ = algorithm;
@@ -182,7 +184,7 @@ namespace crow
         {
             return comp_algorithm_;
         }
-
+#endif
         ///A wrapper for `validate()` in the router
 
         ///
@@ -361,7 +363,10 @@ namespace crow
         std::string server_name_ = "Crow/0.2";
         std::string bindaddr_ = "0.0.0.0";
         Router router_;
+
+#ifdef CROW_ENABLE_COMPRESSION
         compression::algorithm comp_algorithm_;
+#endif
 
         std::chrono::milliseconds tick_interval_;
         std::function<void()> tick_function_;

--- a/include/crow/compression.h
+++ b/include/crow/compression.h
@@ -1,10 +1,10 @@
+#ifdef CROW_ENABLE_COMPRESSION
 #pragma once
 
 #include <string>
 #include <zlib.h>
 
 // http://zlib.net/manual.html
-
 namespace crow
 {
     namespace compression
@@ -95,3 +95,5 @@ namespace crow
         }
     }
 }
+
+#endif

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -356,7 +356,7 @@ namespace crow
                     decltype(*middlewares_)>
                 (*middlewares_, ctx_, req_, res);
             }
-
+#ifdef CROW_ENABLE_COMPRESSION
             std::string accept_encoding = req_.get_header_value("Accept-Encoding");
             if (!accept_encoding.empty() && res.compressed)
             {
@@ -380,7 +380,7 @@ namespace crow
                         break;
                 }
             }
-
+#endif
             //if there is a redirection with a partial URL, treat the URL as a route.
             std::string location = res.get_header_value("Location");
             if (!location.empty() && location.find("://", 0) == std::string::npos)

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -28,7 +28,10 @@ namespace crow
         int code{200}; ///< The Status code for the response.
         std::string body; ///< The actual payload containing the response data.
         ci_map headers; ///< HTTP headers.
+
+#ifdef CROW_ENABLE_COMPRESSION
         bool compressed = true; ///< If compression is enabled and this is false, the individual response will not be compressed.
+#endif
         bool is_head_response = false; ///< Whether this is a response to a HEAD request.
         bool manual_length_header = false; ///< Whether Crow should automatically add a "Content-Length" header.
 
@@ -195,7 +198,9 @@ namespace crow
         void set_static_file_info(std::string path){
             file_info.path = path;
             file_info.statResult = stat(file_info.path.c_str(), &file_info.statbuf);
+#ifdef CROW_ENABLE_COMPRESSION
             compressed = false;
+#endif
             if (file_info.statResult == 0)
             {
                 std::size_t last_dot = path.find_last_of(".");

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
             - Middleware: guides/middleware.md
             - SSL: guides/ssl.md
             - Static Files: guides/static.md
+            - Compression: guides/compression.md
             - Websockets: guides/websockets.md
             - Writing Tests: guides/testing.md
         - Server setup:

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1,4 +1,5 @@
 #define CATCH_CONFIG_MAIN
+#define CROW_ENABLE_COMPRESSION
 #define CROW_LOG_LEVEL 0
 #define CROW_MAIN
 #include <sys/stat.h>


### PR DESCRIPTION
This PR adds the macro `CROW_ENABLE_COMPRESSION` making the zlib dependency optional. And it fixes some of the documentation and adds a guide for compression.

Thanks to @alejandroarmas for bringing up the issue with zlib and taking the initiative to implement the macro. Ultimately this PR is his work.