### PR TITLE
Fixes issue where `crow::json` escapes UTF-8 characters above value `127`

### DIFF
--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -53,7 +53,7 @@ namespace crow
                     case '\r': ret += "\\r"; break;
                     case '\t': ret += "\\t"; break;
                     default:
-                        if (c < 0x20)
+                        if (c >= 0 && c < 0x20)
                         {
                             ret += "\\u00";
                             auto to_hex = [](char c) {


### PR DESCRIPTION
https://github.com/CrowCpp/Crow/issues/302
Escape only the invisible characters from 0 to 31 inclusive
Motivation: do not escape UTF8 encoding bytes