### PR TITLE
Improve sanitize_filename

### DIFF
--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2447,6 +2447,34 @@ TEST_CASE("base64")
     CHECK(crow::utility::base64decode(sample_bin2_enc_np, 6) == std::string(reinterpret_cast<char const*>(sample_bin2)).substr(0, 4));
 } // base64
 
+TEST_CASE("sanitize_filename")
+{
+    auto sanitize_filename = [](string s) {
+        crow::utility::sanitize_filename(s);
+        return s;
+    };
+    CHECK(sanitize_filename("abc/def") == "abc/def");
+    CHECK(sanitize_filename("abc/../def") == "abc/_/def");
+    CHECK(sanitize_filename("abc/..\\..\\..//.../def") == "abc/_\\_\\_//_./def");
+    CHECK(sanitize_filename("abc/..../def") == "abc/_../def");
+    CHECK(sanitize_filename("abc/x../def") == "abc/x../def");
+    CHECK(sanitize_filename("../etc/passwd") == "_/etc/passwd");
+    CHECK(sanitize_filename("abc/AUX") == "abc/_");
+    CHECK(sanitize_filename("abc/AUX/foo") == "abc/_/foo");
+    CHECK(sanitize_filename("abc/AUX:") == "abc/__");
+    CHECK(sanitize_filename("abc/AUXxy") == "abc/AUXxy");
+    CHECK(sanitize_filename("abc/AUX.xy") == "abc/_.xy");
+    CHECK(sanitize_filename("abc/NUL") == "abc/_");
+    CHECK(sanitize_filename("abc/NU") == "abc/NU");
+    CHECK(sanitize_filename("abc/NuL") == "abc/_");
+    CHECK(sanitize_filename("abc/LPT1\\") == "abc/_\\");
+    CHECK(sanitize_filename("abc/COM1") == "abc/_");
+    CHECK(sanitize_filename("ab?<>:*|\"cd") == "ab_______cd");
+    CHECK(sanitize_filename("abc/COM9") == "abc/_");
+    CHECK(sanitize_filename("abc/COM") == "abc/COM");
+    CHECK(sanitize_filename("abc/CON") == "abc/_");
+}
+
 TEST_CASE("get_port")
 {
     SimpleApp app;


### PR DESCRIPTION
The old sanitize_filename implementation copied the string unconditionally, and then did multiple passes over the string to detect Windows special device files. This implementation now keeps the string in place and finds all special devices in a single pass.

The separate commit for catch.hpp is required to build Crown on Ubuntu 21.10, MINSIGSTKSZ is not a constexpr but calls sysconf. This mimics what upstream catch2 does, an alternative would be to update the catch2 header to the latest upstream release.