### PR TITLE
http_response: fix move assign operator not moving file_info.

### DIFF
--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -87,6 +87,7 @@ namespace crow
             code = r.code;
             headers = std::move(r.headers);
             completed_ = r.completed_;
+            file_info = std::move(r.file_info);
             return *this;
         }
 


### PR DESCRIPTION
This PR fixes an issue I've been experiencing, leading to an error with static file serving as the client will receive `net::ERR_CONTENT_LENGTH_MISMATCH`.

My example project's main file:
```c++
#define CROW_MAIN
#include <crow.h>

int main() {
  crow::SimpleApp app;

  CROW_ROUTE(app, "/")
  ([](const crow::request& req) {
    crow::response r;
    r.set_static_file_info("index.html");
    return r;
  });

  app.port(80).multithreaded().run();

  return 0;
}

```

The error happens because of this check failing to recognize that the given response is of static type:
https://github.com/CrowCpp/crow/blob/189e0709b14e2c782f9dd94609bfd3af1212e1df/include/crow/http_connection.h#L398-L403

The function `is_static_type` checks for a `path` inside `file_info` which is set by `set_static_file_info`:
https://github.com/CrowCpp/crow/blob/189e0709b14e2c782f9dd94609bfd3af1212e1df/include/crow/http_response.h#L182-L185

The check returns `false` because after moving the response, `file_info` isn't being moved along with it, leading to an empty `path`:
https://github.com/CrowCpp/crow/blob/189e0709b14e2c782f9dd94609bfd3af1212e1df/include/crow/http_response.h#L84-L91

This is leading to a response with an empty body but a specific `Content-Length` being set, leading to the given error on the client's side.

Signed-off-by: Luca Schlecker <luca.schlecker@hotmail.com>