### PR TITLE
Local middleware

### DIFF
--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -1,29 +1,94 @@
-Any middleware requires following 3 members:
-## struct context
-Storing data for the middleware; can be read from another middleware or handlers
+Middleware is used for altering and inspecting requests before and after the handler call.
 
+Any middleware requires the following 3 members:
+
+* A context struct for storing the middleware data.
+* A `before_handle` method, which is called before the handler. If `res.end()` is called, the operation is halted.
+* A `after_handle` method, which is called after the handler.
 
 ## before_handle
-Called before handling the request.<br>
-If `res.end()` is called, the operation is halted. (`after_handle` will still be called)<br>
-2 signatures:<br>
-`#!cpp void before_handle(request& req, response& res, context& ctx)`
-    if you only need to access this middleware's context.
+There are two possible signatures for before_handle
+
+1. if you only need to access this middleware's context.
+
+```cpp
+void before_handle(request& req, response& res, context& ctx)
+```
+
+2. To get access to other middlewares context
 ``` cpp
 template <typename AllContext>
-void before_handle(request& req, response& res, context& ctx, AllContext& all_ctx)
+void before_handle(request& req, response& res, context& ctx, AllContext& all_ctx) 
+{
+    auto other_ctx = all_ctx.template get<OtherMiddleware>();
+}
 ```
-You can access other middlewares' context by calling `#!cpp all_ctx.template get<MW>()`<br>
-`#!cpp ctx == all_ctx.template get<CurrentMiddleware>()`
 
 
 ## after_handle
-Called after handling the request.<br>
+There are two possible signatures for after_handle
 
-`#!cpp void after_handle(request& req, response& res, context& ctx)`
+1. if you only need to access this middleware's context.
+
+```cpp
+void after_handle(request& req, response& res, context& ctx)
+```
+
+2. To get access to other middlewares context
 ``` cpp
 template <typename AllContext>
-void after_handle(request& req, response& res, context& ctx, AllContext& all_ctx)
+void after_handle(request& req, response& res, context& ctx, AllContext& all_ctx) 
+{
+    auto other_ctx = all_ctx.template get<OtherMiddleware>();
+}
 ```
