### PR TITLE
Add basic load balancing

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -53,7 +53,7 @@ IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2
     SortPriority:    2
-    CaseSensitive:   true
+#    CaseSensitive:   true
   - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
     Priority:        3
   - Regex:           '<[[:alnum:].]+>'

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -187,7 +187,7 @@ namespace crow
           std::function<std::string()>& get_cached_date_str_f,
           detail::task_timer& task_timer,
           typename Adaptor::context* adaptor_ctx_,
-          std::atomic<unsigned int>& queue_length_):
+          std::atomic<unsigned int>& queue_length):
           adaptor_(io_service, adaptor_ctx_),
           handler_(handler),
           parser_(this),
@@ -196,7 +196,7 @@ namespace crow
           get_cached_date_str(get_cached_date_str_f),
           task_timer_(task_timer),
           res_stream_threshold_(handler->stream_threshold()),
-          queue_length(queue_length_)
+          queue_length_(queue_length)
         {
 #ifdef CROW_ENABLE_DEBUG
             connectionCount++;
@@ -406,8 +406,6 @@ namespace crow
             {
                 do_write_general();
             }
-
-            queue_length--;
         }
 
     private:
@@ -644,6 +642,7 @@ namespace crow
             CROW_LOG_DEBUG << this << " is_reading " << is_reading << " is_writing " << is_writing;
             if (!is_reading && !is_writing)
             {
+                queue_length_--;
                 CROW_LOG_DEBUG << this << " delete (idle) ";
                 delete this;
             }
@@ -705,7 +704,7 @@ namespace crow
 
         size_t res_stream_threshold_;
 
-        std::atomic<unsigned int>& queue_length;
+        std::atomic<unsigned int>& queue_length_;
     };
 
 } // namespace crow

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -187,7 +187,7 @@ namespace crow
           std::function<std::string()>& get_cached_date_str_f,
           detail::task_timer& task_timer,
           typename Adaptor::context* adaptor_ctx_,
-          int &queue_length_):
+          int& queue_length_):
           adaptor_(io_service, adaptor_ctx_),
           handler_(handler),
           parser_(this),
@@ -705,7 +705,7 @@ namespace crow
 
         size_t res_stream_threshold_;
 
-        int &queue_length;
+        int& queue_length;
     };
 
 } // namespace crow

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -187,7 +187,7 @@ namespace crow
           std::function<std::string()>& get_cached_date_str_f,
           detail::task_timer& task_timer,
           typename Adaptor::context* adaptor_ctx_,
-          int& queue_length_):
+          std::atomic<unsigned int>& queue_length_):
           adaptor_(io_service, adaptor_ctx_),
           handler_(handler),
           parser_(this),
@@ -705,7 +705,7 @@ namespace crow
 
         size_t res_stream_threshold_;
 
-        int& queue_length;
+        std::atomic<unsigned int>& queue_length;
     };
 
 } // namespace crow

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -407,7 +407,7 @@ namespace crow
                 do_write_general();
             }
 
-            queue_length -= 1;
+            queue_length--;
         }
 
     private:

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -643,7 +643,7 @@ namespace crow
             if (!is_reading && !is_writing)
             {
                 queue_length_--;
-                CROW_LOG_DEBUG << this << " delete (idle) ";
+                CROW_LOG_DEBUG << this << " delete (idle) (queue length: " << queue_length_ << ')';
                 delete this;
             }
         }

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -186,7 +186,8 @@ namespace crow
           std::tuple<Middlewares...>* middlewares,
           std::function<std::string()>& get_cached_date_str_f,
           detail::task_timer& task_timer,
-          typename Adaptor::context* adaptor_ctx_):
+          typename Adaptor::context* adaptor_ctx_,
+          int &queue_length_):
           adaptor_(io_service, adaptor_ctx_),
           handler_(handler),
           parser_(this),
@@ -194,7 +195,8 @@ namespace crow
           middlewares_(middlewares),
           get_cached_date_str(get_cached_date_str_f),
           task_timer_(task_timer),
-          res_stream_threshold_(handler->stream_threshold())
+          res_stream_threshold_(handler->stream_threshold()),
+          queue_length(queue_length_)
         {
 #ifdef CROW_ENABLE_DEBUG
             connectionCount++;
@@ -404,6 +406,8 @@ namespace crow
             {
                 do_write_general();
             }
+
+            queue_length -= 1;
         }
 
     private:
