### PR TITLE
http_response.h : added custom type support

### DIFF
--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -79,12 +79,15 @@ namespace crow
             *this = std::move(r);
         }
         
-        response(std::string contentType, std::string body)
+        response(std::string contentType, std::string body) : body(std::move(body))
         {
             set_header("Content-Type",mime_types[contentType]);
-            this->body = body;
         }
 
+        response(int code, std::string contentType, std::string body): code(code),body(std::move(body))
+        {
+            set_header("Content-Type",mime_types[contentType]);
+        }
 
         response& operator = (const response& r) = delete;
 

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -78,6 +78,13 @@ namespace crow
         {
             *this = std::move(r);
         }
+        
+        response(std::string contentType, std::string body)
+        {
+            set_header("Content-Type",mime_types[contentType]);
+            this->body = body;
+        }
+
 
         response& operator = (const response& r) = delete;
 


### PR DESCRIPTION
Added a response constructor where content-type can be specified by the user
Usage 
```
    CROW_ROUTE(app,"/test")([](){
        std::ostringstream os;
        os<<"<First>";
        os<<"<Content>";
        os<<"Element1";
        os<<"</Content>";
        os<<"<Content>";
        os<<"Element2";
        os<<"</Content>";
        os<<"<Content>";
            os<<"<InnerContent>";
            os<<"Element3";
            os<<"</InnerContent>";
        os<<"</Content>";
        os<<"</First>";
        
        return crow::response("xml",os.str());
    });
```
This PR aims to fix: https://github.com/CrowCpp/Crow/issues/48
