### PR TITLE
License Correction

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-Copyright (c) 2014, ipkn
+Copyright (c) 2014-2017, ipkn
+              2020-2021, CrowCpp
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/scripts/merge_all.py
+++ b/scripts/merge_all.py
@@ -18,6 +18,8 @@ output_path = sys.argv[2]
 
 middlewares = [x.rsplit(sep, 1)[-1][:-2] for x in glob(pt.join(header_path, ('crow'+sep+'middlewares'+sep+'*.h*')))]
 
+with open(header_path+'/../LICENSE', 'r') as file:
+    lsc = file.read()
 
 middlewares_actual = []
 if len(sys.argv) > 3:
@@ -83,7 +85,7 @@ for x in edges:
         assert order.index(x) < order.index(y), 'cyclic include detected'
 
 print(order)
-build = []
+build = [lsc]
 for header in order:
     d = open(pt.join(header_path, header)).read()
     build.append(re_depends.sub(lambda x: '\n', d))

--- a/scripts/merge_all.py
+++ b/scripts/merge_all.py
@@ -19,7 +19,7 @@ output_path = sys.argv[2]
 middlewares = [x.rsplit(sep, 1)[-1][:-2] for x in glob(pt.join(header_path, ('crow'+sep+'middlewares'+sep+'*.h*')))]
 
 with open(header_path+'/../LICENSE', 'r') as file:
-    lsc = file.read()
+    lsc = '/*' + file.read() + '*/'
 
 middlewares_actual = []
 if len(sys.argv) > 3:


### PR DESCRIPTION
Edited license to reflect the change in people involved with the development, and `merge_all.py` to add the LICENSE to the top of `crow_all.h`, since it is usually not distributed with the rest of Crow's source code.

Replaces #155, contributes to #143