### PR TITLE
Enable a better experience using custom loggers.

### DIFF
--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -14,7 +14,35 @@ The available log levels are as follows (please not that setting a level will al
 
 To set a logLevel, just use `#!cpp app.loglevel(crow::LogLevel::Warning)`, This will not show any debug or info logs. It will however still show error and critical logs.<br><br>
 
-Please note that setting the Macro `CROW_ENABLE_DEBUG` during compilation will also set the log level to `Debug`.
+!!! note
+
+    Setting the Macro `CROW_ENABLE_DEBUG` during compilation will also set the log level to `Debug` (unless otherwise set using `loglevel()`).
+
 
 ## Writing a log
 Writing a log is as simple as `#!cpp CROW_LOG_<LOG LEVEL> << "Hello";` (replace&lt;LOG LEVEL&gt; with the actual level in all caps, so you have `CROW_LOG_WARNING`).
+
+## Creating A custom logger
+Assuming you have an existing logger or Crow's default format just doesn't work for you. Crow allows you to use a custom logger for any log made using the `CROW_LOG_<LOG LEVEL>` macro.<br>
+All you need is a class extending `#!cpp crow::ILogHandler` containing the method `#!cpp void log(std::string, crow::LogLevel)`.<br>
+Once you have your custom logger, you need to set it via `#!cpp crow::logger::setHandler(&MyLogger);`. Here's a full example:<br>
+```cpp
+class CustomLogger : public crow::ILogHandler {
+ public:
+  CustomLogger() {}
+  void log(std::string message, crow::LogLevel /*level*/) {
+    // "message" doesn't contain the timestamp and loglevel prefix the default
+    // logger does and it ends with a std::endl.
+    std::cerr << message;
+  }
+};
+
+int main(int argc, char** argv) {
+  CustomLogger logger;
+  crow::logger::setHandler(&logger);
+  
+  crow::SimpleApp app;
+  CROW_ROUTE(app, "/")([]() { return "Hello"; });
+  app.run();
+}
+```

--- a/include/crow/logging.h
+++ b/include/crow/logging.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <string>
+#include "crow/settings.h"
+
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>
 #include <iostream>
 #include <sstream>
-
-#include "crow/settings.h"
+#include <string>
 
 namespace crow
 {
@@ -30,115 +30,128 @@ namespace crow
         Critical,
     };
 
-    class ILogHandler {
-        public:
-            virtual void log(std::string message, LogLevel level) = 0;
+    class ILogHandler
+    {
+    public:
+        virtual void log(std::string message, LogLevel level) = 0;
     };
 
-    class CerrLogHandler : public ILogHandler {
-        public:
-            void log(std::string message, LogLevel /*level*/) override {
-                std::cerr << message;
-            }
-    };
-
-    class logger {
-
-        private:
-            //
-            static std::string timestamp()
+    class CerrLogHandler : public ILogHandler
+    {
+    public:
+        void log(std::string message, LogLevel level) override
+        {
+            std::string prefix;
+            switch (level)
             {
-                char date[32];
-                time_t t = time(0);
+                case LogLevel::Debug:
+                    prefix = "DEBUG   ";
+                    break;
+                case LogLevel::Info:
+                    prefix = "INFO    ";
+                    break;
+                case LogLevel::Warning:
+                    prefix = "WARNING ";
+                    break;
+                case LogLevel::Error:
+                    prefix = "ERROR   ";
+                    break;
+                case LogLevel::Critical:
+                    prefix = "CRITICAL";
+                    break;
+            }
+            std::cerr << "(" << timestamp() << ") [" << prefix << "] " << message;
+        }
 
-                tm my_tm;
+    private:
+        static std::string timestamp()
+        {
+            char date[32];
+            time_t t = time(0);
+
+            tm my_tm;
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
-                gmtime_s(&my_tm, &t);
+            gmtime_s(&my_tm, &t);
 #else
-                gmtime_r(&t, &my_tm);
+            gmtime_r(&t, &my_tm);
 #endif
 
-                size_t sz = strftime(date, sizeof(date), "%Y-%m-%d %H:%M:%S", &my_tm);
-                return std::string(date, date+sz);
-            }
-
-        public:
-
-
-            logger(std::string prefix, LogLevel level) : level_(level) {
-    #ifdef CROW_ENABLE_LOGGING
-                    stringstream_ << "(" << timestamp() << ") [" << prefix << "] ";
-    #endif
-
-            }
-            ~logger() {
-    #ifdef CROW_ENABLE_LOGGING
-                if(level_ >= get_current_log_level()) {
-                    stringstream_ << std::endl;
-                    get_handler_ref()->log(stringstream_.str(), level_);
-                }
-    #endif
-            }
-
-            //
-            template <typename T>
-            logger& operator<<(T const &value) {
-
-    #ifdef CROW_ENABLE_LOGGING
-                if(level_ >= get_current_log_level()) {
-                    stringstream_ << value;
-                }
-    #endif
-                return *this;
-            }
-
-            //
-            static void setLogLevel(LogLevel level) {
-                get_log_level_ref() = level;
-            }
-
-            static void setHandler(ILogHandler* handler) {
-                get_handler_ref() = handler;
-            }
-
-            static LogLevel get_current_log_level() {
-                return get_log_level_ref();
-            }
-
-        private:
-            //
-            static LogLevel& get_log_level_ref()
-            {
-                static LogLevel current_level = static_cast<LogLevel>(CROW_LOG_LEVEL);
-                return current_level;
-            }
-            static ILogHandler*& get_handler_ref()
-            {
-                static CerrLogHandler default_handler;
-                static ILogHandler* current_handler = &default_handler;
-                return current_handler;
-            }
-
-            //
-            std::ostringstream stringstream_;
-            LogLevel level_;
+            size_t sz = strftime(date, sizeof(date), "%Y-%m-%d %H:%M:%S", &my_tm);
+            return std::string(date, date + sz);
+        }
     };
-}
 
-#define CROW_LOG_CRITICAL   \
-        if (crow::logger::get_current_log_level() <= crow::LogLevel::Critical) \
-            crow::logger("CRITICAL", crow::LogLevel::Critical)
-#define CROW_LOG_ERROR      \
-        if (crow::logger::get_current_log_level() <= crow::LogLevel::Error) \
-            crow::logger("ERROR   ", crow::LogLevel::Error)
-#define CROW_LOG_WARNING    \
-        if (crow::logger::get_current_log_level() <= crow::LogLevel::Warning) \
-            crow::logger("WARNING ", crow::LogLevel::Warning)
-#define CROW_LOG_INFO       \
-        if (crow::logger::get_current_log_level() <= crow::LogLevel::Info) \
-            crow::logger("INFO    ", crow::LogLevel::Info)
-#define CROW_LOG_DEBUG      \
-        if (crow::logger::get_current_log_level() <= crow::LogLevel::Debug) \
-            crow::logger("DEBUG   ", crow::LogLevel::Debug)
+    class logger
+    {
+    public:
+        logger(LogLevel level):
+          level_(level)
+        {
+        }
+        ~logger()
+        {
+#ifdef CROW_ENABLE_LOGGING
+            if (level_ >= get_current_log_level())
+            {
+                stringstream_ << std::endl;
+                get_handler_ref()->log(stringstream_.str(), level_);
+            }
+#endif
+        }
 
+        //
+        template<typename T>
+        logger& operator<<(T const& value)
+        {
+#ifdef CROW_ENABLE_LOGGING
+            if (level_ >= get_current_log_level())
+            {
+                stringstream_ << value;
+            }
+#endif
+            return *this;
+        }
+
+        //
+        static void setLogLevel(LogLevel level) { get_log_level_ref() = level; }
+
+        static void setHandler(ILogHandler* handler) { get_handler_ref() = handler; }
+
+        static LogLevel get_current_log_level() { return get_log_level_ref(); }
+
+    private:
+        //
+        static LogLevel& get_log_level_ref()
+        {
+            static LogLevel current_level = static_cast<LogLevel>(CROW_LOG_LEVEL);
+            return current_level;
+        }
+        static ILogHandler*& get_handler_ref()
+        {
+            static CerrLogHandler default_handler;
+            static ILogHandler* current_handler = &default_handler;
+            return current_handler;
+        }
+
+        //
+        std::ostringstream stringstream_;
+        LogLevel level_;
+    };
+} // namespace crow
+
+#define CROW_LOG_CRITICAL                                                  \
+    if (crow::logger::get_current_log_level() <= crow::LogLevel::Critical) \
+    crow::logger(crow::LogLevel::Critical)
+#define CROW_LOG_ERROR                                                  \
+    if (crow::logger::get_current_log_level() <= crow::LogLevel::Error) \
+    crow::logger(crow::LogLevel::Error)
+#define CROW_LOG_WARNING                                                  \
+    if (crow::logger::get_current_log_level() <= crow::LogLevel::Warning) \
+    crow::logger(crow::LogLevel::Warning)
+#define CROW_LOG_INFO                                                  \
+    if (crow::logger::get_current_log_level() <= crow::LogLevel::Info) \
+    crow::logger(crow::LogLevel::Info)
+#define CROW_LOG_DEBUG                                                  \
+    if (crow::logger::get_current_log_level() <= crow::LogLevel::Debug) \
+    crow::logger(crow::LogLevel::Debug)


