### PR TITLE
Disable log timestamp prefix when disabled

### DIFF
--- a/include/crow/logging.h
+++ b/include/crow/logging.h
@@ -68,7 +68,13 @@ namespace crow
 
             logger(std::string prefix, LogLevel level) : level_(level) {
     #ifdef CROW_ENABLE_LOGGING
+    #if defined(CROW_DISABLE_LOG_TIMESTAMP) && !defined(CROW_DISABLE_LOG_PREFIX)
+                    stringstream_ << "[" << prefix << "] ";
+    #elif !defined(CROW_DISABLE_LOG_TIMESTAMP) && defined(CROW_DISABLE_LOG_PREFIX)
+                    stringstream_ << "(" << timestamp() << ") ";
+    #else
                     stringstream_ << "(" << timestamp() << ") [" << prefix << "] ";
+    #endif
     #endif
 
             }

--- a/include/crow/logging.h
+++ b/include/crow/logging.h
@@ -72,7 +72,7 @@ namespace crow
                     stringstream_ << "[" << prefix << "] ";
     #elif !defined(CROW_DISABLE_LOG_TIMESTAMP) && defined(CROW_DISABLE_LOG_PREFIX)
                     stringstream_ << "(" << timestamp() << ") ";
-    #else
+    #elif !defined(CROW_DISABLE_LOG_TIMESTAMP) && !defined(CROW_DISABLE_LOG_PREFIX)
                     stringstream_ << "(" << timestamp() << ") [" << prefix << "] ";
     #endif
     #endif

--- a/include/crow/settings.h
+++ b/include/crow/settings.h
@@ -5,6 +5,12 @@
 /* #ifdef - enables debug mode */
 //#define CROW_ENABLE_DEBUG
 
+/* #ifdef - disable timestamp in logs */
+//#define CROW_DISABLE_LOG_TIMESTAMP
+
+/* #ifdef - disable prefix in logs */
+//#define CROW_DISABLE_LOG_PREFIX
+
 /* #ifdef - enables logging */
 #define CROW_ENABLE_LOGGING
 


### PR DESCRIPTION
There are scenarios when client uses another logging
framework which provides both the timestamp and prefix,
so we need a way to drop those from Crow logging.
This will avoid unnecessary performance penalty and
noise in the same log line.