### PR TITLE
Similar to Flask decorator for Method @app.route('/route', methods = ['POST'])

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -27,6 +27,7 @@
 #define CROW_ROUTE(app, url) app.route_dynamic(url)
 #else
 #define CROW_ROUTE(app, url) app.route<crow::black_magic::get_parameter_tag(url)>(url)
+#define CROW_ROUTE_M(app, url, method) app.route<crow::black_magic::get_parameter_tag(url)>(url).methods(method)
 #endif
 #define CROW_CATCHALL_ROUTE(app) app.catchall_route()
 


### PR DESCRIPTION
It is more exressive like a Flask decorator for using methods like @app.route('/route', methods = ['POST'])
rather than using CROW_ROUTE(app, "/route").methods(HTTPMethod::POST),
CROW_ROUTE_M(app, "/route", HTTPMethod::POST) is more expressive
to users.

Before:
```cpp
    CROW_ROUTE(app, "/a").methods(HTTPMethod::POST)
    ([]() {
         return "Hello";
     });
```
After
```cpp    
CROW_ROUTE_M(app, "/a", HTTPMethod::POST)
    ([]() {
         return "Hello";
     });
```

Even I have created issue for this improvement.
Issue: #170