### PR DESCRIPTION
Signed-off-by: Luca Schlecker <luca.schlecker@hotmail.com>

Alternative to #285 as this PR will address the concern with providing a custom logger and the message including a timestamp and prefix.

Example of using a custom logger:
```c++
#include <crow.h>

#include <iostream>

class CustomLogger : public crow::ILogHandler {
 public:
  CustomLogger() {}
  void log(std::string message, crow::LogLevel /*level*/) {
    // "message" doesn't contain the timestamp and loglevel prefix the default
    // logger does and it ends with a std::endl.
    std::cerr << message;
  }
};

int main(int argc, char** argv) {
  CustomLogger logger;
  crow::logger::setHandler(&logger);
  crow::SimpleApp app;
  CROW_ROUTE(app, "/")([]() { return "Hello"; });
  app.multithreaded().port(80).run();
  return 0;
}
```
This will for example only print:
```
Crow/master server is running at http://0.0.0.0:80 using 8 threads
Call `app.loglevel(crow::LogLevel::Warning)` to hide Info level logs.
```
instead of the default:
```
(2021-11-26 11:16:15) [INFO    ] Crow/master server is running at http://0.0.0.0:80 using 8 threads
(2021-11-26 11:16:15) [INFO    ] Call `app.loglevel(crow::LogLevel::Warning)` to hide Info level logs.
```