### PR TITLE
Re-implemented the Trie crow uses to match rules with URLs

### DIFF
--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -740,12 +740,7 @@ namespace crow
         {
             if (node->children.empty())
                 return;
-            bool mergeWithChild = true;
-                if (!node->IsSimpleNode() /*|| node->children[0]->param != ParamType::MAX*/)
-                {
-                    mergeWithChild = false;
-                }
-            if (mergeWithChild)
+            if (node->IsSimpleNode())
             {
                 Node* child_temp = node->children[0];
                 node->key = node->key + child_temp->key;

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -770,27 +770,27 @@ namespace crow
                 switch(node->param)
                 {
                     case ParamType::INT:
-                        std::cout << std::string(2*level, ' ') << "<int>" << std::endl;
+                        CROW_LOG_DEBUG << std::string(2*level, ' ') << "<int>";
                         break;
                     case ParamType::UINT:
-                        std::cout << std::string(2*level, ' ') << "<uint>" << std::endl;
+                        CROW_LOG_DEBUG << std::string(2*level, ' ') << "<uint>";
                         break;
                     case ParamType::DOUBLE:
-                        std::cout << std::string(2*level, ' ') << "<double>" << std::endl;
+                        CROW_LOG_DEBUG << std::string(2*level, ' ') << "<double>";
                         break;
                     case ParamType::STRING:
-                        std::cout << std::string(2*level, ' ') << "<string>" << std::endl;
+                        CROW_LOG_DEBUG << std::string(2*level, ' ') << "<string>";
                         break;
                     case ParamType::PATH:
-                        std::cout << std::string(2*level, ' ') << "<path>" << std::endl;
+                        CROW_LOG_DEBUG << std::string(2*level, ' ') << "<path>";
                         break;
                     default:
-                        std::cout << std::string(2*level, ' ') << "<ERROR>" << std::endl;
+                        CROW_LOG_DEBUG << std::string(2*level, ' ') << "<ERROR>";
                         break;
                 }
             }
             else
-                std::cout << std::string(2*level, ' ') << node->key << std::endl;
+                CROW_LOG_DEBUG << std::string(2*level, ' ') << node->key;
 
             for(auto& child : node->children)
             {
@@ -801,7 +801,7 @@ namespace crow
 
         void debug_print()
         {
-            std::cout << "HEAD" << std::endl;
+            CROW_LOG_DEBUG << "HEAD";
             for (auto& child : head_.children)
                 debug_node_print(child, 1);
         }

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -701,100 +701,133 @@ namespace crow
         struct Node
         {
             unsigned rule_index{};
-            std::array<unsigned, static_cast<int>(ParamType::MAX)> param_childrens{};
-            std::unordered_map<std::string, unsigned> children;
+            std::string key;
+            ParamType param = ParamType::MAX; // MAX = No param.
+            std::vector<Node*> children;
 
             bool IsSimpleNode() const
             {
                 return
                     !rule_index &&
-                    std::all_of(
-                        std::begin(param_childrens),
-                        std::end(param_childrens),
-                        [](unsigned x){ return !x; });
+                    children.size() < 2 &&
+                    param == ParamType::MAX &&
+                    std::all_of(std::begin(children), std::end(children), [](Node* x){ return x->param == ParamType::MAX; });
             }
         };
 
-        Trie() : nodes_(1)
+
+        Trie()
         {
         }
 
         ///Check whether or not the trie is empty.
         bool is_empty()
         {
-            return nodes_.size() > 1;
+            return head_.children.empty();
         }
+
+        void optimize()
+        {
+            for (auto child: head_.children)
+            {
+                optimizeNode(child);
+            }
+        }
+
 
     private:
         void optimizeNode(Node* node)
         {
-            for(auto x : node->param_childrens)
-            {
-                if (!x)
-                    continue;
-                Node* child = &nodes_[x];
-                optimizeNode(child);
-            }
             if (node->children.empty())
                 return;
             bool mergeWithChild = true;
-            for(auto& kv : node->children)
-            {
-                Node* child = &nodes_[kv.second];
-                if (!child->IsSimpleNode())
+                if (!node->IsSimpleNode() /*|| node->children[0]->param != ParamType::MAX*/)
                 {
                     mergeWithChild = false;
-                    break;
                 }
-            }
             if (mergeWithChild)
             {
-                decltype(node->children) merged;
-                for(auto& kv : node->children)
-                {
-                    Node* child = &nodes_[kv.second];
-                    for(auto& child_kv : child->children)
-                    {
-                        merged[kv.first + child_kv.first] = child_kv.second;
-                    }
-                }
-                node->children = std::move(merged);
+                Node* child_temp = node->children[0];
+                node->key = node->key + child_temp->key;
+                node->rule_index = child_temp->rule_index;
+                node->children = std::move(child_temp->children);
+                delete(child_temp);
                 optimizeNode(node);
             }
             else
             {
-                for(auto& kv : node->children)
+                for(auto& child : node->children)
                 {
-                    Node* child = &nodes_[kv.second];
                     optimizeNode(child);
                 }
             }
         }
 
-        void optimize()
+        void debug_node_print(Node* node, int level)
         {
-            optimizeNode(head());
+            if (node->param != ParamType::MAX)
+            {
+                switch(node->param)
+                {
+                    case ParamType::INT:
+                        std::cout << std::string(2*level, ' ') << "<int>" << std::endl;
+                        break;
+                    case ParamType::UINT:
+                        std::cout << std::string(2*level, ' ') << "<uint>" << std::endl;
+                        break;
+                    case ParamType::DOUBLE:
+                        std::cout << std::string(2*level, ' ') << "<double>" << std::endl;
+                        break;
+                    case ParamType::STRING:
+                        std::cout << std::string(2*level, ' ') << "<string>" << std::endl;
+                        break;
+                    case ParamType::PATH:
+                        std::cout << std::string(2*level, ' ') << "<path>" << std::endl;
+                        break;
+                    default:
+                        std::cout << std::string(2*level, ' ') << "<ERROR>" << std::endl;
+                        break;
+                }
+            }
+            else
+                std::cout << std::string(2*level, ' ') << node->key << std::endl;
+
+            for(auto& child : node->children)
+            {
+                debug_node_print(child, level+1);
+            }
+        }
+    public:
+
+        void debug_print()
+        {
+            std::cout << "HEAD" << std::endl;
+            for (auto& child : head_.children)
+                debug_node_print(child, 1);
         }
 
-    public:
         void validate()
         {
-            if (!head()->IsSimpleNode())
+            if (!head_.IsSimpleNode())
                 throw std::runtime_error("Internal error: Trie header should be simple!");
             optimize();
         }
 
         std::pair<unsigned, routing_params> find(const std::string& req_url, const Node* node = nullptr, unsigned pos = 0, routing_params* params = nullptr) const
         {
+            //start params as an empty struct
             routing_params empty;
             if (params == nullptr)
                 params = &empty;
 
-            unsigned found{};
-            routing_params match_params;
+            unsigned found{}; //The rule index to be found
+            routing_params match_params; //supposedly the final matched parameters
 
+            //start from the head node
             if (node == nullptr)
-                node = head();
+                node = &head_;
+
+            //if the function was called on a node at the end of the string (the last recursion), return the nodes rule index, and whatever params were passed to the function
             if (pos == req_url.size())
                 return {node->rule_index, *params};
 
@@ -807,109 +840,113 @@ namespace crow
                 }
             };
 
-            if (node->param_childrens[static_cast<int>(ParamType::INT)])
+
+            for(auto& child : node->children)
             {
-                char c = req_url[pos];
-                if ((c >= '0' && c <= '9') || c == '+' || c == '-')
+                if (child->param != ParamType::MAX)
                 {
-                    char* eptr;
-                    errno = 0;
-                    long long int value = strtoll(req_url.data()+pos, &eptr, 10);
-                    if (errno != ERANGE && eptr != req_url.data()+pos)
+                    if (child->param == ParamType::INT)
                     {
-                        params->int_params.push_back(value);
-                        auto ret = find(req_url, &nodes_[node->param_childrens[static_cast<int>(ParamType::INT)]], eptr - req_url.data(), params);
+                        char c = req_url[pos];
+                        if ((c >= '0' && c <= '9') || c == '+' || c == '-')
+                        {
+                            char* eptr;
+                            errno = 0;
+                            long long int value = strtoll(req_url.data()+pos, &eptr, 10);
+                            if (errno != ERANGE && eptr != req_url.data()+pos)
+                            {
+                                params->int_params.push_back(value);
+                                auto ret = find(req_url, child, eptr - req_url.data(), params);
+                                update_found(ret);
+                                params->int_params.pop_back();
+                            }
+                        }
+                    }
+
+                    else if (child->param == ParamType::UINT)
+                    {
+                        char c = req_url[pos];
+                        if ((c >= '0' && c <= '9') || c == '+')
+                        {
+                            char* eptr;
+                            errno = 0;
+                            unsigned long long int value = strtoull(req_url.data()+pos, &eptr, 10);
+                            if (errno != ERANGE && eptr != req_url.data()+pos)
+                            {
+                                params->uint_params.push_back(value);
+                                auto ret = find(req_url, child, eptr - req_url.data(), params);
+                                update_found(ret);
+                                params->uint_params.pop_back();
+                            }
+                        }
+                    }
+
+                    else if (child->param == ParamType::DOUBLE)
+                    {
+                        char c = req_url[pos];
+                        if ((c >= '0' && c <= '9') || c == '+' || c == '-' || c == '.')
+                        {
+                            char* eptr;
+                            errno = 0;
+                            double value = strtod(req_url.data()+pos, &eptr);
+                            if (errno != ERANGE && eptr != req_url.data()+pos)
+                            {
+                                params->double_params.push_back(value);
+                                auto ret = find(req_url, child, eptr - req_url.data(), params);
+                                update_found(ret);
+                                params->double_params.pop_back();
+                            }
+                        }
+                    }
+
+                    else if (child->param == ParamType::STRING)
+                    {
+                        size_t epos = pos;
+                        for(; epos < req_url.size(); epos ++)
+                        {
+                            if (req_url[epos] == '/')
+                                break;
+                        }
+
+                        if (epos != pos)
+                        {
+                            params->string_params.push_back(req_url.substr(pos, epos-pos));
+                            auto ret = find(req_url, child, epos, params);
+                            update_found(ret);
+                            params->string_params.pop_back();
+                        }
+                    }
+
+                    else if (child->param == ParamType::PATH)
+                    {
+                        size_t epos = req_url.size();
+
+                        if (epos != pos)
+                        {
+                            params->string_params.push_back(req_url.substr(pos, epos-pos));
+                            auto ret = find(req_url, child, epos, params);
+                            update_found(ret);
+                            params->string_params.pop_back();
+                        }
+                    }
+                }
+
+                else
+                {
+                    const std::string& fragment = child->key;
+                    if (req_url.compare(pos, fragment.size(), fragment) == 0)
+                    {
+                        auto ret = find(req_url, child, pos + fragment.size(), params);
                         update_found(ret);
-                        params->int_params.pop_back();
                     }
                 }
             }
-
-            if (node->param_childrens[static_cast<int>(ParamType::UINT)])
-            {
-                char c = req_url[pos];
-                if ((c >= '0' && c <= '9') || c == '+')
-                {
-                    char* eptr;
-                    errno = 0;
-                    unsigned long long int value = strtoull(req_url.data()+pos, &eptr, 10);
-                    if (errno != ERANGE && eptr != req_url.data()+pos)
-                    {
-                        params->uint_params.push_back(value);
-                        auto ret = find(req_url, &nodes_[node->param_childrens[static_cast<int>(ParamType::UINT)]], eptr - req_url.data(), params);
-                        update_found(ret);
-                        params->uint_params.pop_back();
-                    }
-                }
-            }
-
-            if (node->param_childrens[static_cast<int>(ParamType::DOUBLE)])
-            {
-                char c = req_url[pos];
-                if ((c >= '0' && c <= '9') || c == '+' || c == '-' || c == '.')
-                {
-                    char* eptr;
-                    errno = 0;
-                    double value = strtod(req_url.data()+pos, &eptr);
-                    if (errno != ERANGE && eptr != req_url.data()+pos)
-                    {
-                        params->double_params.push_back(value);
-                        auto ret = find(req_url, &nodes_[node->param_childrens[static_cast<int>(ParamType::DOUBLE)]], eptr - req_url.data(), params);
-                        update_found(ret);
-                        params->double_params.pop_back();
-                    }
-                }
-            }
-
-            if (node->param_childrens[static_cast<int>(ParamType::STRING)])
-            {
-                size_t epos = pos;
-                for(; epos < req_url.size(); epos ++)
-                {
-                    if (req_url[epos] == '/')
-                        break;
-                }
-
-                if (epos != pos)
-                {
-                    params->string_params.push_back(req_url.substr(pos, epos-pos));
-                    auto ret = find(req_url, &nodes_[node->param_childrens[static_cast<int>(ParamType::STRING)]], epos, params);
-                    update_found(ret);
-                    params->string_params.pop_back();
-                }
-            }
-
-            if (node->param_childrens[static_cast<int>(ParamType::PATH)])
-            {
-                size_t epos = req_url.size();
-
-                if (epos != pos)
-                {
-                    params->string_params.push_back(req_url.substr(pos, epos-pos));
-                    auto ret = find(req_url, &nodes_[node->param_childrens[static_cast<int>(ParamType::PATH)]], epos, params);
-                    update_found(ret);
-                    params->string_params.pop_back();
-                }
-            }
-
-            for(auto& kv : node->children)
-            {
-                const std::string& fragment = kv.first;
-                const Node* child = &nodes_[kv.second];
-
-                if (req_url.compare(pos, fragment.size(), fragment) == 0)
-                {
-                    auto ret = find(req_url, child, pos + fragment.size(), params);
-                    update_found(ret);
-                }
-            }
-
-            return {found, match_params};
+            return {found, match_params}; //Called after all the recursions have been done
         }
 
         void add(const std::string& url, unsigned rule_index)
         {
-            unsigned idx{0};
+            Node* idx = &head_;
 
             for(unsigned i = 0; i < url.size(); i ++)
             {
@@ -935,12 +972,23 @@ namespace crow
                     {
                         if (url.compare(i, x.name.size(), x.name) == 0)
                         {
-                            if (!nodes_[idx].param_childrens[static_cast<int>(x.type)])
+                            bool found = false;
+                            for (Node* child : idx->children)
                             {
-                                auto new_node_idx = new_node();
-                                nodes_[idx].param_childrens[static_cast<int>(x.type)] = new_node_idx;
+                                if (child->param == x.type)
+                                {
+                                    idx = child;
+                                    i += x.name.size();
+                                    found = true;
+                                    break;
+                                }
                             }
-                            idx = nodes_[idx].param_childrens[static_cast<int>(x.type)];
+                            if (found)
+                                break;
+
+                            auto new_node_idx = new_node(idx);
+                            new_node_idx->param = x.type;
+                            idx = new_node_idx;
                             i += x.name.size();
                             break;
                         }
@@ -950,83 +998,60 @@ namespace crow
                 }
                 else
                 {
-                    std::string piece(&c, 1);
-                    if (!nodes_[idx].children.count(piece))
+                    //This part assumes the tree is unoptimized (every node has a max 1 character key)
+                    bool piece_found = false;
+                    for (auto& child : idx->children)
                     {
-                        auto new_node_idx = new_node();
-                        nodes_[idx].children.emplace(piece, new_node_idx);
+                        if (child->key[0] == c)
+                        {
+                            idx = child;
+                            piece_found = true;
+                            break;
+                        }
                     }
-                    idx = nodes_[idx].children[piece];
+                    if (!piece_found)
+                    {
+                        auto new_node_idx = new_node(idx);
+                        new_node_idx->key = c;
+                        idx = new_node_idx;
+                    }
                 }
             }
-            if (nodes_[idx].rule_index)
+
+            //check if the last node already has a value (exact url already in Trie)
+            if (idx->rule_index)
                 throw std::runtime_error("handler already exists for " + url);
-            nodes_[idx].rule_index = rule_index;
-        }
-    private:
-        void debug_node_print(Node* n, int level)
-        {
-            for(int i = 0; i < static_cast<int>(ParamType::MAX); i ++)
-            {
-                if (n->param_childrens[i])
-                {
-                    CROW_LOG_DEBUG << std::string(2*level, ' ') /*<< "("<<n->param_childrens[i]<<") "*/;
-                    switch(static_cast<ParamType>(i))
-                    {
-                        case ParamType::INT:
-                            CROW_LOG_DEBUG << "<int>";
-                            break;
-                        case ParamType::UINT:
-                            CROW_LOG_DEBUG << "<uint>";
-                            break;
-                        case ParamType::DOUBLE:
-                            CROW_LOG_DEBUG << "<float>";
-                            break;
-                        case ParamType::STRING:
-                            CROW_LOG_DEBUG << "<str>";
-                            break;
-                        case ParamType::PATH:
-                            CROW_LOG_DEBUG << "<path>";
-                            break;
-                        default:
-                            CROW_LOG_DEBUG << "<ERROR>";
-                            break;
-                    }
-
-                    debug_node_print(&nodes_[n->param_childrens[i]], level+1);
-                }
-            }
-            for(auto& kv : n->children)
-            {
-                CROW_LOG_DEBUG << std::string(2*level, ' ') /*<< "(" << kv.second << ") "*/ << kv.first;
-                debug_node_print(&nodes_[kv.second], level+1);
-            }
+            idx->rule_index = rule_index;
         }
 
