### PR TITLE
fix routing on windows.

### DIFF
--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -895,7 +895,7 @@ namespace crow
                                 auto ret = find(req_url, child, eptr - req_url.data(), params, blueprints);
                                 update_found(ret);
                                 params->int_params.pop_back();
-                                blueprints->pop_back();
+                                if (!blueprints->empty()) blueprints->pop_back();
                             }
                         }
                     }
@@ -916,7 +916,7 @@ namespace crow
                                 auto ret = find(req_url, child, eptr - req_url.data(), params, blueprints);
                                 update_found(ret);
                                 params->uint_params.pop_back();
-                                blueprints->pop_back();
+                                if (!blueprints->empty()) blueprints->pop_back();
                             }
                         }
                     }
@@ -937,7 +937,7 @@ namespace crow
                                 auto ret = find(req_url, child, eptr - req_url.data(), params, blueprints);
                                 update_found(ret);
                                 params->double_params.pop_back();
-                                blueprints->pop_back();
+                                if (!blueprints->empty()) blueprints->pop_back();
                             }
                         }
                     }
@@ -959,7 +959,7 @@ namespace crow
                             auto ret = find(req_url, child, epos, params, blueprints);
                             update_found(ret);
                             params->string_params.pop_back();
-                            blueprints->pop_back();
+                            if (!blueprints->empty()) blueprints->pop_back();
                         }
                     }
 
@@ -975,7 +975,7 @@ namespace crow
                             auto ret = find(req_url, child, epos, params, blueprints);
                             update_found(ret);
                             params->string_params.pop_back();
-                            blueprints->pop_back();
+                            if (!blueprints->empty()) blueprints->pop_back();
                         }
                     }
                 }
@@ -989,7 +989,7 @@ namespace crow
                         if (child->blueprint_index != INVALID_BP_ID) blueprints->push_back(child->blueprint_index);
                         auto ret = find(req_url, child, pos + fragment.size(), params, blueprints);
                         update_found(ret);
-                        blueprints->pop_back();
+                        if (!blueprints->empty()) blueprints->pop_back();
                     }
                 }
             }


### PR DESCRIPTION
It seems like the blueprints feature broke crow on some (at least mine) windows machines.

On my linux instance, executing `pop_back` on an empty vector doesn't seem to do anything. On my windows instance though, it crashes the program. This PR just checks if the `blueprints`-vector is empty and only if it isn't, removes an item.

It is [undefined behavior to use `pop_back` on an empty vector](https://en.cppreference.com/w/cpp/container/vector/pop_back) and should be avoided.