### PR TITLE
logger: don't append `std::endl` to the message.

### DIFF
--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -31,16 +31,17 @@ class CustomLogger : public crow::ILogHandler {
  public:
   CustomLogger() {}
   void log(std::string message, crow::LogLevel /*level*/) {
-    // "message" doesn't contain the timestamp and loglevel prefix the default
-    // logger does and it ends with a std::endl.
-    std::cerr << message;
+    // "message" doesn't contain the timestamp and loglevel
+    // prefix the default logger does and it doesn't end
+    // in a newline.
+    std::cerr << message << std::endl;
   }
 };
 
 int main(int argc, char** argv) {
   CustomLogger logger;
   crow::logger::setHandler(&logger);
-  
+
   crow::SimpleApp app;
   CROW_ROUTE(app, "/")([]() { return "Hello"; });
   app.run();

--- a/include/crow/logging.h
+++ b/include/crow/logging.h
@@ -60,7 +60,7 @@ namespace crow
                     prefix = "CRITICAL";
                     break;
             }
-            std::cerr << "(" << timestamp() << ") [" << prefix << "] " << message;
+            std::cerr << "(" << timestamp() << ") [" << prefix << "] " << message << std::endl;
         }
 
     private:
@@ -93,7 +93,6 @@ namespace crow
 #ifdef CROW_ENABLE_LOGGING
             if (level_ >= get_current_log_level())
             {
-                stringstream_ << std::endl;
                 get_handler_ref()->log(stringstream_.str(), level_);
             }
 #endif


### PR DESCRIPTION
`ILogHandler` instances should take care of that:
```c++
class CustomLogger : public crow::ILogHandler {
 public:
  CustomLogger() {}
  void log(std::string message, crow::LogLevel /*level*/) {
    // "message" doesn't contain the timestamp and loglevel
    // prefix the default logger does and it doesn't end
    // in a newline.
    std::cerr << message << std::endl;
  }
};
```

Signed-off-by: Luca Schlecker <luca.schlecker@hotmail.com>