### PR TITLE
Fix inconsistencies in `concurrency`

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -156,9 +156,8 @@ namespace crow
         /// Run the server on multiple threads using a specific number
         self_t& concurrency(std::uint16_t concurrency)
         {
-            if (concurrency < 2) // using 2 instead of 1 because 1 will be subtracted later.
+            if (concurrency < 2) // Crow can have a minimum of 2 threads running
                 concurrency = 2;
-            concurrency--; // Account for the main (acceptor) thread creating all the other threads.
             concurrency_ = concurrency;
             return *this;
         }
@@ -421,7 +420,7 @@ namespace crow
     private:
         std::uint8_t timeout_{5};
         uint16_t port_ = 80;
-        uint16_t concurrency_ = 1;
+        uint16_t concurrency_ = 2;
         bool validated_ = false;
         std::string server_name_ = std::string("Crow/") + VERSION;
         std::string bindaddr_ = "0.0.0.0";

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -156,8 +156,9 @@ namespace crow
         /// Run the server on multiple threads using a specific number
         self_t& concurrency(std::uint16_t concurrency)
         {
-            if (concurrency < 1)
-                concurrency = 1;
+            if (concurrency < 2) // using 2 instead of 1 because 1 will be subtracted later.
+                concurrency = 2;
+            concurrency--; // Account for the main (acceptor) thread creating all the other threads.
             concurrency_ = concurrency;
             return *this;
         }

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -31,7 +31,7 @@ namespace crow
           signals_(io_service_),
           tick_timer_(io_service_),
           handler_(handler),
-          concurrency_(concurrency == 0 ? 1 : concurrency),
+          concurrency_(concurrency),
           timeout_(timeout),
           server_name_(server_name),
           port_(port),
@@ -137,8 +137,7 @@ namespace crow
             handler_->port(port_);
 
 
-            CROW_LOG_INFO << server_name_ << " server is running at " << (handler_->ssl_used() ? "https://" : "http://") << bindaddr_ << ":" << acceptor_.local_endpoint().port()
-                          << " using " << concurrency_ << " threads";
+            CROW_LOG_INFO << server_name_ << " server is running at " << (handler_->ssl_used() ? "https://" : "http://") << bindaddr_ << ":" << acceptor_.local_endpoint().port() << " using " << (concurrency_ + 1) << " threads"; // +1 is for the main thread
             CROW_LOG_INFO << "Call `app.loglevel(crow::LogLevel::Warning)` to hide Info level logs.";
 
             signals_.async_wait(


### PR DESCRIPTION
`concurrency` (whether the variable or function) used to represent the number of worker threads to be used.

This PR changes that to include the primary thread (acceptor thread) as well as all the worker threads.

This does have the effect of making Crow report a minimum of 2 threads (which is the actual minimum thread count).

I also removed the redundant check for the value being `0` in `http_server.h` since that's already being done in `app.h`.