### PR TITLE
Disable non SSL code on SSL macro

### DIFF
--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -23,7 +23,7 @@ namespace crow
     using namespace boost;
     using tcp = asio::ip::tcp;
 
-    template <typename Handler, typename Adaptor = SocketAdaptor, typename ... Middlewares>
+    template <typename Handler, typename Adaptor, typename ... Middlewares>
     class Server
     {
     public:

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -49,12 +49,13 @@ namespace crow
         }
 
         virtual void handle(const request&, response&, const routing_params&) = 0;
+#ifndef CROW_ENABLE_SSL
         virtual void handle_upgrade(const request&, response& res, SocketAdaptor&&)
         {
             res = response(404);
             res.end();
         }
-#ifdef CROW_ENABLE_SSL
+#else
         virtual void handle_upgrade(const request&, response& res, SSLAdaptor&&)
         {
             res = response(404);
@@ -399,12 +400,12 @@ namespace crow
             res = response(404);
             res.end();
         }
-
+#ifndef CROW_ENABLE_SSL
         void handle_upgrade(const request& req, response&, SocketAdaptor&& adaptor) override
         {
             new crow::websocket::Connection<SocketAdaptor>(req, std::move(adaptor), open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_);
         }
-#ifdef CROW_ENABLE_SSL
+#else
         void handle_upgrade(const request& req, response&, SSLAdaptor&& adaptor) override
         {
             new crow::websocket::Connection<SSLAdaptor>(req, std::move(adaptor), open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_);

--- a/include/crow/socket_adaptors.h
+++ b/include/crow/socket_adaptors.h
@@ -13,7 +13,7 @@ namespace crow
 {
     using namespace boost;
     using tcp = asio::ip::tcp;
-
+#ifndef CROW_ENABLE_SSL
     ///A wrapper for the asio::ip::tcp::socket and asio::ssl::stream
     struct SocketAdaptor
     {
@@ -83,7 +83,7 @@ namespace crow
         tcp::socket socket_;
     };
 
-#ifdef CROW_ENABLE_SSL
+#else
     struct SSLAdaptor
     {
         using context = boost::asio::ssl::context;


### PR DESCRIPTION
Disclaimer: SSL refers to the OpenSSL library, **not** the SSL protocol.

Crow used to keep the non SSL code if SSL is enabled, This PR makes it so that at a time, either SSL code is there or non SSL code is there (you will get an error if you define the `CROW_ENABLE_SSL` macro without defining a certificate).

This is a matter of preference, I have no problem scrapping it and its issue.

Closes #67 