-    public:
-        void debug_print()
+        size_t get_size()
         {
-            debug_node_print(head(), 0);
+            return get_size(&head_);
         }
+
+        size_t get_size(Node* node)
+        {
+            unsigned size = 8; //rule_index and param
+            size += (node->key.size()); //each character in the key is 1 byte
+            for (auto child: node->children)
+            {
+                size += get_size(child);
+            }
+            return size;
+        }
+
 
     private:
-        const Node* head() const
+
+        Node* new_node(Node* parent)
         {
-            return &nodes_.front();
+            auto& children = parent->children;
+            children.resize(children.size()+1);
+            children[children.size()-1] = new Node();
+            return children[children.size()-1];
         }
 
-        Node* head()
-        {
-            return &nodes_.front();
-        }
-
-        unsigned new_node()
-        {
-            nodes_.resize(nodes_.size()+1);
-            return nodes_.size() - 1;
-        }
-
-        std::vector<Node> nodes_;
+        Node head_;
     };
 
 
@@ -1199,7 +1224,7 @@ namespace crow
                 {
                     for(int i = 0; i < static_cast<int>(HTTPMethod::InternalMethodCount); i ++)
                     {
-                        if (per_methods_[i].trie.is_empty())
+                        if (!per_methods_[i].trie.is_empty())
                         {
                             allow += method_name(static_cast<HTTPMethod>(i)) + ", ";
                         }


### PR DESCRIPTION
One of the parts I avoided documenting because of how complex it was.. Here I am digging into the deepest parts of it and making a better version.

With the poetic crap out of the way, Here's what the old version did and how I changed it.


**OLD**
- Nodes are placed in a list, initially the list contains only 1 head node.
- Nodes have 3 variables, `rule_index`, `param_childrens`, and `children`.
  - `rule_index` is an integer to inform where a rule name ends.
  - `param_childrens` is an array of 5 integers, representing the 5 different parameter types (`<int>`, `<path>` etc..). if a child of the node is a parameter, its index (from the nodes list) is placed in the corresponding place in the array.
  - children is a map<string, uint> which contained the letter (or letters) associated with a child, and its index in the rules list.
- adding a node to the trie involves increasing the size of the nodes list and then adding the index of the last element to the children of the parent node.
- searching is done by going through the tree one children list at a time, then recursively looking for the rest of the string in the correct child's children (if found), the idea is that checking an entire level happens in 1 function call, preventing unnecessary calls and jumps.
- optimizing the node simply flattens the entire trie, this is done by getting the children of a node and merging their children into them, then recursively doing the same thing for the new merged children. Merging involves adding the strings of the grandchildren and children of a node, and having the new result point to the grandchild's index. This did not happen in cases where the grandchild was a param node, or if the child had a rule index. There were some anomalies where merging did not occur, but they were not investigated (primarily because the implementation was to be changed anyway).
- Printing the tree had a problem where params would not be in the correct position according to their level, this is due to to `CROW_LOG_DEBUG` adding its own line end, and the fact that the printing function was adding the level spaces and param in 2 different calls.


**NEW**
- The Trie always has direct access to the head node only, with each node containing its own children.
- Nodes have 4 variables, `rule_index`, `key`, `param`, `children`
  - `rule_index` remains unchanged.
  - `key` was previously the string in children, is now part of the node itself.
  - `param` replaces `param_childrens`, being a single variable telling the parameter type of the node itself.
  - `children` a list of node pointers, replacing the map.
- adding a node now involves adding a pointer to a new node (a parent has to be given) in the node's children.
- searching was only changed as far as to be compatible with the variable changes, which simplified certain parts of the function. but the functionality was mostly left unchanged.
- optimization was almost completely rewritten, the optimize function now checks only the node itself and its child, and only merges if the node has 1 child and if the node itself has no rule index or children with a param (because param overrides any key for a given node). solving both the flattening issue and the no merging anomalies.
- printing was cleaned up to prevent the spacing issue from happening, and some commented code was removed.

The architectural changes were primarily giving the node more autonomy over data related to it, and fixing the optimization.

Performance wise, 2 different tests consistently showed the following:
- old optimization function increased the memory consumption of the trie by about `10%`
- new implementation takes about `35%` as much memory for the same tree as the old one (pre optimization)
- post optimization, the new implementation consumes `10%` as much memory as the old implementation did. Proving that the optimization (at least when it comes to memory) actually works.
- speed testing (for searching) shows that the new implementation is a lot more consistent, having much less standard deviation from the average time when compared to the old version. And being consistently faster, taking on average 50% as much time to find a string. To put things into perspective, old: `20µs with 40µs jumps` and new: `10µs`, so while it is a large gain percentange, it is very small in actual time.