### PR TITLE
Selecting features after installation

### DIFF
--- a/cmake/CrowConfig.cmake.in
+++ b/cmake/CrowConfig.cmake.in
@@ -1,8 +1,5 @@
 @PACKAGE_INIT@
 
-set(CROW_ENABLE_COMPRESSION @CROW_ENABLE_COMPRESSION@)
-set(CROW_ENABLE_SSL @CROW_ENABLE_SSL@)
-
 include(CMakeFindDependencyMacro)
 find_dependency(Boost 1.64 COMPONENTS system date_time)
 find_dependency(Threads)
@@ -17,3 +14,24 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/CrowTargets.cmake")
 check_required_components("@PROJECT_NAME@")
+
+get_target_property(_CROW_ILL Crow::Crow INTERFACE_LINK_LIBRARIES)
+get_target_property(_CROW_ICD Crow::Crow INTERFACE_COMPILE_DEFINITIONS)
+
+list(REMOVE_ITEM _CROW_ILL "ZLIB::ZLIB" "OpenSSL::SSL")
+list(REMOVE_ITEM _CROW_ICD "CROW_ENABLE_SSL" "CROW_ENABLE_COMPRESSION")
+
+if(CROW_ENABLE_COMPRESSION)
+  list(APPEND _CROW_ILL "ZLIB::ZLIB")
+  list(APPEND _CROW_ICD "CROW_ENABLE_COMPRESSION")
+endif()
+
+if(CROW_ENABLE_SSL)
+  list(APPEND _CROW_ILL "OpenSSL::SSL")
+  list(APPEND _CROW_ICD "CROW_ENABLE_SSL")
+endif()
+
+set_target_properties(Crow::Crow PROPERTIES
+  INTERFACE_COMPILE_DEFINITIONS "${_CROW_ICD}"
+  INTERFACE_LINK_LIBRARIES "${_CROW_ILL}"
+)


### PR DESCRIPTION
Don't enforce the set of features crow was installed with but instead give the ability to freely choose them, even after it was installed.

Only thing: Depending on what Crow was configured with during install, `CrowTargets.cmake` can differ.
It is taken care of though, just wanted to point it out.
In the `.cmake.in` file OpenSSL and ZLIB are excluded by default and added back in based on `CROW_ENABLE_COMPRESSION` and `CROW_ENABLE_SSL`.

This feels a bit sketchy but it should be fine.