### PR TITLE
Eliminate extern-initializer warning

### DIFF
--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -22,7 +22,7 @@ namespace crow
 #ifdef CROW_MAIN
     uint16_t INVALID_BP_ID{0xFFFF};
 #else
-    extern uint16_t INVALID_BP_ID{0xFFFF};
+    extern uint16_t INVALID_BP_ID;
 #endif
     /// A base class for all rules.
 


### PR DESCRIPTION
When including `crow.h` (or, rather, `routing.h`) without `CROW_MAIN`, the `INVALID_BP_ID` variable is declared as extern, which is triggers the `-Wextern-initializer` warning (at least with clang):

```
include/crow/routing.h:25:21: error: 'extern' variable has an initializer [-Werror,-Wextern-initializer]                                                                                                                           
    extern uint16_t INVALID_BP_ID{0xFFFF};   
```

Since Crow is header-only, this means that any sources using Crow cannot be compiled with `-Werror` or similar. This PR simply removes the initialzer when declaring as extern.