### PR TITLE
Missing inline specifier in http_status_str function definition fixed

### DIFF
--- a/include/crow/http_parser_merged.h
+++ b/include/crow/http_parser_merged.h
@@ -2568,7 +2568,7 @@ static const char *method_strings[] =
   return CROW_ELEM_AT(method_strings, m, "<unknown>");
 }
 
-const char *
+inline const char *
 http_status_str (enum http_status s)
 {
   switch (s) {


### PR DESCRIPTION
The missing inline specifier leads to a build error where compiler produces " multiple definition of `http__status_str' " error.
![http_status_str](https://user-images.githubusercontent.com/51493483/146409367-f29a0ad3-085e-4d3b-a478-b7b799ea690d.jpeg)
.