### PR TITLE
Send codes to catchall

### DIFF
--- a/examples/example_catchall.cpp
+++ b/examples/example_catchall.cpp
@@ -11,10 +11,17 @@ int main()
 
     //Setting a custom route for any URL that isn't defined, instead of a simple 404.
     CROW_CATCHALL_ROUTE(app)
-            ([](crow::response& res) {
-                res.body = "The URL does not seem to be correct.";
-                res.end();
-            });
+    ([](crow::response& res) {
+        if (res.code == 404)
+        {
+            res.body = "The URL does not seem to be correct.";
+        }
+        else if (res.code == 405)
+        {
+            res.body = "The HTTP method does not seem to be correct.";
+        }
+        res.end();
+    });
 
     app.port(18080).run();
 }

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -1500,15 +1500,14 @@ namespace crow
                     {
                         found_bps.clear();
                         found_bps.push_back(blueprints_[bp_i[index]]);
-                        get_found_bp(bp_i, found_bps.back()->blueprints_, found_bps, ++index);
                     }
                     else
                     {
                         found_bps.pop_back();
                         Blueprint* last_element  = found_bps.back();
                         found_bps.push_back(last_element->blueprints_[bp_i[index]]);
-                        get_found_bp(bp_i, found_bps.back()->blueprints_, found_bps, ++index);
                     }
+                    get_found_bp(bp_i, found_bps.back()->blueprints_, found_bps, ++index);
                 }
             }
         }
@@ -1616,7 +1615,7 @@ namespace crow
                 {
                     if (std::get<0>(per_method.trie.find(req.url))) //Route found, but in another method
                     {
-                        std::string error_message(get_error(405, found, req, res));
+                        const std::string error_message(get_error(405, found, req, res));
                         CROW_LOG_DEBUG << "Cannot match method " << req.url << " " << method_name(method_actual) << ". " << error_message;
                         res.end();
                         return;
@@ -1624,7 +1623,7 @@ namespace crow
                 }
                 //Route does not exist anywhere
 
-                std::string error_message(get_error(404, found, req, res));
+                const std::string error_message(get_error(404, found, req, res));
                 CROW_LOG_DEBUG << "Cannot match rules " << req.url << ". " << error_message;
                 res.end();
                 return;

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -17,5 +17,5 @@ if os.path.exists(releasePath):
 os.mkdir(releasePath)
 os.chdir(releasePath)
 os.system("cmake -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DCPACK_PACKAGE_FILE_NAME=\"crow-{}\" .. && make -j5".format(version))
-os.system("sed -i 's/constexpr char VERSION\\[\\] = \"master\";/constexpr char VERSION\\[\\] = \"{}\";/g' crow_all.h".format(version))
-os.system("cpack")
+os.system("sed -i 's/char VERSION\\[\\] = \"master\";/char VERSION\\[\\] = \"{}\";/g' crow_all.h".format(version))
+os.system("cpack -R {}".format(version))

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1,5 +1,6 @@
 #define CATCH_CONFIG_MAIN
 #define CROW_ENABLE_COMPRESSION
+#define CROW_ENABLE_DEBUG
 #define CROW_LOG_LEVEL 0
 #define CROW_MAIN
 #include <sys/stat.h>
@@ -2094,7 +2095,7 @@ TEST_CASE("catchall")
 
     CROW_ROUTE(app, "/place")([](){return "place";});
 
-    CROW_CATCHALL_ROUTE(app)([](){return "!place";});
+    CROW_CATCHALL_ROUTE(app)([](response& res){res.body = "!place";});
 
     CROW_ROUTE(app2, "/place")([](){return "place";});
 
@@ -2120,7 +2121,7 @@ TEST_CASE("catchall")
 
       app.handle(req, res);
 
-      CHECK(200 == res.code);
+      CHECK(404 == res.code);
       CHECK("!place" == res.body);
     }
 


### PR DESCRIPTION
- Made catchall work with 404 or 405 errors and made it way easier to implement it for other errors
- snuck in a fix for release.py where version name wouldn't change
- also snuck in slight improvement in finding blueprint (removed extra if statement)

I wasn't sure whether it was a good idea or not to also use catchall for 500 errors, please let me know so I can change it.

closes #180 