### PR TITLE
Remove the need for `#define CROW_MAIN`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Available [here](https://crowcpp.org).
 
 #### Hello World
 ```cpp
-#define CROW_MAIN
 #include "crow.h"
 
 int main()

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Available [here](https://crowcpp.org).
 
 ## Examples
 
+#### Disclaimer
+
+> If you are using version v0.3, then you have to put `#!cpp #define CROW_MAIN` at the top of one and only one source file.
+
 #### Hello World
 ```cpp
 #include "crow.h"

--- a/docs/getting_started/your_first_application.md
+++ b/docs/getting_started/your_first_application.md
@@ -1,11 +1,7 @@
 This page shows how you can get started with a simple hello world application.
 
 ## 1. Include
-Starting with an empty `main.cpp` file, first add `#!cpp #define CROW_MAIN` then `#!cpp #include "crow.h"` or `#!cpp #include "crow_all.h"` if you're using the single header file.
-
-!!! note
-
-    If you're using multiple C++ source files make sure to have `CROW_MAIN` defined only in your main source file.
+Starting with an empty `main.cpp` file, first add `#!cpp #include "crow.h"` or `#!cpp #include "crow_all.h"` if you're using the single header file.
 
 ## 2. App declaration
 Next Create a `main()` and declare a `#!cpp crow::SimpleApp` inside, your code should look like this
@@ -39,7 +35,6 @@ Please note that the `port()` and `multithreaded()` methods aren't needed, Thoug
 Once you've followed all the steps above, your code should look similar to this
 
 ``` cpp linenums="1"
-#define CROW_MAIN //let the compiler know this is your main cpp file
 #include "crow.h"
 //#include "crow_all.h"
 

--- a/docs/getting_started/your_first_application.md
+++ b/docs/getting_started/your_first_application.md
@@ -3,6 +3,10 @@ This page shows how you can get started with a simple hello world application.
 ## 1. Include
 Starting with an empty `main.cpp` file, first add `#!cpp #include "crow.h"` or `#!cpp #include "crow_all.h"` if you're using the single header file.
 
+!!! note
+
+    If you are using version v0.3, then you have to put `#!cpp #define CROW_MAIN` at the top of one and only one source file.
+
 ## 2. App declaration
 Next Create a `main()` and declare a `#!cpp crow::SimpleApp` inside, your code should look like this
 ``` cpp

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -169,7 +169,7 @@ code{
         <h2 style="text-align: center;">Easy to get started</h3>
     </div>
     <div class="scontent">
-        <div class="highlight"><pre id="__code_0"><span></span><button class="md-clipboard md-icon" title="Copy to clipboard" data-clipboard-target="#__code_0 > code"></button><code><span class="cp">#define CROW_MAIN</span>
+        <div class="highlight"><pre id="__code_0"><span></span><button class="md-clipboard md-icon" title="Copy to clipboard" data-clipboard-target="#__code_0 > code"></button><code>
 <span class="cp">#include</span> <span class="cpf">"crow.h"</span><span class="cp"></span>
 
 <span class="kt">int</span> <span class="nf">main</span><span class="p">()</span>

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -1,4 +1,3 @@
-#define CROW_MAIN
 #include "crow.h"
 
 #include <sstream>

--- a/examples/example_blueprint.cpp
+++ b/examples/example_blueprint.cpp
@@ -1,4 +1,3 @@
-#define CROW_MAIN
 #include "crow.h"
 
 int main()

--- a/examples/example_catchall.cpp
+++ b/examples/example_catchall.cpp
@@ -1,4 +1,3 @@
-#define CROW_MAIN
 #include <crow.h>
 
 

--- a/examples/example_chat.cpp
+++ b/examples/example_chat.cpp
@@ -1,4 +1,3 @@
-#define CROW_MAIN
 #include "crow.h"
 #include <string>
 #include <vector>

--- a/examples/example_compression.cpp
+++ b/examples/example_compression.cpp
@@ -1,4 +1,3 @@
-#define CROW_MAIN
 #include "crow.h"
 #include "crow/compression.h"
 

--- a/examples/example_json_map.cpp
+++ b/examples/example_json_map.cpp
@@ -1,4 +1,3 @@
-#define CROW_MAIN
 #define CROW_JSON_USE_MAP
 #include "crow.h"
 

--- a/examples/example_static_file.cpp
+++ b/examples/example_static_file.cpp
@@ -1,7 +1,6 @@
 //#define CROW_STATIC_DRIECTORY "alternative_directory/"
 //#define CROW_STATIC_ENDPOINT "/alternative_endpoint/<path>"
 //#define CROW_DISABLE_STATIC_DIR
-#define CROW_MAIN
 #include "crow.h"
 
 int main()
@@ -18,10 +17,10 @@ CROW_ROUTE(app, "/")
     res.end();
 });
 
-	
+
 	app.port(18080).run();
-	
-	
+
+
 	return 0;
 }
 

--- a/examples/example_vs.cpp
+++ b/examples/example_vs.cpp
@@ -1,4 +1,3 @@
-#define CROW_MAIN
 #include "crow.h"
 
 #include <sstream>
@@ -10,7 +9,7 @@ class ExampleLogHandler : public crow::ILogHandler {
         }
 };
 
-struct ExampleMiddleware 
+struct ExampleMiddleware
 {
     std::string message;
 
@@ -108,7 +107,7 @@ int main()
     app.route_dynamic("/params")
     ([](const crow::request& req){
         std::ostringstream os;
-        os << "Params: " << req.url_params << "\n\n"; 
+        os << "Params: " << req.url_params << "\n\n";
         os << "The key 'foo' was " << (req.url_params.get("foo") == nullptr ? "not " : "") << "found.\n";
         if(req.url_params.get("pew") != nullptr) {
             double countD = boost::lexical_cast<double>(req.url_params.get("pew"));
@@ -120,7 +119,7 @@ int main()
             os << " - " << countVal << '\n';
         }
         return crow::response{os.str()};
-    });    
+    });
 
     // ignore all log
     crow::logger::setLogLevel(crow::LogLevel::Debug);

--- a/examples/example_with_all.cpp
+++ b/examples/example_with_all.cpp
@@ -1,4 +1,3 @@
-#define CROW_MAIN
 #include "crow_all.h"
 
 #include <sstream>
@@ -96,7 +95,7 @@ int main()
     CROW_ROUTE(app, "/params")
     ([](const crow::request& req){
         std::ostringstream os;
-        os << "Params: " << req.url_params << "\n\n"; 
+        os << "Params: " << req.url_params << "\n\n";
         os << "The key 'foo' was " << (req.url_params.get("foo") == nullptr ? "not " : "") << "found.\n";
         if(req.url_params.get("pew") != nullptr) {
             double countD = boost::lexical_cast<double>(req.url_params.get("pew"));
@@ -108,7 +107,7 @@ int main()
             os << " - " << countVal << '\n';
         }
         return crow::response{os.str()};
-    });    
+    });
 
     // ignore all log
     crow::logger::setLogLevel(crow::LogLevel::Debug);

--- a/examples/helloworld.cpp
+++ b/examples/helloworld.cpp
@@ -1,4 +1,3 @@
-#define CROW_MAIN
 #include "crow.h"
 
 int main()

--- a/examples/ssl/example_ssl.cpp
+++ b/examples/ssl/example_ssl.cpp
@@ -1,4 +1,3 @@
-#define CROW_MAIN
 #include "crow.h"
 
 int main()
@@ -14,7 +13,7 @@ int main()
 
     // Use .pem file
     //app.port(18080).ssl_file("test.pem").run();
-    
+
     // Use custom context; see boost::asio::ssl::context
     /*
      * crow::ssl_context_t ctx;

--- a/examples/websocket/example_ws.cpp
+++ b/examples/websocket/example_ws.cpp
@@ -1,4 +1,3 @@
-#define CROW_MAIN
 #include "crow.h"
 #include <unordered_set>
 #include <mutex>
@@ -38,7 +37,7 @@ int main()
         gethostname(name, 256);
         crow::mustache::context x;
         x["servername"] = name;
-	
+
         auto page = crow::mustache::load("ws.html");
         return page.render(x);
      });

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -78,7 +78,7 @@ namespace crow
         {
             *this = std::move(r);
         }
-        
+
         response(std::string contentType, std::string body) : body(std::move(body))
         {
             set_header("Content-Type", mime_types.at(contentType));

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -81,12 +81,12 @@ namespace crow
         
         response(std::string contentType, std::string body) : body(std::move(body))
         {
-            set_header("Content-Type",mime_types[contentType]);
+            set_header("Content-Type", mime_types.at(contentType));
         }
 
         response(int code, std::string contentType, std::string body): code(code),body(std::move(body))
         {
-            set_header("Content-Type",mime_types[contentType]);
+            set_header("Content-Type", mime_types.at(contentType));
         }
 
         response& operator = (const response& r) = delete;
@@ -221,7 +221,7 @@ namespace crow
                 this->add_header("Content-length", std::to_string(file_info.statbuf.st_size));
 
                 if (extension != ""){
-                    mimeType = mime_types[extension];
+                    mimeType = mime_types.at(extension);
                     if (mimeType != "")
                         this-> add_header("Content-Type", mimeType);
                     else

--- a/include/crow/mime_types.h
+++ b/include/crow/mime_types.h
@@ -3,9 +3,7 @@
 #include <string>
 
 namespace crow {
-
-#ifdef CROW_MAIN
-    std::unordered_map<std::string, std::string> mime_types {
+    const std::unordered_map<std::string, std::string> mime_types {
         {"shtml", "text/html"},
         {"htm", "text/html"},
         {"html", "text/html"},
@@ -115,7 +113,4 @@ namespace crow {
         {"wmv", "video/x-ms-wmv"},
         {"avi", "video/x-msvideo"}
     };
-#else
-    extern std::unordered_map<std::string, std::string> mime_types;
-#endif
 }

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -19,11 +19,8 @@
 namespace crow
 {
 
-#ifdef CROW_MAIN
-    uint16_t INVALID_BP_ID{0xFFFF};
-#else
-    extern uint16_t INVALID_BP_ID;
-#endif
+    constexpr const uint16_t INVALID_BP_ID{0xFFFF};
+
     /// A base class for all rules.
 
     /// Used to provide a common interface for code dealing with different types of rules.

--- a/include/crow/version.h
+++ b/include/crow/version.h
@@ -1,10 +1,5 @@
 #pragma once
 
 namespace crow {
-
-#ifdef CROW_MAIN
-  char VERSION[] = "master";
-#else
-  extern char VERSION[];
-#endif
+  constexpr const char VERSION[] = "master";
 }

--- a/scripts/nginx_mime2cpp.py
+++ b/scripts/nginx_mime2cpp.py
@@ -20,9 +20,7 @@ def main():
         "#include <string>",
         "",
         "namespace crow {",
-        "",
-        "#ifdef CROW_MAIN"
-        tabspace + "std::unordered_map<std::string, std::string> mime_types {"])
+        tabspace + "const std::unordered_map<std::string, std::string> mime_types {"])
 
     with open(file_path, "r") as mtfile:
         incomplete = ""
@@ -44,9 +42,6 @@ def main():
     outLines[-1] = outLines[-1][:-1]
     outLines.extend([
 		tabspace + "};",
-		"#else",
-		"extern std::unordered_map<std::string, std::string> mime_types;",
-		"#endif",
 		"}"
 		])
 

--- a/tests/ssl/ssltest.cpp
+++ b/tests/ssl/ssltest.cpp
@@ -1,6 +1,5 @@
 #define CATCH_CONFIG_MAIN
 #define CROW_LOG_LEVEL 0
-#define CROW_MAIN
 
 #include <thread>
 

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1,7 +1,6 @@
 #define CATCH_CONFIG_MAIN
 #define CROW_ENABLE_DEBUG
 #define CROW_LOG_LEVEL 0
-#define CROW_MAIN
 #include <sys/stat.h>
 
 #include <iostream>


### PR DESCRIPTION
Signed-off-by: Luca Schlecker <luca.schlecker@hotmail.com>

It fixes #273.
This is achieved using the const type qualifier as it gives internal linkage.
[_"The const qualifier used on a declaration of a non-local non-volatile non-template (since C++14) non-inline (since C++17) variable that is not declared extern gives it internal linkage." (cppreference.com)_](https://en.cppreference.com/w/cpp/language/cv#Notes)

The release script didn't need an update, as it just worked with the changes. The mime-type script was changed to reflect the needed changes.

I also deleted all references to `#define CROW_MAIN` in the documentation, but I didn't take a look at it. Could you please confirm it not breaking anything horribly @The-EDev?

The examples compile fine and my test application also worked without a problem.