-<br><br>
-This was pulled from `cookie_parser.h`. Further Editing required, possibly use parts of [@ipkn's wiki page](https://github.com/ipkn/crow/wiki/Middleware).
+
+## Using middleware
+
+All middleware has to be registered in the Crow application and is enabled globally by default.
+
+```cpp
+crow::App<FirstMiddleware, SecondMiddleware> app;
+```
+
+if you want to enable some middleware only for specific handlers, you have to extend it from `crow::ILocalMiddleware`.
+
+```cpp
+struct LocalMiddleware : crow::ILocalMiddleware 
+{
+... 
+```
+
+After this, you can enable it for specific handlers.
+
+```cpp
+CROW_ROUTE(app, "/with_middleware")
+.middlewares<decltype(app), LocalMiddleware>()
+([]() {
+    return "Hello world!";
+});
+```
+
+## Examples
+
+A local middleware that can be used to guard admin handlers
+
+```cpp
+struct AdminAreaGuard : crow::ILocalMiddleware
+{
+    struct context
+    {};
+
+    void before_handle(crow::request& req, crow::response& res, context& ctx)
+    {
+        if (req.remote_ip_address != ADMIN_IP) 
+        {
+            res.code = 403;
+            res.end();
+        }
+    }
+
+    void after_handle(crow::request& req, crow::response& res, context& ctx)
+    {} 
+};
+```

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -63,7 +63,7 @@ After this, you can enable it for specific handlers.
 
 ```cpp
 CROW_ROUTE(app, "/with_middleware")
-.middlewares<decltype(app), LocalMiddleware>()
+.CROW_MIDDLEWARES(app, LocalMiddleware)
 ([]() {
     return "Hello world!";
 });

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -79,6 +79,10 @@ add_executable(example_blueprint example_blueprint.cpp)
 add_warnings_optimizations(example_blueprint)
 target_link_libraries(example_blueprint PUBLIC Crow::Crow)
 
+add_executable(example_middleware example_middleware.cpp)
+add_warnings_optimizations(example_middleware)
+target_link_libraries(example_middleware PUBLIC Crow::Crow)
+
 if(MSVC)
   add_executable(example_vs example_vs.cpp)
   add_warnings_optimizations(example_vs)

--- a/examples/example_middleware.cpp
+++ b/examples/example_middleware.cpp
@@ -43,11 +43,10 @@ int main()
     });
 
     CROW_ROUTE(app, "/secret")
-    // Enable SecretContentGuard for this handler
-    .middlewares<decltype(app), SecretContentGuard>()
-    ([]() {
-        return "";
-    });
+      // Enable SecretContentGuard for this handler
+      .middlewares<decltype(app), SecretContentGuard>()([]() {
+          return "";
+      });
 
     app.port(18080).run();
 

--- a/examples/example_middleware.cpp
+++ b/examples/example_middleware.cpp
@@ -44,7 +44,7 @@ int main()
 
     CROW_ROUTE(app, "/secret")
       // Enable SecretContentGuard for this handler
-      .middlewares<decltype(app), SecretContentGuard>()([]() {
+      .CROW_MIDDLEWARES(app, SecretContentGuard)([]() {
           return "";
       });
 

--- a/examples/example_middleware.cpp
+++ b/examples/example_middleware.cpp
@@ -1,0 +1,55 @@
+#include "crow.h"
+
+struct RequestLogger
+{
+    struct context
+    {};
+
+    void before_handle(crow::request& req, crow::response& /*res*/, context& /*ctx*/)
+    {
+        CROW_LOG_INFO << "Request to:" + req.url;
+    }
+
+    void after_handle(crow::request& /*req*/, crow::response& /*res*/, context& /*ctx*/)
+    {}
+};
+
+// Per handler middleware has to extend ILocalMiddleware
+// It is called only if enabled
+struct SecretContentGuard : crow::ILocalMiddleware
+{
+    struct context
+    {};
+
+    void before_handle(crow::request& /*req*/, crow::response& res, context& /*ctx*/)
+    {
+        res.write("SECRET!");
+        res.code = 403;
+        res.end();
+    }
+
+    void after_handle(crow::request& /*req*/, crow::response& /*res*/, context& /*ctx*/)
+    {}
+};
+
+int main()
+{
+    // ALL middleware (including per handler) is listed
+    crow::App<RequestLogger, SecretContentGuard> app;
+
+    CROW_ROUTE(app, "/")
+    ([]() {
+        return "Hello, world!";
+    });
+
+    CROW_ROUTE(app, "/secret")
+    // Enable SecretContentGuard for this handler
+    .middlewares<decltype(app), SecretContentGuard>()
+    ([]() {
+        return "";
+    });
+
+    app.port(18080).run();
+
+    return 0;
+}

--- a/include/crow.h
+++ b/include/crow.h
@@ -17,6 +17,7 @@
 #include "crow/http_response.h"
 #include "crow/multipart.h"
 #include "crow/routing.h"
+#include "crow/middleware.h"
 #include "crow/middleware_context.h"
 #include "crow/compression.h"
 #include "crow/http_connection.h"

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -68,7 +68,7 @@ namespace crow
         }
 
         /// Process the request and generate a response for it
-        void handle(const request& req, response& res)
+        void handle(request& req, response& res)
         {
             router_.handle(req, res);
         }
@@ -394,6 +394,7 @@ namespace crow
 
         // middleware
         using context_t = detail::context<Middlewares...>;
+        using mw_container_t = std::tuple<Middlewares...>;
         template<typename T>
         typename T::context& get_context(const request& req)
         {

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -29,6 +29,7 @@
 #else
 #define CROW_ROUTE(app, url) app.route<crow::black_magic::get_parameter_tag(url)>(url)
 #define CROW_BP_ROUTE(blueprint, url) blueprint.new_rule_tagged<crow::black_magic::get_parameter_tag(url)>(url)
+#define CROW_MIDDLEWARES(app, ...) middlewares<decltype(app), __VA_ARGS__>()
 #endif
 #define CROW_CATCHALL_ROUTE(app) app.catchall_route()
 #define CROW_BP_CATCHALL_ROUTE(blueprint) blueprint.catchall_rule()

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -177,7 +177,7 @@ namespace crow
                 req.io_service = &adaptor_.get_io_service();
 
                 detail::middleware_call_helper<detail::middleware_call_criteria_only_global,
-                    0, decltype(ctx_), decltype(*middlewares_)>(*middlewares_, req, res, ctx_);
+                                               0, decltype(ctx_), decltype(*middlewares_)>(*middlewares_, req, res, ctx_);
 
                 if (!res.completed_)
                 {

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -15,6 +15,7 @@
 #include "crow/settings.h"
 #include "crow/task_timer.h"
 #include "crow/middleware_context.h"
+#include "crow/middleware.h"
 #include "crow/socket_adaptors.h"
 #include "crow/compression.h"
 
@@ -23,150 +24,6 @@ namespace crow
     using namespace boost;
     using tcp = asio::ip::tcp;
 
-    namespace detail
-    {
-        template<typename MW>
-        struct check_before_handle_arity_3_const
-        {
-            template<typename T, void (T::*)(request&, response&, typename MW::context&) const = &T::before_handle>
-            struct get
-            {};
-        };
-
-        template<typename MW>
-        struct check_before_handle_arity_3
-        {
-            template<typename T, void (T::*)(request&, response&, typename MW::context&) = &T::before_handle>
-            struct get
-            {};
-        };
-
-        template<typename MW>
-        struct check_after_handle_arity_3_const
-        {
-            template<typename T, void (T::*)(request&, response&, typename MW::context&) const = &T::after_handle>
-            struct get
-            {};
-        };
-
-        template<typename MW>
-        struct check_after_handle_arity_3
-        {
-            template<typename T, void (T::*)(request&, response&, typename MW::context&) = &T::after_handle>
-            struct get
-            {};
-        };
-
-        template<typename T>
-        struct is_before_handle_arity_3_impl
-        {
-            template<typename C>
-            static std::true_type f(typename check_before_handle_arity_3_const<T>::template get<C>*);
-
-            template<typename C>
-            static std::true_type f(typename check_before_handle_arity_3<T>::template get<C>*);
-
-            template<typename C>
-            static std::false_type f(...);
-
-        public:
-            static const bool value = decltype(f<T>(nullptr))::value;
-        };
-
-        template<typename T>
-        struct is_after_handle_arity_3_impl
-        {
-            template<typename C>
-            static std::true_type f(typename check_after_handle_arity_3_const<T>::template get<C>*);
-
-            template<typename C>
-            static std::true_type f(typename check_after_handle_arity_3<T>::template get<C>*);
-
-            template<typename C>
-            static std::false_type f(...);
-
-        public:
-            static const bool value = decltype(f<T>(nullptr))::value;
-        };
-
-        template<typename MW, typename Context, typename ParentContext>
-        typename std::enable_if<!is_before_handle_arity_3_impl<MW>::value>::type
-          before_handler_call(MW& mw, request& req, response& res, Context& ctx, ParentContext& /*parent_ctx*/)
-        {
-            mw.before_handle(req, res, ctx.template get<MW>(), ctx);
-        }
-
-        template<typename MW, typename Context, typename ParentContext>
-        typename std::enable_if<is_before_handle_arity_3_impl<MW>::value>::type
-          before_handler_call(MW& mw, request& req, response& res, Context& ctx, ParentContext& /*parent_ctx*/)
-        {
-            mw.before_handle(req, res, ctx.template get<MW>());
-        }
-
-        template<typename MW, typename Context, typename ParentContext>
-        typename std::enable_if<!is_after_handle_arity_3_impl<MW>::value>::type
-          after_handler_call(MW& mw, request& req, response& res, Context& ctx, ParentContext& /*parent_ctx*/)
-        {
-            mw.after_handle(req, res, ctx.template get<MW>(), ctx);
-        }
-
-        template<typename MW, typename Context, typename ParentContext>
-        typename std::enable_if<is_after_handle_arity_3_impl<MW>::value>::type
-          after_handler_call(MW& mw, request& req, response& res, Context& ctx, ParentContext& /*parent_ctx*/)
-        {
-            mw.after_handle(req, res, ctx.template get<MW>());
-        }
-
-        template<int N, typename Context, typename Container, typename CurrentMW, typename... Middlewares>
-        bool middleware_call_helper(Container& middlewares, request& req, response& res, Context& ctx)
-        {
-            using parent_context_t = typename Context::template partial<N - 1>;
-            before_handler_call<CurrentMW, Context, parent_context_t>(std::get<N>(middlewares), req, res, ctx, static_cast<parent_context_t&>(ctx));
-
-            if (res.is_completed())
-            {
-                after_handler_call<CurrentMW, Context, parent_context_t>(std::get<N>(middlewares), req, res, ctx, static_cast<parent_context_t&>(ctx));
-                return true;
-            }
-
-            if (middleware_call_helper<N + 1, Context, Container, Middlewares...>(middlewares, req, res, ctx))
-            {
-                after_handler_call<CurrentMW, Context, parent_context_t>(std::get<N>(middlewares), req, res, ctx, static_cast<parent_context_t&>(ctx));
-                return true;
-            }
-
-            return false;
-        }
-
-        template<int N, typename Context, typename Container>
-        bool middleware_call_helper(Container& /*middlewares*/, request& /*req*/, response& /*res*/, Context& /*ctx*/)
-        {
-            return false;
-        }
-
-        template<int N, typename Context, typename Container>
-        typename std::enable_if<(N < 0)>::type
-          after_handlers_call_helper(Container& /*middlewares*/, Context& /*context*/, request& /*req*/, response& /*res*/)
-        {
-        }
-
-        template<int N, typename Context, typename Container>
-        typename std::enable_if<(N == 0)>::type after_handlers_call_helper(Container& middlewares, Context& ctx, request& req, response& res)
-        {
-            using parent_context_t = typename Context::template partial<N - 1>;
-            using CurrentMW = typename std::tuple_element<N, typename std::remove_reference<Container>::type>::type;
-            after_handler_call<CurrentMW, Context, parent_context_t>(std::get<N>(middlewares), req, res, ctx, static_cast<parent_context_t&>(ctx));
-        }
-
-        template<int N, typename Context, typename Container>
-        typename std::enable_if<(N > 0)>::type after_handlers_call_helper(Container& middlewares, Context& ctx, request& req, response& res)
-        {
-            using parent_context_t = typename Context::template partial<N - 1>;
-            using CurrentMW = typename std::tuple_element<N, typename std::remove_reference<Container>::type>::type;
-            after_handler_call<CurrentMW, Context, parent_context_t>(std::get<N>(middlewares), req, res, ctx, static_cast<parent_context_t&>(ctx));
-            after_handlers_call_helper<N - 1, Context, Container>(middlewares, ctx, req, res);
-        }
-    } // namespace detail
 
 #ifdef CROW_ENABLE_DEBUG
     static std::atomic<int> connectionCount;
@@ -316,8 +173,11 @@ namespace crow
 
                 ctx_ = detail::context<Middlewares...>();
                 req.middleware_context = static_cast<void*>(&ctx_);
+                req.middleware_container = static_cast<void*>(middlewares_);
                 req.io_service = &adaptor_.get_io_service();
-                detail::middleware_call_helper<0, decltype(ctx_), decltype(*middlewares_), Middlewares...>(*middlewares_, req, res, ctx_);
+
+                detail::middleware_call_helper<detail::middleware_call_criteria_only_global,
+                    0, decltype(ctx_), decltype(*middlewares_)>(*middlewares_, req, res, ctx_);
 
                 if (!res.completed_)
                 {
@@ -351,6 +211,7 @@ namespace crow
 
                 // call all after_handler of middlewares
                 detail::after_handlers_call_helper<
+                  detail::middleware_call_criteria_only_global,
                   (static_cast<int>(sizeof...(Middlewares)) - 1),
                   decltype(ctx_),
                   decltype(*middlewares_)>(*middlewares_, ctx_, req_, res);

--- a/include/crow/http_request.h
+++ b/include/crow/http_request.h
@@ -34,6 +34,7 @@ namespace crow
         std::string remote_ip_address; ///< The IP address from which the request was sent.
 
         void* middleware_context{};
+        void* middleware_container{};
         boost::asio::io_service* io_service{};
 
         /// Construct an empty request. (sets the method to `GET`)

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -19,7 +19,8 @@ namespace crow
     template<typename Adaptor, typename Handler, typename... Middlewares>
     class Connection;
 
-    namespace detail {
+    namespace detail
+    {
         template<typename F, typename App, typename... Middlewares>
         struct handler_middleware_wrapper;
     } // namespace detail

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -19,11 +19,19 @@ namespace crow
     template<typename Adaptor, typename Handler, typename... Middlewares>
     class Connection;
 
+    namespace detail {
+        template<typename F, typename App, typename... Middlewares>
+        struct handler_middleware_wrapper;
+    } // namespace detail
+
     /// HTTP response
     struct response
     {
         template<typename Adaptor, typename Handler, typename... Middlewares>
         friend class crow::Connection;
+
+        template<typename F, typename App, typename... Middlewares>
+        friend struct crow::detail::handler_middleware_wrapper;
 
         int code{200};    ///< The Status code for the response.
         std::string body; ///< The actual payload containing the response data.

--- a/include/crow/middleware.h
+++ b/include/crow/middleware.h
@@ -1,0 +1,308 @@
+#pragma once
+
+#include "crow/http_request.h"
+#include "crow/http_response.h"
+#include "crow/utility.h"
+
+#include <tuple>
+#include <type_traits>
+#include <iostream>
+#include <utility>
+
+namespace crow {
+
+    /// Local middleware should extend ILocalMiddleware 
+    struct ILocalMiddleware {
+        using call_global = std::false_type;
+    };
+
+    namespace detail
+    {
+        template<typename MW>
+        struct check_before_handle_arity_3_const
+        {
+            template<typename T, void (T::*)(request&, response&, typename MW::context&) const = &T::before_handle>
+            struct get
+            {};
+        };
+
+        template<typename MW>
+        struct check_before_handle_arity_3
+        {
+            template<typename T, void (T::*)(request&, response&, typename MW::context&) = &T::before_handle>
+            struct get
+            {};
+        };
+
+        template<typename MW>
+        struct check_after_handle_arity_3_const
+        {
+            template<typename T, void (T::*)(request&, response&, typename MW::context&) const = &T::after_handle>
+            struct get
+            {};
+        };
+
+        template<typename MW>
+        struct check_after_handle_arity_3
+        {
+            template<typename T, void (T::*)(request&, response&, typename MW::context&) = &T::after_handle>
+            struct get
+            {};
+        };
+
+        template<typename MW>
+        struct check_global_call_false {
+            template<typename T, typename std::enable_if<T::call_global::value == false, bool>::type = true>
+            struct get
+            {};
+        };
+
+        template<typename T>
+        struct is_before_handle_arity_3_impl
+        {
+            template<typename C>
+            static std::true_type f(typename check_before_handle_arity_3_const<T>::template get<C>*);
+
+            template<typename C>
+            static std::true_type f(typename check_before_handle_arity_3<T>::template get<C>*);
+
+            template<typename C>
+            static std::false_type f(...);
+
+        public:
+            static const bool value = decltype(f<T>(nullptr))::value;
+        };
+
+        template<typename T>
+        struct is_after_handle_arity_3_impl
+        {
+            template<typename C>
+            static std::true_type f(typename check_after_handle_arity_3_const<T>::template get<C>*);
+
+            template<typename C>
+            static std::true_type f(typename check_after_handle_arity_3<T>::template get<C>*);
+
+            template<typename C>
+            static std::false_type f(...);
+
+        public:
+            static constexpr bool value = decltype(f<T>(nullptr))::value;
+        };
+
+        template<typename MW, typename Context, typename ParentContext>
+        typename std::enable_if<!is_before_handle_arity_3_impl<MW>::value>::type
+          before_handler_call(MW& mw, request& req, response& res, Context& ctx, ParentContext& /*parent_ctx*/)
+        {
+            mw.before_handle(req, res, ctx.template get<MW>(), ctx);
+        }
+
+        template<typename MW, typename Context, typename ParentContext>
+        typename std::enable_if<is_before_handle_arity_3_impl<MW>::value>::type
+          before_handler_call(MW& mw, request& req, response& res, Context& ctx, ParentContext& /*parent_ctx*/)
+        {
+            mw.before_handle(req, res, ctx.template get<MW>());
+        }
+
+        template<typename MW, typename Context, typename ParentContext>
+        typename std::enable_if<!is_after_handle_arity_3_impl<MW>::value>::type
+          after_handler_call(MW& mw, request& req, response& res, Context& ctx, ParentContext& /*parent_ctx*/)
+        {
+            mw.after_handle(req, res, ctx.template get<MW>(), ctx);
+        }
+
+        template<typename MW, typename Context, typename ParentContext>
+        typename std::enable_if<is_after_handle_arity_3_impl<MW>::value>::type
+          after_handler_call(MW& mw, request& req, response& res, Context& ctx, ParentContext& /*parent_ctx*/)
+        {
+            mw.after_handle(req, res, ctx.template get<MW>());
+        }
+
+        
+        template<template<typename QueryMW> class CallCriteria, // Checks if QueryMW should be called in this context 
+            int N, typename Context, typename Container>
+        typename std::enable_if<(N < std::tuple_size<typename std::remove_reference<Container>::type>::value), bool>::type
+          middleware_call_helper(Container& middlewares, request& req, response& res, Context& ctx)
+        {
+
+            using CurrentMW = typename std::tuple_element<N, typename std::remove_reference<Container>::type>::type;
+
+            if (!CallCriteria<CurrentMW>::value) {
+                return middleware_call_helper<CallCriteria, N + 1, Context, Container>(middlewares, req, res, ctx);
+            }
+
+            using parent_context_t = typename Context::template partial<N - 1>;
+            before_handler_call<CurrentMW, Context, parent_context_t>(std::get<N>(middlewares), req, res, ctx, static_cast<parent_context_t&>(ctx));
+            if (res.is_completed())
+            {
+                after_handler_call<CurrentMW, Context, parent_context_t>(std::get<N>(middlewares), req, res, ctx, static_cast<parent_context_t&>(ctx));
+                return true;
+            }
+
+            if (middleware_call_helper<CallCriteria, N + 1, Context, Container>(middlewares, req, res, ctx))
+            {
+                after_handler_call<CurrentMW, Context, parent_context_t>(std::get<N>(middlewares), req, res, ctx, static_cast<parent_context_t&>(ctx));
+                return true;
+            }
+
+            return false;
+        }
+
+        template<template<typename QueryMW> class CallCriteria, int N, typename Context, typename Container>
+        typename std::enable_if<(N >= std::tuple_size<typename std::remove_reference<Container>::type>::value), bool>::type
+          middleware_call_helper(Container& /*middlewares*/, request& /*req*/, response& /*res*/, Context& /*ctx*/)
+        {
+            return false;
+        }
+
+        template<template<typename QueryMW> class CallCriteria, int N, typename Context, typename Container>
+        typename std::enable_if<(N < 0)>::type
+          after_handlers_call_helper(Container& /*middlewares*/, Context& /*context*/, request& /*req*/, response& /*res*/)
+        {
+        }
+
+        template<template<typename QueryMW> class CallCriteria, int N, typename Context, typename Container>
+        typename std::enable_if<(N == 0)>::type after_handlers_call_helper(Container& middlewares, Context& ctx, request& req, response& res)
+        {
+            using parent_context_t = typename Context::template partial<N - 1>;
+            using CurrentMW = typename std::tuple_element<N, typename std::remove_reference<Container>::type>::type;
+            if (CallCriteria<CurrentMW>::value) {
+                after_handler_call<CurrentMW, Context, parent_context_t>(std::get<N>(middlewares), req, res, ctx, static_cast<parent_context_t&>(ctx));
+            }
+        }
+
+        template<template<typename QueryMW> class CallCriteria, int N, typename Context, typename Container>
+        typename std::enable_if<(N > 0)>::type after_handlers_call_helper(Container& middlewares, Context& ctx, request& req, response& res)
+        {
+            using parent_context_t = typename Context::template partial<N - 1>;
+            using CurrentMW = typename std::tuple_element<N, typename std::remove_reference<Container>::type>::type;
+            if (CallCriteria<CurrentMW>::value) {
+                after_handler_call<CurrentMW, Context, parent_context_t>(std::get<N>(middlewares), req, res, ctx, static_cast<parent_context_t&>(ctx));
+            }
+            after_handlers_call_helper<CallCriteria, N - 1, Context, Container>(middlewares, ctx, req, res);
+        }
+
+        // A CallCriteria that accepts only global middleware
+        template<typename MW>
+        struct middleware_call_criteria_only_global
+        {
+            template<typename C>
+            static std::false_type f(typename check_global_call_false<MW>::template get<C>*);
+
+            template<typename C>
+            static std::true_type f(...);
+
+            static const bool value = decltype(f<MW>(nullptr))::value;
+        };
+
+        // wrapped_handler_call transparently wraps a handler call behind (req, res, args...)
+        template<typename F, typename... Args>
+        typename std::enable_if<black_magic::is_callable<F, const crow::request, crow::response&, Args...>::value>::type
+          wrapped_handler_call(crow::request& req, crow::response& res, const F& f, Args&&... args)
+        {
+            static_assert(std::is_same<void, decltype(f(std::declval<crow::request>(), std::declval<crow::response&>(), std::declval<Args>()...))>::value,
+                          "Handler function with response argument should have void return type");
+
+            f(req, res, std::forward<Args>(args)...);
+        }
+
+        template<typename F, typename... Args>
+        typename std::enable_if<black_magic::is_callable<F, crow::request&, crow::response&, Args...>::value
+            && !black_magic::is_callable<F, const crow::request, crow::response&, Args...>::value
+        >::type
+          wrapped_handler_call(crow::request& req, crow::response& res, const F& f, Args&&... args)
+        {
+            static_assert(std::is_same<void, decltype(f(std::declval<crow::request&>(), std::declval<crow::response&>(), std::declval<Args>()...))>::value,
+                          "Handler function with response argument should have void return type");
+
+            f(req, res, std::forward<Args>(args)...);
+        }
+
+        template<typename F, typename... Args>
+        typename std::enable_if<black_magic::is_callable<F, crow::response&, Args...>::value>::type
+          wrapped_handler_call(crow::request& /*req*/, crow::response& res, const F& f, Args&&... args)
+        {
+            static_assert(std::is_same<void, decltype(f(std::declval<crow::response&>(), std::declval<Args>()...))>::value,
+                          "Handler function with response argument should have void return type");
+
+            f(res, std::forward<Args>(args)...);
+        }
+
+        template<typename F, typename... Args>
+        typename std::enable_if<black_magic::is_callable<F, crow::request, Args...>::value>::type
+          wrapped_handler_call(crow::request& req, crow::response& res, const F& f, Args&&... args)
+        {
+            static_assert(!std::is_same<void, decltype(f(std::declval<crow::request>(), std::declval<Args>()...))>::value,
+                          "Handler function cannot have void return type; valid return types: string, int, crow::response, crow::returnable");
+
+            res = crow::response(f(req, std::forward<Args>(args)...));
+            res.end();
+        }
+
+        template<typename F, typename... Args>
+        typename std::enable_if<black_magic::is_callable<F, Args...>::value>::type
+          wrapped_handler_call(crow::request& /*req*/, crow::response& res, const F& f, Args&&... args)
+        {
+            static_assert(!std::is_same<void, decltype(f(std::declval<Args>()...))>::value,
+                          "Handler function cannot have void return type; valid return types: string, int, crow::response, crow::returnable");
+
+            res = crow::response(f(std::forward<Args>(args)...));
+            res.end();
+        }
+
+        template<typename F, typename App, typename... Middlewares>
+        struct handler_middleware_wrapper
+        {
+            // CallCriteria bound to the current Middlewares pack
+            template<typename MW>
+            struct middleware_call_criteria
+            {
+                static constexpr bool value = black_magic::has_type<MW, std::tuple<Middlewares...>>::value;
+            };
+
+            template<typename... Args>
+            void operator()(crow::request& req, crow::response& res, Args&&... args) const
+            {
+                auto& ctx = *reinterpret_cast<typename App::context_t*>(req.middleware_context);
+                auto& container = *reinterpret_cast<typename App::mw_container_t*>(req.middleware_container);
+
+                bool completed = middleware_call_helper<middleware_call_criteria,
+                    0, typename App::context_t, typename App::mw_container_t>(container, req, res, ctx);
+
+                if (completed) return;
+
+                wrapped_handler_call(req, res, f, std::forward<Args>(args)...);
+
+                after_handlers_call_helper<
+                  middleware_call_criteria,
+                  std::tuple_size<typename App::mw_container_t>::value - 1,
+                  typename App::context_t,
+                  typename App::mw_container_t>(container, ctx, req, res);
+            }
+
+            F f;
+        };
+
+        template<typename Route, typename App, typename... Middlewares>
+        struct handler_call_bridge
+        {   
+            template<typename MW>
+            using check_app_contains = typename black_magic::has_type<MW, typename App::mw_container_t>;
+
+            static_assert(black_magic::all_true<(std::is_base_of<crow::ILocalMiddleware, Middlewares>::value)...>::value,
+              "Local middleware has to inherit crow::ILocalMiddleware");
+
+            static_assert(black_magic::all_true<(check_app_contains<Middlewares>::value)...>::value,
+              "Local middleware has to be listed in app middleware");
+
+            template<typename F>
+            void operator()(F&& f) const
+            {
+                auto wrapped = handler_middleware_wrapper<F, App, Middlewares...> {std::forward<F>(f)};
+                tptr->operator()(std::move(wrapped));
+            }
+
+            Route* tptr;
+        };
+
+    } // namespace detail
+} // namespace crow

--- a/include/crow/middleware.h
+++ b/include/crow/middleware.h
@@ -269,13 +269,19 @@ namespace crow
                 auto& ctx = *reinterpret_cast<typename App::context_t*>(req.middleware_context);
                 auto& container = *reinterpret_cast<typename App::mw_container_t*>(req.middleware_container);
 
-                bool completed = middleware_call_helper<middleware_call_criteria,
-                                                        0, typename App::context_t, typename App::mw_container_t>(container, req, res, ctx);
-
-                if (completed) return;
-
                 auto glob_completion_handler = std::move(res.complete_request_handler_);
-                auto completion_handler = [&ctx, &container, &req, &res, &glob_completion_handler] {
+                res.complete_request_handler_ = [] {};
+
+                middleware_call_helper<middleware_call_criteria,
+                                       0, typename App::context_t, typename App::mw_container_t>(container, req, res, ctx);
+
+                if (res.completed_)
+                {
+                    glob_completion_handler();
+                    return;
+                }
+
+                res.complete_request_handler_ = [&ctx, &container, &req, &res, &glob_completion_handler] {
                     after_handlers_call_helper<
                       middleware_call_criteria,
                       std::tuple_size<typename App::mw_container_t>::value - 1,
@@ -283,7 +289,6 @@ namespace crow
                       typename App::mw_container_t>(container, ctx, req, res);
                     glob_completion_handler();
                 };
-                res.complete_request_handler_ = std::move(completion_handler);
 
                 wrapped_handler_call(req, res, f, std::forward<Args>(args)...);
             }

--- a/include/crow/middleware_context.h
+++ b/include/crow/middleware_context.h
@@ -34,23 +34,18 @@ namespace crow
         };
 
 
-
-        template<int N, typename Context, typename Container, typename CurrentMW, typename... Middlewares>
-        bool middleware_call_helper(Container& middlewares, request& req, response& res, Context& ctx);
-
-
-
         template<typename... Middlewares>
         struct context : private partial_context<Middlewares...>
         //struct context : private Middlewares::context... // simple but less type-safe
         {
-            template<int N, typename Context, typename Container>
+            template<template<typename QueryMW> class CallCriteria, int N, typename Context, typename Container>
             friend typename std::enable_if<(N == 0)>::type after_handlers_call_helper(Container& middlewares, Context& ctx, request& req, response& res);
-            template<int N, typename Context, typename Container>
+            template<template<typename QueryMW> class CallCriteria, int N, typename Context, typename Container>
             friend typename std::enable_if<(N > 0)>::type after_handlers_call_helper(Container& middlewares, Context& ctx, request& req, response& res);
 
-            template<int N, typename Context, typename Container, typename CurrentMW, typename... Middlewares2>
-            friend bool middleware_call_helper(Container& middlewares, request& req, response& res, Context& ctx);
+            template<template<typename QueryMW> class CallCriteria, int N, typename Context, typename Container>
+            friend typename std::enable_if<(N < std::tuple_size<typename std::remove_reference<Container>::type>::value), bool>::type
+              middleware_call_helper(Container& middlewares, request& req, response& res, Context& ctx);
 
             template<typename T>
             typename T::context& get()

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -571,7 +571,8 @@ namespace crow
         }
 
         template<typename Func>
-        void operator()(Func&& f) {
+        void operator()(Func&& f)
+        {
             handler_ = (
 #ifdef CROW_CAN_USE_CPP14
               [f = std::move(f)]
@@ -598,14 +599,11 @@ namespace crow
                 mustache::set_base("templates");
 
             detail::routing_handler_call_helper::call<
-                detail::routing_handler_call_helper::call_params<decltype(handler_)>,
-                0, 0, 0, 0,
-                black_magic::S<Args...>,
-                black_magic::S<>>()
-                (
-                    detail::routing_handler_call_helper::call_params<decltype(handler_)>
-                    {handler_, params, req, res}
-                );
+              detail::routing_handler_call_helper::call_params<decltype(handler_)>,
+              0, 0, 0, 0,
+              black_magic::S<Args...>,
+              black_magic::S<>>()(
+              detail::routing_handler_call_helper::call_params<decltype(handler_)>{handler_, params, req, res});
         }
 
         /// Enable local middleware for this handler

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -15,6 +15,7 @@
 #include "crow/logging.h"
 #include "crow/websocket.h"
 #include "crow/mustache.h"
+#include "crow/middleware.h"
 
 namespace crow
 {
@@ -44,7 +45,7 @@ namespace crow
             return {};
         }
 
-        virtual void handle(const request&, response&, const routing_params&) = 0;
+        virtual void handle(request&, response&, const routing_params&) = 0;
         virtual void handle_upgrade(const request&, response& res, SocketAdaptor&&)
         {
             res = response(404);
@@ -109,7 +110,7 @@ namespace crow
             {
                 H1& handler;
                 const routing_params& params;
-                const request& req;
+                request& req;
                 response& res;
             };
 
@@ -251,7 +252,7 @@ namespace crow
 
                 typename handler_type_helper<ArgsWrapped...>::type handler_;
 
-                void operator()(const request& req, response& res, const routing_params& params)
+                void operator()(request& req, response& res, const routing_params& params)
                 {
                     detail::routing_handler_call_helper::call<
                       detail::routing_handler_call_helper::call_params<
@@ -378,7 +379,7 @@ namespace crow
         void validate() override
         {}
 
-        void handle(const request&, response& res, const routing_params&) override
+        void handle(request&, response& res, const routing_params&) override
         {
             res = response(404);
             res.end();
@@ -490,7 +491,7 @@ namespace crow
             }
         }
 
-        void handle(const request& req, response& res, const routing_params& params) override
+        void handle(request& req, response& res, const routing_params& params) override
         {
             if (!custom_templates_base.empty())
                 mustache::set_base(custom_templates_base);
@@ -518,7 +519,7 @@ namespace crow
 #else
         template<typename Func, unsigned... Indices>
 #endif
-        std::function<void(const request&, response&, const routing_params&)>
+        std::function<void(request&, response&, const routing_params&)>
           wrap(Func f, black_magic::seq<Indices...>)
         {
 #ifdef CROW_MSVC_WORKAROUND
@@ -547,7 +548,7 @@ namespace crow
         }
 
     private:
-        std::function<void(const request&, response&, const routing_params&)> erased_handler_;
+        std::function<void(request&, response&, const routing_params&)> erased_handler_;
     };
 
     /// Default rule created when CROW_ROUTE is called.
@@ -570,92 +571,16 @@ namespace crow
         }
 
         template<typename Func>
-        typename std::enable_if<black_magic::CallHelper<Func, black_magic::S<Args...>>::value, void>::type
-          operator()(Func&& f)
-        {
-            static_assert(black_magic::CallHelper<Func, black_magic::S<Args...>>::value ||
-                            black_magic::CallHelper<Func, black_magic::S<crow::request, Args...>>::value,
-                          "Handler type is mismatched with URL parameters");
-            static_assert(!std::is_same<void, decltype(f(std::declval<Args>()...))>::value,
-                          "Handler function cannot have void return type; valid return types: string, int, crow::response, crow::returnable");
-
+        void operator()(Func&& f) {
             handler_ = (
 #ifdef CROW_CAN_USE_CPP14
               [f = std::move(f)]
 #else
               [f]
 #endif
-              (const request&, response& res, Args... args) {
-                  res = response(f(args...));
-                  res.end();
+              (crow::request& req, crow::response& res, Args... args) {
+                  detail::wrapped_handler_call(req, res, f, std::forward<Args>(args)...);
               });
-        }
-
-        template<typename Func>
-        typename std::enable_if<
-          !black_magic::CallHelper<Func, black_magic::S<Args...>>::value &&
-            black_magic::CallHelper<Func, black_magic::S<crow::request, Args...>>::value,
-          void>::type
-          operator()(Func&& f)
-        {
-            static_assert(black_magic::CallHelper<Func, black_magic::S<Args...>>::value ||
-                            black_magic::CallHelper<Func, black_magic::S<crow::request, Args...>>::value,
-                          "Handler type is mismatched with URL parameters");
-            static_assert(!std::is_same<void, decltype(f(std::declval<crow::request>(), std::declval<Args>()...))>::value,
-                          "Handler function cannot have void return type; valid return types: string, int, crow::response, crow::returnable");
-
-            handler_ = (
-#ifdef CROW_CAN_USE_CPP14
-              [f = std::move(f)]
-#else
-              [f]
-#endif
-              (const crow::request& req, crow::response& res, Args... args) {
-                  res = response(f(req, args...));
-                  res.end();
-              });
-        }
-
-        template<typename Func>
-        typename std::enable_if<
-          !black_magic::CallHelper<Func, black_magic::S<Args...>>::value &&
-            !black_magic::CallHelper<Func, black_magic::S<crow::request, Args...>>::value &&
-            black_magic::CallHelper<Func, black_magic::S<crow::response&, Args...>>::value,
-          void>::type
-          operator()(Func&& f)
-        {
-            static_assert(black_magic::CallHelper<Func, black_magic::S<Args...>>::value ||
-                            black_magic::CallHelper<Func, black_magic::S<crow::response&, Args...>>::value,
-                          "Handler type is mismatched with URL parameters");
-            static_assert(std::is_same<void, decltype(f(std::declval<crow::response&>(), std::declval<Args>()...))>::value,
-                          "Handler function with response argument should have void return type");
-            handler_ = (
-#ifdef CROW_CAN_USE_CPP14
-              [f = std::move(f)]
-#else
-              [f]
-#endif
-              (const crow::request&, crow::response& res, Args... args) {
-                  f(res, args...);
-              });
-        }
-
-        template<typename Func>
-        typename std::enable_if<
-          !black_magic::CallHelper<Func, black_magic::S<Args...>>::value &&
-            !black_magic::CallHelper<Func, black_magic::S<crow::request, Args...>>::value &&
-            !black_magic::CallHelper<Func, black_magic::S<crow::response&, Args...>>::value,
-          void>::type
-          operator()(Func&& f)
-        {
-            static_assert(black_magic::CallHelper<Func, black_magic::S<Args...>>::value ||
-                            black_magic::CallHelper<Func, black_magic::S<crow::request, Args...>>::value ||
-                            black_magic::CallHelper<Func, black_magic::S<crow::request, crow::response&, Args...>>::value,
-                          "Handler type is mismatched with URL parameters");
-            static_assert(std::is_same<void, decltype(f(std::declval<crow::request>(), std::declval<crow::response&>(), std::declval<Args>()...))>::value,
-                          "Handler function with response argument should have void return type");
-
-            handler_ = std::move(f);
         }
 
         template<typename Func>
@@ -665,7 +590,7 @@ namespace crow
             (*this).template operator()<Func>(std::forward(f));
         }
 
-        void handle(const request& req, response& res, const routing_params& params) override
+        void handle(request& req, response& res, const routing_params& params) override
         {
             if (!custom_templates_base.empty())
                 mustache::set_base(custom_templates_base);
@@ -673,17 +598,28 @@ namespace crow
                 mustache::set_base("templates");
 
             detail::routing_handler_call_helper::call<
-              detail::routing_handler_call_helper::call_params<
-                decltype(handler_)>,
-              0, 0, 0, 0,
-              black_magic::S<Args...>,
-              black_magic::S<>>()(
-              detail::routing_handler_call_helper::call_params<
-                decltype(handler_)>{handler_, params, req, res});
+                detail::routing_handler_call_helper::call_params<decltype(handler_)>,
+                0, 0, 0, 0,
+                black_magic::S<Args...>,
+                black_magic::S<>>()
+                (
+                    detail::routing_handler_call_helper::call_params<decltype(handler_)>
+                    {handler_, params, req, res}
+                );
+        }
+
+        /// Enable local middleware for this handler
+        template<typename App, typename... Middlewares>
+        crow::detail::handler_call_bridge<TaggedRule<Args...>, App, Middlewares...>
+          middlewares()
+        {
+            // the handler_call_bridge allows the functor to be placed directly after this function
+            // instead of wrapping it with more parentheses
+            return {this};
         }
 
     private:
-        std::function<void(const crow::request&, crow::response&, Args...)> handler_;
+        std::function<void(crow::request&, crow::response&, Args...)> handler_;
     };
 
     const int RULE_SPECIAL_REDIRECT_SLASH = 1;
@@ -1507,7 +1443,7 @@ namespace crow
             return std::string();
         }
 
-        void handle(const request& req, response& res)
+        void handle(request& req, response& res)
         {
             HTTPMethod method_actual = req.method;
             if (req.method >= HTTPMethod::InternalMethodCount)

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -258,16 +258,10 @@ namespace crow
         struct is_callable
         {
             template<typename F2, typename... Args2>
-            static std::true_type __test(decltype(std::declval<F2>()(std::declval<Args2>()...))*)
-            {
-                return {};
-            }
+            static std::true_type __test(decltype(std::declval<F2>()(std::declval<Args2>()...))*);
 
             template<typename F2, typename... Args2>
-            static std::false_type __test(...)
-            {
-                return {};
-            }
+            static std::false_type __test(...);
 
             static constexpr bool value = decltype(__test<F, Args...>(nullptr))::value;
         };

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -238,27 +238,36 @@ namespace crow
         };
 
         // Check Tuple contains type T
-        template <typename T, typename Tuple>
+        template<typename T, typename Tuple>
         struct has_type;
 
-        template <typename T>
-        struct has_type<T, std::tuple<>> : std::false_type {};
+        template<typename T>
+        struct has_type<T, std::tuple<>> : std::false_type
+        {};
 
-        template <typename T, typename U, typename... Ts>
-        struct has_type<T, std::tuple<U, Ts...>> : has_type<T, std::tuple<Ts...>> {};
+        template<typename T, typename U, typename... Ts>
+        struct has_type<T, std::tuple<U, Ts...>> : has_type<T, std::tuple<Ts...>>
+        {};
 
-        template <typename T, typename... Ts>
-        struct has_type<T, std::tuple<T, Ts...>> : std::true_type {};
+        template<typename T, typename... Ts>
+        struct has_type<T, std::tuple<T, Ts...>> : std::true_type
+        {};
 
         // Check F is callable with Args
-        template<typename F, typename...Args>
+        template<typename F, typename... Args>
         struct is_callable
         {
-            template<typename F2, typename...Args2>
-            static std::true_type __test(decltype(std::declval<F2>()(std::declval<Args2>()...)) *) { return {}; }
+            template<typename F2, typename... Args2>
+            static std::true_type __test(decltype(std::declval<F2>()(std::declval<Args2>()...))*)
+            {
+                return {};
+            }
 
-            template<typename F2, typename...Args2>
-            static std::false_type __test(...) { return {}; }
+            template<typename F2, typename... Args2>
+            static std::false_type __test(...)
+            {
+                return {};
+            }
 
             static constexpr bool value = decltype(__test<F, Args...>(nullptr))::value;
         };

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -237,6 +237,37 @@ namespace crow
             static constexpr bool value = sizeof(__test<F, Args...>(0)) == sizeof(char);
         };
 
+        // Check Tuple contains type T
+        template <typename T, typename Tuple>
+        struct has_type;
+
+        template <typename T>
+        struct has_type<T, std::tuple<>> : std::false_type {};
+
+        template <typename T, typename U, typename... Ts>
+        struct has_type<T, std::tuple<U, Ts...>> : has_type<T, std::tuple<Ts...>> {};
+
+        template <typename T, typename... Ts>
+        struct has_type<T, std::tuple<T, Ts...>> : std::true_type {};
+
+        // Check F is callable with Args
+        template<typename F, typename...Args>
+        struct is_callable
+        {
+            template<typename F2, typename...Args2>
+            static std::true_type __test(decltype(std::declval<F2>()(std::declval<Args2>()...)) *) { return {}; }
+
+            template<typename F2, typename...Args2>
+            static std::false_type __test(...) { return {}; }
+
+            static constexpr bool value = decltype(__test<F, Args...>(nullptr))::value;
+        };
+
+        // Kind of fold expressions in C++11
+        template<bool...>
+        struct bool_pack;
+        template<bool... bs>
+        using all_true = std::is_same<bool_pack<bs..., true>, bool_pack<true, bs...>>;
 
         template<int N>
         struct single_tag_to_type

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1142,12 +1142,14 @@ TEST_CASE("template_basic")
 
 TEST_CASE("template_function")
 {
-  auto t = crow::mustache::compile("attack of {{func}}");
-  crow::mustache::context ctx;
-  ctx["name"] = "killer tomatoes";
-  ctx["func"] = [&](std::string){return std::string("{{name}}, IN SPACE!");};
-  auto result = t.render(ctx);
-  CHECK("attack of killer tomatoes, IN SPACE!" == result);
+    auto t = crow::mustache::compile("attack of {{func}}");
+    crow::mustache::context ctx;
+    ctx["name"] = "killer tomatoes";
+    ctx["func"] = [&](std::string) {
+        return std::string("{{name}}, IN SPACE!");
+    };
+    auto result = t.render(ctx);
+    CHECK("attack of killer tomatoes, IN SPACE!" == result);
 }
 
 TEST_CASE("template_load")
@@ -1375,7 +1377,8 @@ TEST_CASE("middleware_context")
     app.stop();
 } // middleware_context
 
-struct LocalSecretMiddleware : crow::ILocalMiddleware {
+struct LocalSecretMiddleware : crow::ILocalMiddleware
+{
     struct context
     {};
 
@@ -1399,10 +1402,9 @@ TEST_CASE("local_middleware")
     });
 
     CROW_ROUTE(app, "/secret")
-    .middlewares<decltype(app), LocalSecretMiddleware>()
-    ([]() {
-        return "works!";
-    });
+      .middlewares<decltype(app), LocalSecretMiddleware>()([]() {
+          return "works!";
+      });
 
     app.validate();
 


### PR DESCRIPTION
Hi! I've restructured middleware invocation and added per-handler middleware as discussed in the issue.

### What it looks like

It's fully backward compatible and all  (including local) middleware as previously has to be listed in the App<>.
Local middleware extends `crow::ILocalMiddleware` and is not called by default. It has to be enabled with a `middleware()` call on the rule.
```cpp
// extend ILocalMiddleware
struct MyLocalMiddleware : crow::ILocalMiddleware
{ ... }

// Now only MyGlobalMiddleware is called for every request
crow::App<MyGlobalMiddleware, MyLocalMiddleware> app;

CROW_ROUTE(app, "/")
// Enable MyLocalMiddleware for this handler
.middleware<decltype(app), MyLocalMiddleware>()
([]() { ... });
```

### What I've changed

I'll try to briefly explain my changes and decisions here, but I'll also leave some PR comments.

This is the current call chain for all requests:

```
* request *
  | 
http_connection.handle()
  |
  | - middleware is called here
  |
app.handle()
  |
--- middleware type information is preserved until here ---
  | 
router.handle()
  |
rule.handle()
  | 
  |  - this seems to be the best place to squeeze in local middleware invocation
  |
* handler *
```

#### Getting type info up the chain

To allow wrapping the handler directly with middleware we'd have to somehow get the type information to it. This could be done in two ways: 
* templatize the router/rules to wire it all the way through the call chain
* inject it during handler registration

The first approach is somewhat more complex. It'd would seem more reasonable to move global middleware invocation from something as low-level as an http connection further up the chain to the router and restructure it.

The second one is straightforward, but has some tradeoffs:
* middleware<_decltype(app)_, ...> might look somewhat strange
* middleware<> always has to be the last one in the builder (this can be fixed but requires some refactoring)
```cpp
CROWD_ROUTE(app, "/")
.middleware<>()  // doesn't work this way
.methods(...)
```
* the structure as a whole remains somewhat messy 

I've chosen the second approach as it seems more likely to be fully implemented 😁 

#### Filtering middleware at compile time

`http_connection` was responsible for handling all middleware, including template magic. I've moved most of it to `middleware.h`, some parts to `utility.h`.

To reuse the same code for calling global and local middleware, I've generalized the `middleware_call_helper` to include a `CallCriteria`, which can be used to determine whether a specific middleware should be called.

```cpp
template<template<typename QueryMW> class CallCriteria, ...>
bool middleware_call_helper(...) 
{
    using CurrentMW = ...
    if (!CallCriteria<CurrentMW>::value) 
    {
        return;
    }
}
```
Now a handlers criteria simply checks whether the queried middleware is present in its enabled middleware. 

```cpp
template<typename F, 
  typename App,              // App::mw_container_t holds all middleware
  typename... Middlewares    // enabled middleware
>
struct handler_middleware_wrapper
{
    template<typename MW>
    struct middleware_call_criteria
    {
        static constexpr bool value = black_magic::has_type<MW, std::tuple<Middlewares...>>::value;
    };

    void operator() 
    {
        // call only enabled middleware
        middleware_call_helper<middleware_call_criteria, typename App::mw_container_t, ...>(...)
    }

```

The `http_connection` still handles global middleware and calls all middleware with `middleware_call_criteria_only_global`.

I've also refactored `middleware_call_helper` to use tuple indexing (like `after_handlers_call_helper` does) instead of recursively unpacking the parameter pack, as it is not available to the handler in its raw form.

#### Transparently wrapping handlers

Router rules already do it and hide all handlers behind a `std::function<void(const request, response, args...)>`.

Handlers with middleware are wrapped in `handler_middleware_wrapper`, which extracts the middleware context from the request, and calls all the local middlewares, which require both a **mutable** request and response. This means that we have to get a mutable request all the way through the chain, so I've removed the interfering const qualifiers.

I've moved the handler wrapping logic from `TaggedRule::operator(Func&&)` to `wrapped_handler_call` in `middleware.h`. I've also refactored it to use a more elegant `is_callable` sfinae check and allow mutable requests as parameters.

### To sum up

The call chain now looks the following:

```
* request *
  | 
http_connection.handle()
  |
  | - calls only global middleware
  | - stores middlewares in request
  |
app.handle()
  |
--- middleware type information is lost here ---
  | 
router.handle()
  |
rule.handle()
  | 
  |                  | --- middleware type information has been injected during handler wrapping ---
  |                  |
handler_middleware_wrapper ()
  |
  | - retrieves middlewares from request and cast to correct type
  | - calls only enabled middleware
  |
* handler *
```

This is how a handler is wrapped:

```
* Rule as RuleParameterTraits *
  |
middlewares<decltype(app), Mw1, Mw2, ...>()
  |
detail::handler_call_bridge
  |
  | - overloads operator() to and registers itself 
  |    to act transparent and remove redundant nesting/parentheses
  | - static_asserts that middleware is local and present in app
  |
detail::handler_middleware_wrapper
  |
  | - declares its middleware_call_criteria
  | - transparently wraps a handler
  |
* handler *
```

### Issues

Global middleware is called before local, there is no way to intertwine them. To support this all middleware invocation has to be moved directly to the handler, oh, and all handlers had to be wrapped. I can't guess whether this is a big tradeoff, because the solution to this is quite complex.

The local invocation order is defined not in the `middleware()` call, but in the App params. This can be fixed, but requires restructuring all middleware call helpers.

At the time of writing I haven't touched dynamic rules. I've never used them and it seems like they are only part of the [CROW_MSVC_WORKAROUND](https://github.com/CrowCpp/Crow/commit/02f81f7eaa9b4428b33c471a020c43b2f647b91c). 
I also don't know whether CatchAll routes should support middleware, so I've restricted it to only TaggedRules.

### Testing

I've included a small example and unit test. I've tested it with both gcc/clang on my small crow projects. 
Would be great if you'd test it out.

The changes are somewhat verbose in some parts, but therefore c++11 compliant.
