### PR TITLE
Opt-in websocket protocol enforcement

### DIFF
--- a/docs/guides/websockets.md
+++ b/docs/guides/websockets.md
@@ -4,6 +4,11 @@ To create a websocket in Crow, you need a websocket route.<br>
 A websocket route differs from a normal route quite a bit. While it uses the same `CROW_ROUTE(app, "/url")` macro, that's about where the similarities end.<br>
 A websocket route follows the macro with `.websocket()` which is then followed by a series of methods (with handlers inside) for each event. These are (sorted by order of execution):
 
+!!! Warning
+
+    By default, Crow allows Clients to send unmasked websocket messages, which is useful for debugging but goes against the protocol specification. Production Crow applications should enforce the protocol by adding `#!cpp #define CROW_ENFORCE_WS_SPEC` to their source code.
+
+
 - `#!cpp onaccept([&](const crow::request&){handler code goes here})` (This handler has to return bool)
 - `#!cpp onopen([&](crow::websocket::connection& conn){handler code goes here})`
 - `#!cpp onmessage([&](crow::websocket::connection& conn, const std::string message, bool is_binary){handler code goes here})`

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -104,7 +104,7 @@ int main()
     });
 
     // Same as above, but using crow::status
-    CROW_ROUTE(app,"/hello/<int>")
+    CROW_ROUTE(app,"/hello_status/<int>")
     ([](int count){
         if (count > 100)
             return crow::response(crow::status::BAD_REQUEST);

--- a/include/crow/settings.h
+++ b/include/crow/settings.h
@@ -11,6 +11,9 @@
 /* #ifdef - enables ssl */
 //#define CROW_ENABLE_SSL
 
+/* #ifdef - enforces section 5.2 and 6.1 of RFC6455 (only accepting masked messages from clients) */
+//#define CROW_ENFORCE_WS_SPEC
+
 /* #define - specifies log level */
 /*
     Debug       = 0

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1909,6 +1909,32 @@ TEST_CASE("websocket")
     std::string checkstring4(std::string(buf).substr(0, 16));
     CHECK(checkstring4 == "\x82\x0EHello back bin");
   }
+  //----------16bit Length Text----------
+  {
+    std::fill_n (buf, 2048, 0);
+    char b16_text_message[2+2+5+1]("\x81\x7E"
+        "\x00\x05"
+        "Hello");
+
+    c.send(asio::buffer(b16_text_message, 9));
+    c.receive(asio::buffer(buf, 2048));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    std::string checkstring(std::string(buf).substr(0, 12));
+    CHECK(checkstring == "\x81\x0AHello back");
+  }
+  //----------64bit Length Text----------
+  {
+    std::fill_n (buf, 2048, 0);
+    char b64text_message[2+8+5+1]("\x81\x7F"
+        "\x00\x00\x00\x00\x00\x00\x00\x05"
+        "Hello");
+
+    c.send(asio::buffer(b64text_message, 15));
+    c.receive(asio::buffer(buf, 2048));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    std::string checkstring(std::string(buf).substr(0, 12));
+    CHECK(checkstring == "\x81\x0AHello back");
+  }
   //----------Close----------
   {
     std::fill_n (buf, 2048, 0);


### PR DESCRIPTION
Basically what I did is I fixed the original problem with the one way switch, then added a macro that will terminate the connection instead of proceeding if the protocol isn't followed (the mask bit isn't `1`).
I also added the unit tests that caused me to discover this problem in the first place.

closes #279