### PR TITLE
avoid memory allocation in base64decode

### DIFF
--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -29,7 +29,7 @@ std::string myauth = req.get_header_value("Authorization");
 Next we need to isolate our encoded credentials and decode them as follows:
 ```cpp
 std::string mycreds = myauth.substr(6);
-std::string d_mycreds = crow::utility::base64decode(mycreds, mycreds.size()/*, URLSafe? (true/false)*/);
+std::string d_mycreds = crow::utility::base64decode(mycreds, mycreds.size());
 ```
 <br>
 

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2437,9 +2437,10 @@ TEST_CASE("base64")
     CHECK(crow::utility::base64encode((unsigned char*)sample_bin2, 4) == sample_bin2_enc);
 
 
+    CHECK(crow::utility::base64decode(sample_base64) == sample_text);
     CHECK(crow::utility::base64decode(sample_base64, sample_base64.length()) == sample_text);
     CHECK(crow::utility::base64decode(sample_bin_enc, 8) == std::string(reinterpret_cast<char const*>(sample_bin)));
-    CHECK(crow::utility::base64decode(sample_bin_enc_url, 8, true) == std::string(reinterpret_cast<char const*>(sample_bin)));
+    CHECK(crow::utility::base64decode(sample_bin_enc_url, 8) == std::string(reinterpret_cast<char const*>(sample_bin)));
     CHECK(crow::utility::base64decode(sample_bin1_enc, 8) == std::string(reinterpret_cast<char const*>(sample_bin1)).substr(0, 5));
     CHECK(crow::utility::base64decode(sample_bin1_enc_np, 7) == std::string(reinterpret_cast<char const*>(sample_bin1)).substr(0, 5));
     CHECK(crow::utility::base64decode(sample_bin2_enc, 8) == std::string(reinterpret_cast<char const*>(sample_bin2)).substr(0, 4));


### PR DESCRIPTION
Every single call to base64decode allocates a mapping table for all
base64 characters. This is quite wasteful, as the map is in fact static.
We could use a static variable here, but that would have unpleasant consequences
if we ever encounter input with non-valid base64 characters (which
implicitly modifies the map).

The number of character ranges for base64 is quite low (3, plus 4 exceptions),
thus we can simply check that explicitly in code instead of using a dynamic hash table.