### PR TITLE
Fix faulty https redirection.

### DIFF
--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -391,10 +391,11 @@ namespace crow
             if (!location.empty() && location.find("://", 0) == std::string::npos)
             {
                 #ifdef CROW_ENABLE_SSL
-                location.insert(0, "https://" + req_.get_header_value("Host"));
-                #else
-                location.insert(0, "http://" + req_.get_header_value("Host"));
+                if (handler_->ssl_used())
+                    location.insert(0, "https://" + req_.get_header_value("Host"));
+                else
                 #endif
+                location.insert(0, "http://" + req_.get_header_value("Host"));
                 res.set_header("location", location);
             }
 

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -231,10 +231,6 @@ namespace crow
 
         std::tuple<Middlewares...>* middlewares_;
 
-#ifdef CROW_ENABLE_SSL
-        bool use_ssl_{false};
-        boost::asio::ssl::context ssl_context_{boost::asio::ssl::context::sslv23};
-#endif
         typename Adaptor::context* adaptor_ctx_;
     };
 }

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -138,7 +138,8 @@ namespace crow
             port_ = acceptor_.local_endpoint().port();
             handler_->port(port_);
 
-            CROW_LOG_INFO << server_name_ << " server is running at " << bindaddr_ <<":" << acceptor_.local_endpoint().port()
+
+            CROW_LOG_INFO << server_name_ << " server is running at " << (handler_->ssl_used() ? "https://" : "http://") << bindaddr_ <<":" << acceptor_.local_endpoint().port()
                           << " using " << concurrency_ << " threads";
             CROW_LOG_INFO << "Call `app.loglevel(crow::LogLevel::Warning)` to hide Info level logs.";
 


### PR DESCRIPTION
Signed-off-by: Luca Schlecker <luca.schlecker@hotmail.com>

If SSL is enabled, but not used, redirection breaks.

https://github.com/CrowCpp/Crow/blob/0e15963cd2ff0c0b265eef8d6f528face6c53964/include/crow/http_connection.h#L393-L397

If SSL is enabled, `response::redirect` will always redirect to `https://` leading to broken links.

This PR fixes this by adding a `bool ssl_used() const` function to the App which can be used to determine whether or not SSL is being actively used. Based on that the right protocol will be selected.
The second commit removes unneeded SSL Code which I guess is a leftover from when https support was first implemented.