### PR TITLE
fix vcpkg manifest

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "crow-examples",
-    "version": "master",
+    "version-string": "master",
     "dependencies": [
         {
             "name": "boost-array",


### PR DESCRIPTION
I guess the commit message is already saying everything there's to say.

'master' is not a valid version -> use version-string instead