### PR TITLE
Fixed data leak when sending static files

### DIFF
--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -572,6 +572,7 @@ namespace crow
                         //buf.reserve(16385);
                         buf = res.body.substr(0, 16384);
                         res.body = res.body.substr(16384);
+                        buffers.clear();
                         buffers.push_back(boost::asio::buffer(buf));
                         do_write_sync(buffers);
                     }
@@ -580,6 +581,7 @@ namespace crow
                     buf = res.body;
                     res.body.clear();
 
+                    buffers.clear();
                     buffers.push_back(boost::asio::buffer(buf));
                     do_write_sync(buffers);
                 }

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -247,16 +247,5 @@ namespace crow
         std::function<bool()> is_alive_helper_;
         static_file_info file_info;
 
-        template<typename Stream, typename Adaptor>
-        void write_streamed(Stream& is, Adaptor& adaptor)
-        {
-            char buf[16384];
-            while (is.read(buf, sizeof(buf)).gcount() > 0)
-            {
-                std::vector<asio::const_buffer> buffers;
-                buffers.push_back(boost::asio::buffer(buf));
-                write_buffer_list(buffers, adaptor);
-            }
-        }
     };
 } // namespace crow

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -246,6 +246,5 @@ namespace crow
         std::function<void()> complete_request_handler_;
         std::function<bool()> is_alive_helper_;
         static_file_info file_info;
-
     };
 } // namespace crow


### PR DESCRIPTION
This PR moves the file sending logic to the connection class and adds the necessary checks for errors or the need to close the connection and delete the object.

closes #291 