@@ -700,6 +704,8 @@ namespace crow
         detail::task_timer& task_timer_;
 
         size_t res_stream_threshold_;
+
+        int &queue_length;
     };
 
 } // namespace crow

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -192,9 +192,10 @@ namespace crow
 
         void do_accept()
         {
-            int service_idx = pick_io_service_idx();
+            uint16_t service_idx = pick_io_service_idx();
             asio::io_service& is = *io_service_pool_[service_idx];
             task_queue_length_pool_[service_idx]++;
+            CROW_LOG_DEBUG << &is << " {" <<  service_idx << "} queue length: " << task_queue_length_pool_[service_idx];
 
             auto p = new Connection<Adaptor, Handler, Middlewares...>(
               is, handler_, server_name_, middlewares_,
@@ -213,6 +214,7 @@ namespace crow
                   else
                   {
                       task_queue_length_pool_[service_idx]--;
+                      CROW_LOG_DEBUG << &is << " {" <<  service_idx << "} queue length: " << task_queue_length_pool_[service_idx];
                       delete p;
                   }
                   do_accept();

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -102,13 +102,13 @@ namespace crow
                         detail::task_timer task_timer(*io_service_pool_[i]);
                         task_timer.set_default_timeout(timeout_);
                         task_timer_pool_[i] = &task_timer;
+                        task_queue_length_pool_[i] = 0;
 
                         init_count++;
                         while (1)
                         {
                             try
                             {
-                                task_queue_length_pool_[i] = 0;
                                 if (io_service_pool_[i]->run() == 0)
                                 {
                                     // when io_service.run returns 0, there are no more works to do.

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -177,12 +177,13 @@ namespace crow
         }
 
     private:
-        int pick_io_service_idx()
+        uint16_t pick_io_service_idx()
         {
-            int min_queue_idx = 0;
+            uint16_t min_queue_idx = 0;
 
             // TODO improve load balancing
-            for (uint16_t i = 1; i < task_queue_length_pool_.size(); i++)
+            for (uint16_t i = 1; i < task_queue_length_pool_.size() && task_queue_length_pool_[min_queue_idx] > 0; i++)
+            // No need to check other io_services if the current one has no tasks
             {
                 if (task_queue_length_pool_[i] < task_queue_length_pool_[min_queue_idx])
                     min_queue_idx = i;

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -196,7 +196,7 @@ namespace crow
             asio::io_service& is = *io_service_pool_[service_idx];
             auto p = new Connection<Adaptor, Handler, Middlewares...>(
               is, handler_, server_name_, middlewares_,
-                get_cached_date_str_pool_[service_idx], *task_timer_pool_[service_idx], adaptor_ctx_, task_queue_length_pool_[service_idx]);
+              get_cached_date_str_pool_[service_idx], *task_timer_pool_[service_idx], adaptor_ctx_, task_queue_length_pool_[service_idx]);
             task_queue_length_pool_[service_idx] += 1;
             acceptor_.async_accept(
               p->socket(),

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -196,7 +196,7 @@ namespace crow
             uint16_t service_idx = pick_io_service_idx();
             asio::io_service& is = *io_service_pool_[service_idx];
             task_queue_length_pool_[service_idx]++;
-            CROW_LOG_DEBUG << &is << " {" <<  service_idx << "} queue length: " << task_queue_length_pool_[service_idx];
+            CROW_LOG_DEBUG << &is << " {" << service_idx << "} queue length: " << task_queue_length_pool_[service_idx];
 
             auto p = new Connection<Adaptor, Handler, Middlewares...>(
               is, handler_, server_name_, middlewares_,
@@ -215,7 +215,7 @@ namespace crow
                   else
                   {
                       task_queue_length_pool_[service_idx]--;
-                      CROW_LOG_DEBUG << &is << " {" <<  service_idx << "} queue length: " << task_queue_length_pool_[service_idx];
+                      CROW_LOG_DEBUG << &is << " {" << service_idx << "} queue length: " << task_queue_length_pool_[service_idx];
                       delete p;
                   }
                   do_accept();


### PR DESCRIPTION
Count the number of requests in queue in each thread and use the thread with the smallest queue for new requests.
Related to issue #258, may fix issue #182.
This will avoid ignoring some requests when a thread is stuck.