### PR TITLE
Patch Static Folder

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -65,6 +65,10 @@ else ()
   target_compile_options(example_chat PRIVATE "${compiler_options}")
   target_link_libraries(example_chat PUBLIC ${REQUIRED_LIBRARIES})
 
+  add_executable(example_static_file example_static_file.cpp)
+  target_compile_options(example_static_file PRIVATE "${compiler_options}")
+  target_link_libraries(example_static_file PUBLIC ${REQUIRED_LIBRARIES})
+
   add_executable(example_catchall example_catchall.cpp)
   target_compile_options(example_catchall PRIVATE "${compiler_options}")
   target_link_libraries(example_catchall PUBLIC ${REQUIRED_LIBRARIES})

--- a/examples/example_static_file.cpp
+++ b/examples/example_static_file.cpp
@@ -1,5 +1,6 @@
 //#define CROW_STATIC_DRIECTORY "alternative_directory/"
 //#define CROW_STATIC_ENDPOINT "/alternative_endpoint/<path>"
+//#define CROW_DISABLE_STATIC_DIR
 #define CROW_MAIN
 #include "crow.h"
 

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -212,8 +212,8 @@ namespace crow
               res.set_static_file_info(CROW_STATIC_DIRECTORY + file_path_partial);
               res.end();
             });
-            validate();
 #endif
+            validate();
 
 #ifdef CROW_ENABLE_SSL
             if (use_ssl_)


### PR DESCRIPTION
Fixes bug where disabling crow static folder makes all routes inaccessible.
Also allows the static example to be built and adds the issue causing macro as a comment on top of the example

This will also be cherry-picked into v0.3, and a release will be made.