### PR TITLE
unresolved conversion warning fix

### DIFF
--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -194,7 +194,7 @@ namespace crow
                     buf[0] += opcode;
                     if (size < 126)
                     {
-                        buf[1] += size;
+                        buf[1] += static_cast<char>(size);
                         return {buf, buf+2};
                     }
                     else if (size < 0x10000)

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -408,10 +408,10 @@ namespace crow
                             break;
                         case WebSocketReadState::Payload:
                             {
-                                size_t to_read = buffer_.size();
+                                auto to_read = static_cast<std::uint64_t>(buffer_.size());
                                 if (remaining_length_ < to_read)
                                     to_read = remaining_length_;
-                                adaptor_.socket().async_read_some( boost::asio::buffer(buffer_, to_read), 
+                                adaptor_.socket().async_read_some(boost::asio::buffer(buffer_, static_cast<std::size_t>(to_read)), 
                                     [this](const boost::system::error_code& ec, std::size_t bytes_transferred)
                                     {
                                         is_reading = false;


### PR DESCRIPTION
As described in pull request name and suggested commits.
This pull request purpose is to fix some warnings related to type conversions (i.e. char - std::size and std::size_t - std::uint64_t).
Thus I corrected those issues, details are available in commits comment.