### PR TITLE
Parser optimization

### DIFF
--- a/include/crow/common.h
+++ b/include/crow/common.h
@@ -6,15 +6,6 @@
 #include <iostream>
 #include "crow/utility.h"
 
-// TODO(EDev): Adding C++20's [[likely]] and [[unlikely]] attributes might be useful
-#if defined(__GNUG__) || defined(__clang__)
-#define CROW_LIKELY(X) __builtin_expect(!!(X), 1)
-#define CROW_UNLIKELY(X) __builtin_expect(!!(X), 0)
-#else
-#define CROW_LIKELY(X) (X)
-#define CROW_UNLIKELY(X) (X)
-#endif
-
 namespace crow
 {
     const char cr = '\r';

--- a/include/crow/common.h
+++ b/include/crow/common.h
@@ -283,6 +283,7 @@ namespace crow
     }
 } // namespace crow
 
+// clang-format off
 #ifndef CROW_MSVC_WORKAROUND
 constexpr crow::HTTPMethod operator"" _method(const char* str, size_t /*len*/)
 {
@@ -330,3 +331,4 @@ constexpr crow::HTTPMethod operator"" _method(const char* str, size_t /*len*/)
                                                            throw std::runtime_error("invalid http method");
 }
 #endif
+// clang-format on

--- a/include/crow/common.h
+++ b/include/crow/common.h
@@ -6,8 +6,21 @@
 #include <iostream>
 #include "crow/utility.h"
 
+// TODO(EDev): Adding C++20's [[likely]] and [[unlikely]] attributes might be useful
+#if defined(__GNUG__) || defined(__clang__)
+#define CROW_LIKELY(X) __builtin_expect(!!(X), 1)
+#define CROW_UNLIKELY(X) __builtin_expect(!!(X), 0)
+#else
+#define CROW_LIKELY(X) (X)
+#define CROW_UNLIKELY(X) (X)
+#endif
+
 namespace crow
 {
+    const char cr = '\r';
+    const char lf = '\n';
+    const std::string crlf("\r\n");
+
     enum class HTTPMethod : char
     {
 #ifndef DELETE
@@ -16,11 +29,43 @@ namespace crow
         HEAD,
         POST,
         PUT,
+
         CONNECT,
         OPTIONS,
         TRACE,
+
         PATCH,
         PURGE,
+
+        COPY,
+        LOCK,
+        MKCOL,
+        MOVE,
+        PROPFIND,
+        PROPPATCH,
+        SEARCH,
+        UNLOCK,
+        BIND,
+        REBIND,
+        UNBIND,
+        ACL,
+
+        REPORT,
+        MKACTIVITY,
+        CHECKOUT,
+        MERGE,
+
+        MSEARCH,
+        NOTIFY,
+        SUBSCRIBE,
+        UNSUBSCRIBE,
+
+        MKCALENDAR,
+
+        LINK,
+        UNLINK,
+
+        SOURCE,
 #endif
 
         Delete = 0,
@@ -28,16 +73,103 @@ namespace crow
         Head,
         Post,
         Put,
+
         Connect,
         Options,
         Trace,
+
         Patch,
         Purge,
+
+        Copy,
+        Lock,
+        MkCol,
+        Move,
+        Propfind,
+        Proppatch,
+        Search,
+        Unlock,
+        Bind,
+        Rebind,
+        Unbind,
+        Acl,
+
+        Report,
+        MkActivity,
+        Checkout,
+        Merge,
+
+        MSearch,
+        Notify,
+        Subscribe,
+        Unsubscribe,
+
+        Mkcalendar,
+
+        Link,
+        Unlink,
+
+        Source,
 
 
         InternalMethodCount,
         // should not add an item below this line: used for array count
     };
+
+    const char* method_strings[] =
+      {
+        "DELETE",
+        "GET",
+        "HEAD",
+        "POST",
+        "PUT",
+
+        "CONNECT",
+        "OPTIONS",
+        "TRACE",
+
+        "PATCH",
+        "PURGE",
+
+        "COPY",
+        "LOCK",
+        "MKCOL",
+        "MOVE",
+        "PROPFIND",
+        "PROPPATCH",
+        "SEARCH",
+        "UNLOCK",
+        "BIND",
+        "REBIND",
+        "UNBIND",
+        "ACL",
+
+        "REPORT",
+        "MKACTIVITY",
+        "CHECKOUT",
+        "MERGE",
+
+        "M-SEARCH",
+        "NOTIFY",
+        "SUBSCRIBE",
+        "UNSUBSCRIBE",
+
+        "MKCALENDAR",
+
+        "LINK",
+        "UNLINK",
+
+        "SOURCE"};
+
+
+    inline std::string method_name(HTTPMethod method)
+    {
+        if (CROW_LIKELY(method < HTTPMethod::InternalMethodCount))
+        {
+            return method_strings[(unsigned char)method];
+        }
+        return "invalid";
+    }
 
     // clang-format off
 
@@ -84,25 +216,6 @@ namespace crow
         SERVICE_UNAVAILABLE           = 503,
         VARIANT_ALSO_NEGOTIATES       = 506
     };
-
-    inline std::string method_name(HTTPMethod method)
-    {
-        switch(method)
-        {
-            case HTTPMethod::Delete: return "DELETE";
-            case HTTPMethod::Get: return "GET";
-            case HTTPMethod::Head: return "HEAD";
-            case HTTPMethod::Post: return "POST";
-            case HTTPMethod::Put: return "PUT";
-            case HTTPMethod::Connect: return "CONNECT";
-            case HTTPMethod::Options: return "OPTIONS";
-            case HTTPMethod::Trace: return "TRACE";
-            case HTTPMethod::Patch: return "PATCH";
-            case HTTPMethod::Purge: return "PURGE";
-            default: return "invalid";
-        }
-        return "invalid";
-    }
 
     // clang-format on
 
@@ -173,16 +286,47 @@ namespace crow
 #ifndef CROW_MSVC_WORKAROUND
 constexpr crow::HTTPMethod operator"" _method(const char* str, size_t /*len*/)
 {
-    return crow::black_magic::is_equ_p(str, "GET", 3)     ? crow::HTTPMethod::Get :
-           crow::black_magic::is_equ_p(str, "DELETE", 6)  ? crow::HTTPMethod::Delete :
-           crow::black_magic::is_equ_p(str, "HEAD", 4)    ? crow::HTTPMethod::Head :
-           crow::black_magic::is_equ_p(str, "POST", 4)    ? crow::HTTPMethod::Post :
-           crow::black_magic::is_equ_p(str, "PUT", 3)     ? crow::HTTPMethod::Put :
+    return crow::black_magic::is_equ_p(str, "GET", 3)    ? crow::HTTPMethod::Get :
+           crow::black_magic::is_equ_p(str, "DELETE", 6) ? crow::HTTPMethod::Delete :
+           crow::black_magic::is_equ_p(str, "HEAD", 4)   ? crow::HTTPMethod::Head :
+           crow::black_magic::is_equ_p(str, "POST", 4)   ? crow::HTTPMethod::Post :
+           crow::black_magic::is_equ_p(str, "PUT", 3)    ? crow::HTTPMethod::Put :
+
            crow::black_magic::is_equ_p(str, "OPTIONS", 7) ? crow::HTTPMethod::Options :
            crow::black_magic::is_equ_p(str, "CONNECT", 7) ? crow::HTTPMethod::Connect :
            crow::black_magic::is_equ_p(str, "TRACE", 5)   ? crow::HTTPMethod::Trace :
-           crow::black_magic::is_equ_p(str, "PATCH", 5)   ? crow::HTTPMethod::Patch :
-           crow::black_magic::is_equ_p(str, "PURGE", 5)   ? crow::HTTPMethod::Purge :
-                                                            throw std::runtime_error("invalid http method");
+
+           crow::black_magic::is_equ_p(str, "PATCH", 5)     ? crow::HTTPMethod::Patch :
+           crow::black_magic::is_equ_p(str, "PURGE", 5)     ? crow::HTTPMethod::Purge :
+           crow::black_magic::is_equ_p(str, "COPY", 4)      ? crow::HTTPMethod::Copy :
+           crow::black_magic::is_equ_p(str, "LOCK", 4)      ? crow::HTTPMethod::Lock :
+           crow::black_magic::is_equ_p(str, "MKCOL", 5)     ? crow::HTTPMethod::MkCol :
+           crow::black_magic::is_equ_p(str, "MOVE", 4)      ? crow::HTTPMethod::Move :
+           crow::black_magic::is_equ_p(str, "PROPFIND", 8)  ? crow::HTTPMethod::Propfind :
+           crow::black_magic::is_equ_p(str, "PROPPATCH", 9) ? crow::HTTPMethod::Proppatch :
+           crow::black_magic::is_equ_p(str, "SEARCH", 6)    ? crow::HTTPMethod::Search :
+           crow::black_magic::is_equ_p(str, "UNLOCK", 6)    ? crow::HTTPMethod::Unlock :
+           crow::black_magic::is_equ_p(str, "BIND", 4)      ? crow::HTTPMethod::Bind :
+           crow::black_magic::is_equ_p(str, "REBIND", 6)    ? crow::HTTPMethod::Rebind :
+           crow::black_magic::is_equ_p(str, "UNBIND", 6)    ? crow::HTTPMethod::Unbind :
+           crow::black_magic::is_equ_p(str, "ACL", 3)       ? crow::HTTPMethod::Acl :
+
+           crow::black_magic::is_equ_p(str, "REPORT", 6)      ? crow::HTTPMethod::Report :
+           crow::black_magic::is_equ_p(str, "MKACTIVITY", 10) ? crow::HTTPMethod::MkActivity :
+           crow::black_magic::is_equ_p(str, "CHECKOUT", 8)    ? crow::HTTPMethod::Checkout :
+           crow::black_magic::is_equ_p(str, "MERGE", 5)       ? crow::HTTPMethod::Merge :
+
+           crow::black_magic::is_equ_p(str, "MSEARCH", 7)      ? crow::HTTPMethod::MSearch :
+           crow::black_magic::is_equ_p(str, "NOTIFY", 6)       ? crow::HTTPMethod::Notify :
+           crow::black_magic::is_equ_p(str, "SUBSCRIBE", 9)    ? crow::HTTPMethod::Subscribe :
+           crow::black_magic::is_equ_p(str, "UNSUBSCRIBE", 11) ? crow::HTTPMethod::Unsubscribe :
+
+           crow::black_magic::is_equ_p(str, "MKCALENDAR", 10) ? crow::HTTPMethod::Mkcalendar :
+
+           crow::black_magic::is_equ_p(str, "LINK", 4)   ? crow::HTTPMethod::Link :
+           crow::black_magic::is_equ_p(str, "UNLINK", 6) ? crow::HTTPMethod::Unlink :
+
+           crow::black_magic::is_equ_p(str, "SOURCE", 6) ? crow::HTTPMethod::Source :
+                                                           throw std::runtime_error("invalid http method");
 }
 #endif

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -302,7 +302,7 @@ namespace crow
                 }
             }
 
-            CROW_LOG_INFO << "Request: " << boost::lexical_cast<std::string>(adaptor_.remote_endpoint()) << " " << this << " HTTP/" << (char)(req.http_ver_major + 48) << "." << (char)(req.http_ver_minor + 48) << ' ' << method_name(req.method) << " " << req.url;
+            CROW_LOG_INFO << "Request: " << boost::lexical_cast<std::string>(adaptor_.remote_endpoint()) << " " << this << " HTTP/" << (char)(req.http_ver_major + '0') << "." << (char)(req.http_ver_minor + '0') << ' ' << method_name(req.method) << " " << req.url;
 
 
             need_to_call_after_handlers_ = false;
@@ -539,11 +539,9 @@ namespace crow
             is_writing = false;
             if (close_connection_)
             {
-                //boost::asio::socket_base::linger option(true, 30);
-                //adaptor_.raw_socket().set_option(option);
                 adaptor_.shutdown_readwrite();
                 adaptor_.close();
-                //CROW_LOG_DEBUG << this << " from write (sync)(1)";
+                CROW_LOG_DEBUG << this << " from write (static)";
                 check_destroy();
             }
 
@@ -598,11 +596,9 @@ namespace crow
                 is_writing = false;
                 if (close_connection_)
                 {
-                    //boost::asio::socket_base::linger option(true, 30);
-                    //adaptor_.raw_socket().set_option(option);
                     adaptor_.shutdown_readwrite();
                     adaptor_.close();
-                    //CROW_LOG_DEBUG << this << " from write (sync)(1)";
+                    CROW_LOG_DEBUG << this << " from write (res_stream)";
                     check_destroy();
                 }
 

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -277,8 +277,8 @@ namespace crow
                     {
                         if (req.get_header_value("upgrade") == "h2")
                         {
-                        // TODO(ipkn): HTTP/2
-                        // currently, ignore upgrade header
+                            // TODO(ipkn): HTTP/2
+                            // currently, ignore upgrade header
                         }
                     }
                     else if (req.get_header_value("upgrade") == "h2c")

--- a/include/crow/http_parser_merged.h
+++ b/include/crow/http_parser_merged.h
@@ -11,6 +11,7 @@
  * 350258965909f249f9c59823aac240313e0d0120 (cannot be implemented due to upgrade)
  */
 
+// clang-format off
 #pragma once
 #include "crow/common.h"
 namespace crow
@@ -2013,3 +2014,5 @@ http_parser_set_max_header_size(uint32_t size) {
 
 }
 }
+
+// clang-format on

--- a/include/crow/http_parser_merged.h
+++ b/include/crow/http_parser_merged.h
@@ -1,45 +1,21 @@
 /* merged revision: 5b951d74bd66ec9d38448e0a85b1cf8b85d97db3 */
-/* updated to     : e13b274770da9b82a1085dec29182acfea72e7a7 */
+/* updated to     : e13b274770da9b82a1085dec29182acfea72e7a7 (beyond v2.9.5) */
 /* commits not included:
  * 091ebb87783a58b249062540bbea07de2a11e9cf
  * 6132d1fefa03f769a3979355d1f5da0b8889cad2
  * 7ba312397c2a6c851a4b5efe6c1603b1e1bda6ff
  * d7675453a6c03180572f084e95eea0d02df39164
- * dff604db203986e532e5a679bafd0e7382c6bdd9 (Might be useful to actually add)
+ * dff604db203986e532e5a679bafd0e7382c6bdd9 (Might be useful to actually add [upgrade requests with a body])
  * e01811e7f4894d7f0f7f4bd8492cccec6f6b4038 (related to above)
  * 05525c5fde1fc562481f6ae08fa7056185325daf (also related to above)
  * 350258965909f249f9c59823aac240313e0d0120 (cannot be implemented due to upgrade)
  */
-/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to
- * deal in the Software without restriction, including without limitation the
- * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
- * sell copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
- * IN THE SOFTWARE.
- */
-#ifndef CROW_http_parser_h
-#define CROW_http_parser_h
-#ifdef __cplusplus
-extern "C" {
-#endif
 
-/* Also update SONAME in the Makefile whenever you change these. */
-#define CROW_HTTP_PARSER_VERSION_MAJOR 2
-#define CROW_HTTP_PARSER_VERSION_MINOR 9
-#define CROW_HTTP_PARSER_VERSION_PATCH 5
+#pragma once
+#include "crow/common.h"
+namespace crow
+{
+extern "C" {
 
 #include <stddef.h>
 #if defined(_WIN32) && !defined(__MINGW32__) && \
@@ -59,19 +35,14 @@ typedef unsigned __int64 uint64_t;
 #include <stdint.h>
 #endif
 
-/* Compile with -DHTTP_PARSER_STRICT=0 to make less checks, but run
- * faster
- */
-#ifndef CROW_HTTP_PARSER_STRICT
-# define CROW_HTTP_PARSER_STRICT 1
-#endif
+
 
 /* Maximium header size allowed. If the macro is not defined
  * before including this header then the default is used. To
  * change the maximum header size, define the macro in the build
  * environment (e.g. -DHTTP_MAX_HEADER_SIZE=<value>). To remove
  * the effective limit on the size of the header, define the macro
- * to a very large number (e.g. -DHTTP_MAX_HEADER_SIZE=0x7fffffff)
+ * to a very large number (e.g. -DCROW_HTTP_MAX_HEADER_SIZE=0x7fffffff)
  */
 #ifndef CROW_HTTP_MAX_HEADER_SIZE
 # define CROW_HTTP_MAX_HEADER_SIZE (80*1024)
@@ -79,8 +50,6 @@ typedef unsigned __int64 uint64_t;
 
 typedef struct http_parser http_parser;
 typedef struct http_parser_settings http_parser_settings;
-
-// TODO "static_cast<x>(y)" should be replaced with "(?enum? x) y" ?
 
 /* Callbacks should return non-zero to indicate an error. The parser will
  * then halt execution.
@@ -104,141 +73,15 @@ typedef int (*http_data_cb) (http_parser*, const char *at, size_t length);
 typedef int (*http_cb) (http_parser*);
 
 
-/* Status Codes */
-#define HTTP_STATUS_MAP(CROW_XX)                                                 \
-  CROW_XX(100, CONTINUE,                        Continue)                        \
-  CROW_XX(101, SWITCHING_PROTOCOLS,             Switching Protocols)             \
-  CROW_XX(102, PROCESSING,                      Processing)                      \
-  CROW_XX(200, OK,                              OK)                              \
-  CROW_XX(201, CREATED,                         Created)                         \
-  CROW_XX(202, ACCEPTED,                        Accepted)                        \
-  CROW_XX(203, NON_AUTHORITATIVE_INFORMATION,   Non-Authoritative Information)   \
-  CROW_XX(204, NO_CONTENT,                      No Content)                      \
-  CROW_XX(205, RESET_CONTENT,                   Reset Content)                   \
-  CROW_XX(206, PARTIAL_CONTENT,                 Partial Content)                 \
-  CROW_XX(207, MULTI_STATUS,                    Multi-Status)                    \
-  CROW_XX(208, ALREADY_REPORTED,                Already Reported)                \
-  CROW_XX(226, IM_USED,                         IM Used)                         \
-  CROW_XX(300, MULTIPLE_CHOICES,                Multiple Choices)                \
-  CROW_XX(301, MOVED_PERMANENTLY,               Moved Permanently)               \
-  CROW_XX(302, FOUND,                           Found)                           \
-  CROW_XX(303, SEE_OTHER,                       See Other)                       \
-  CROW_XX(304, NOT_MODIFIED,                    Not Modified)                    \
-  CROW_XX(305, USE_PROXY,                       Use Proxy)                       \
-  CROW_XX(307, TEMPORARY_REDIRECT,              Temporary Redirect)              \
-  CROW_XX(308, PERMANENT_REDIRECT,              Permanent Redirect)              \
-  CROW_XX(400, BAD_REQUEST,                     Bad Request)                     \
-  CROW_XX(401, UNAUTHORIZED,                    Unauthorized)                    \
-  CROW_XX(402, PAYMENT_REQUIRED,                Payment Required)                \
-  CROW_XX(403, FORBIDDEN,                       Forbidden)                       \
-  CROW_XX(404, NOT_FOUND,                       Not Found)                       \
-  CROW_XX(405, METHOD_NOT_ALLOWED,              Method Not Allowed)              \
-  CROW_XX(406, NOT_ACCEPTABLE,                  Not Acceptable)                  \
-  CROW_XX(407, PROXY_AUTHENTICATION_REQUIRED,   Proxy Authentication Required)   \
-  CROW_XX(408, REQUEST_TIMEOUT,                 Request Timeout)                 \
-  CROW_XX(409, CONFLICT,                        Conflict)                        \
-  CROW_XX(410, GONE,                            Gone)                            \
-  CROW_XX(411, LENGTH_REQUIRED,                 Length Required)                 \
-  CROW_XX(412, PRECONDITION_FAILED,             Precondition Failed)             \
-  CROW_XX(413, PAYLOAD_TOO_LARGE,               Payload Too Large)               \
-  CROW_XX(414, URI_TOO_LONG,                    URI Too Long)                    \
-  CROW_XX(415, UNSUPPORTED_MEDIA_TYPE,          Unsupported Media Type)          \
-  CROW_XX(416, RANGE_NOT_SATISFIABLE,           Range Not Satisfiable)           \
-  CROW_XX(417, EXPECTATION_FAILED,              Expectation Failed)              \
-  CROW_XX(421, MISDIRECTED_REQUEST,             Misdirected Request)             \
-  CROW_XX(422, UNPROCESSABLE_ENTITY,            Unprocessable Entity)            \
-  CROW_XX(423, LOCKED,                          Locked)                          \
-  CROW_XX(424, FAILED_DEPENDENCY,               Failed Dependency)               \
-  CROW_XX(426, UPGRADE_REQUIRED,                Upgrade Required)                \
-  CROW_XX(428, PRECONDITION_REQUIRED,           Precondition Required)           \
-  CROW_XX(429, TOO_MANY_REQUESTS,               Too Many Requests)               \
-  CROW_XX(431, REQUEST_HEADER_FIELDS_TOO_LARGE, Request Header Fields Too Large) \
-  CROW_XX(451, UNAVAILABLE_FOR_LEGAL_REASONS,   Unavailable For Legal Reasons)   \
-  CROW_XX(500, INTERNAL_SERVER_ERROR,           Internal Server Error)           \
-  CROW_XX(501, NOT_IMPLEMENTED,                 Not Implemented)                 \
-  CROW_XX(502, BAD_GATEWAY,                     Bad Gateway)                     \
-  CROW_XX(503, SERVICE_UNAVAILABLE,             Service Unavailable)             \
-  CROW_XX(504, GATEWAY_TIMEOUT,                 Gateway Timeout)                 \
-  CROW_XX(505, HTTP_VERSION_NOT_SUPPORTED,      HTTP Version Not Supported)      \
-  CROW_XX(506, VARIANT_ALSO_NEGOTIATES,         Variant Also Negotiates)         \
-  CROW_XX(507, INSUFFICIENT_STORAGE,            Insufficient Storage)            \
-  CROW_XX(508, LOOP_DETECTED,                   Loop Detected)                   \
-  CROW_XX(510, NOT_EXTENDED,                    Not Extended)                    \
-  CROW_XX(511, NETWORK_AUTHENTICATION_REQUIRED, Network Authentication Required) \
-
-enum http_status
-  {
-#define CROW_XX(num, name, string) HTTP_STATUS_##name = num,
-  HTTP_STATUS_MAP(CROW_XX)
-#undef CROW_XX
-  };
-
-
-/* Request Methods */
-#define CROW_HTTP_METHOD_MAP(CROW_XX)    \
-  CROW_XX(0,  DELETE,      DELETE)       \
-  CROW_XX(1,  GET,         GET)          \
-  CROW_XX(2,  HEAD,        HEAD)         \
-  CROW_XX(3,  POST,        POST)         \
-  CROW_XX(4,  PUT,         PUT)          \
-  /* pathological */                     \
-  CROW_XX(5,  CONNECT,     CONNECT)      \
-  CROW_XX(6,  OPTIONS,     OPTIONS)      \
-  CROW_XX(7,  TRACE,       TRACE)        \
-  /* RFC-5789 */                         \
-  CROW_XX(8, PATCH,       PATCH)         \
-  CROW_XX(9, PURGE,       PURGE)         \
-  /* WebDAV */                           \
-  CROW_XX(10,  COPY,        COPY)        \
-  CROW_XX(11,  LOCK,        LOCK)        \
-  CROW_XX(12, MKCOL,       MKCOL)        \
-  CROW_XX(13, MOVE,        MOVE)         \
-  CROW_XX(14, PROPFIND,    PROPFIND)     \
-  CROW_XX(15, PROPPATCH,   PROPPATCH)    \
-  CROW_XX(16, SEARCH,      SEARCH)       \
-  CROW_XX(17, UNLOCK,      UNLOCK)       \
-  CROW_XX(18, BIND,        BIND)         \
-  CROW_XX(19, REBIND,      REBIND)       \
-  CROW_XX(20, UNBIND,      UNBIND)       \
-  CROW_XX(21, ACL,         ACL)          \
-  /* subversion */                       \
-  CROW_XX(22, REPORT,      REPORT)       \
-  CROW_XX(23, MKACTIVITY,  MKACTIVITY)   \
-  CROW_XX(24, CHECKOUT,    CHECKOUT)     \
-  CROW_XX(25, MERGE,       MERGE)        \
-  /* upnp */                             \
-  CROW_XX(26, MSEARCH,     M-SEARCH)     \
-  CROW_XX(27, NOTIFY,      NOTIFY)       \
-  CROW_XX(28, SUBSCRIBE,   SUBSCRIBE)    \
-  CROW_XX(29, UNSUBSCRIBE, UNSUBSCRIBE)  \
-  /* CalDAV */                           \
-  CROW_XX(30, MKCALENDAR,  MKCALENDAR)   \
-  /* RFC-2068, section 19.6.1.2 */       \
-  CROW_XX(31, LINK,        LINK)         \
-  CROW_XX(32, UNLINK,      UNLINK)       \
-  /* icecast */                          \
-  CROW_XX(33, SOURCE,      SOURCE)       \
-
-enum http_method
-  {
-#define CROW_XX(num, name, string) HTTP_##name = num,
-  CROW_HTTP_METHOD_MAP(CROW_XX)
-#undef CROW_XX
-  };
-
-
-enum http_parser_type { HTTP_REQUEST, HTTP_RESPONSE, HTTP_BOTH };
-
-
 /* Flag values for http_parser.flags field */
-enum http_connection_flags
-  { F_CHUNKED               = 1 << 0
-  , F_CONNECTION_KEEP_ALIVE = 1 << 1
-  , F_CONNECTION_CLOSE      = 1 << 2
-  , F_TRAILING              = 1 << 3
-  , F_UPGRADE               = 1 << 4
-  , F_SKIPBODY              = 1 << 5
-  , F_CONTENTLENGTH         = 1 << 6
+enum http_connection_flags // This is basically 7 booleans placed into 1 integer. Uses 4 bytes instead of n bytes (7 currently).
+  { F_CHUNKED               = 1 << 0 // 00000000 00000000 00000000 00000001
+  , F_CONNECTION_KEEP_ALIVE = 1 << 1 // 00000000 00000000 00000000 00000010
+  , F_CONNECTION_CLOSE      = 1 << 2 // 00000000 00000000 00000000 00000100
+  , F_TRAILING              = 1 << 3 // 00000000 00000000 00000000 00001000
+  , F_UPGRADE               = 1 << 4 // 00000000 00000000 00000000 00010000
+  , F_SKIPBODY              = 1 << 5 // 00000000 00000000 00000000 00100000
+  , F_CONTENTLENGTH         = 1 << 6 // 00000000 00000000 00000000 01000000
   };
 
 
@@ -246,54 +89,48 @@ enum http_connection_flags
  *
  * The provided argument should be a macro that takes 2 arguments.
  */
-#define CROW_HTTP_ERRNO_MAP(CROW_XX)                                      \
-  /* No error */                                                          \
-  CROW_XX(OK, "success")                                                  \
-                                                                          \
-  /* Callback-related errors */                                           \
-  CROW_XX(CB_message_begin, "the on_message_begin callback failed")       \
-  CROW_XX(CB_url, "the on_url callback failed")                           \
-  CROW_XX(CB_header_field, "the on_header_field callback failed")         \
-  CROW_XX(CB_header_value, "the on_header_value callback failed")         \
-  CROW_XX(CB_headers_complete, "the on_headers_complete callback failed") \
-  CROW_XX(CB_body, "the on_body callback failed")                         \
-  CROW_XX(CB_message_complete, "the on_message_complete callback failed") \
-  CROW_XX(CB_status, "the on_status callback failed")                     \
-                                                                          \
-  /* Parsing-related errors */                                            \
-  CROW_XX(INVALID_EOF_STATE, "stream ended at an unexpected time")        \
-  CROW_XX(HEADER_OVERFLOW,                                                \
-     "too many header bytes seen; overflow detected")                     \
-  CROW_XX(CLOSED_CONNECTION,                                              \
-     "data received after completed connection: close message")           \
-  CROW_XX(INVALID_VERSION, "invalid HTTP version")                        \
-  CROW_XX(INVALID_STATUS, "invalid HTTP status code")                     \
-  CROW_XX(INVALID_METHOD, "invalid HTTP method")                          \
-  CROW_XX(INVALID_URL, "invalid URL")                                     \
-  CROW_XX(INVALID_HOST, "invalid host")                                   \
-  CROW_XX(INVALID_PORT, "invalid port")                                   \
-  CROW_XX(INVALID_PATH, "invalid path")                                   \
-  CROW_XX(INVALID_QUERY_STRING, "invalid query string")                   \
-  CROW_XX(INVALID_FRAGMENT, "invalid fragment")                           \
-  CROW_XX(LF_EXPECTED, "CROW_LF character expected")                      \
-  CROW_XX(INVALID_HEADER_TOKEN, "invalid character in header")            \
-  CROW_XX(INVALID_CONTENT_LENGTH,                                         \
-     "invalid character in content-length header")                        \
-  CROW_XX(UNEXPECTED_CONTENT_LENGTH,                                      \
-     "unexpected content-length header")                                  \
-  CROW_XX(INVALID_CHUNK_SIZE,                                             \
-     "invalid character in chunk size header")                            \
-  CROW_XX(INVALID_CONSTANT, "invalid constant string")                    \
-  CROW_XX(INVALID_INTERNAL_STATE, "encountered unexpected internal state")\
-  CROW_XX(STRICT, "strict mode assertion failed")                         \
-  CROW_XX(PAUSED, "parser is paused")                                     \
-  CROW_XX(UNKNOWN, "an unknown error occurred")                           \
-  CROW_XX(INVALID_TRANSFER_ENCODING,                                      \
-     "request has invalid transfer-encoding")                             \
+#define CROW_HTTP_ERRNO_MAP(CROW_XX)                                                    \
+  /* No error */                                                                        \
+  CROW_XX(OK, "success")                                                                \
+                                                                                        \
+  /* Callback-related errors */                                                         \
+  CROW_XX(CB_message_begin, "the on_message_begin callback failed")                     \
+  CROW_XX(CB_url, "the \"on_url\" callback failed")                                     \
+  CROW_XX(CB_header_field, "the \"on_header_field\" callback failed")                   \
+  CROW_XX(CB_header_value, "the \"on_header_value\" callback failed")                   \
+  CROW_XX(CB_headers_complete, "the \"on_headers_complete\" callback failed")           \
+  CROW_XX(CB_body, "the \"on_body\" callback failed")                                   \
+  CROW_XX(CB_message_complete, "the \"on_message_complete\" callback failed")           \
+  CROW_XX(CB_status, "the \"on_status\" callback failed")                               \
+                                                                                        \
+  /* Parsing-related errors */                                                          \
+  CROW_XX(INVALID_EOF_STATE, "stream ended at an unexpected time")                      \
+  CROW_XX(HEADER_OVERFLOW, "too many header bytes seen; overflow detected")             \
+  CROW_XX(CLOSED_CONNECTION, "data received after completed connection: close message") \
+  CROW_XX(INVALID_VERSION, "invalid HTTP version")                                      \
+  CROW_XX(INVALID_STATUS, "invalid HTTP status code")                                   \
+  CROW_XX(INVALID_METHOD, "invalid HTTP method")                                        \
+  CROW_XX(INVALID_URL, "invalid URL")                                                   \
+  CROW_XX(INVALID_HOST, "invalid host")                                                 \
+  CROW_XX(INVALID_PORT, "invalid port")                                                 \
+  CROW_XX(INVALID_PATH, "invalid path")                                                 \
+  CROW_XX(INVALID_QUERY_STRING, "invalid query string")                                 \
+  CROW_XX(INVALID_FRAGMENT, "invalid fragment")                                         \
+  CROW_XX(LF_EXPECTED, "LF character expected")                                         \
+  CROW_XX(INVALID_HEADER_TOKEN, "invalid character in header")                          \
+  CROW_XX(INVALID_CONTENT_LENGTH, "invalid character in content-length header")         \
+  CROW_XX(UNEXPECTED_CONTENT_LENGTH, "unexpected content-length header")                \
+  CROW_XX(INVALID_CHUNK_SIZE, "invalid character in chunk size header")                 \
+  CROW_XX(INVALID_CONSTANT, "invalid constant string")                                  \
+  CROW_XX(INVALID_INTERNAL_STATE, "encountered unexpected internal state")              \
+  CROW_XX(STRICT, "strict mode assertion failed")                                       \
+  /*CROW_XX(PAUSED, "parser is paused")*/ /*There's no need to pause the parser */      \
+  CROW_XX(UNKNOWN, "an unknown error occurred")                                         \
+  CROW_XX(INVALID_TRANSFER_ENCODING, "request has invalid transfer-encoding")           \
 
 
-/* Define HPE_* values for each errno value above */
-#define CROW_HTTP_ERRNO_GEN(n, s) HPE_##n,
+/* Define CHPE_* values for each errno value above */
+#define CROW_HTTP_ERRNO_GEN(n, s) CHPE_##n,
 enum http_errno {
   CROW_HTTP_ERRNO_MAP(CROW_HTTP_ERRNO_GEN)
 };
@@ -301,174 +138,56 @@ enum http_errno {
 
 
 /* Get an http_errno value from an http_parser */
-#define CROW_HTTP_PARSER_ERRNO(p)            ((enum http_errno) (p)->http_errno)
+#define CROW_HTTP_PARSER_ERRNO(p) ((enum http_errno)(p)->http_errno)
 
 
-struct http_parser {
-  /** PRIVATE **/
-  unsigned int type : 2;         /* enum http_parser_type */
-  unsigned int flags : 7;        /* F_* values from 'flags' enum; semi-public */
-  unsigned int state : 8;        /* enum state from http_parser.c */
-  unsigned int header_state : 7; /* enum header_state from http_parser.c */
-  unsigned int index : 5;        /* index into current matcher */
-  unsigned int uses_transfer_encoding : 1; /* Transfer-Encoding header is present */
-  unsigned int allow_chunked_length : 1; /* Allow headers with both
-                                          * `Content-Length` and
-                                          * `Transfer-Encoding: chunked` set */
-  unsigned int lenient_http_headers : 1;
+    struct http_parser
+    {
+        /** PRIVATE **/
+        unsigned int flags : 7;                  /* F_* values from 'flags' enum; semi-public */
+        unsigned int state : 8;                  /* enum state from http_parser.c */
+        unsigned int header_state : 7;           /* enum header_state from http_parser.c */
+        unsigned int index : 5;                  /* index into current matcher */
+        unsigned int uses_transfer_encoding : 1; /* Transfer-Encoding header is present */
+        unsigned int allow_chunked_length : 1;   /* Allow headers with both `Content-Length` and `Transfer-Encoding: chunked` set */
+        unsigned int lenient_http_headers : 1;
 
-  uint32_t nread;          /* # bytes read in various scenarios */
-  uint64_t content_length; /* # bytes in body. `(uint64_t) -1` (all bits one)
-                            * if no Content-Length header.
-                            */
+        uint32_t nread;          /* # bytes read in various scenarios */
+        uint64_t content_length; /* # bytes in body. `(uint64_t) -1` (all bits one) if no Content-Length header. */
+        unsigned long qs_point;
 
-  /** READ-ONLY **/
-  unsigned short http_major;
-  unsigned short http_minor;
-  unsigned int status_code : 16; /* responses only */
-  unsigned int method : 8;       /* requests only */
-  unsigned int http_errno : 7;
+        /** READ-ONLY **/
+        unsigned char http_major;
+        unsigned char http_minor;
+        unsigned int method : 8;       /* requests only */
+        unsigned int http_errno : 7;
 
   /* 1 = Upgrade header was present and the parser has exited because of that.
    * 0 = No upgrade header present.
    * Should be checked when http_parser_execute() returns in addition to
    * error checking.
    */
-  unsigned int upgrade : 1;
+        unsigned int upgrade : 1;
 
-  /** PUBLIC **/
-  void *data; /* A pointer to get hook to the "connection" or "socket" object */
-};
-
-
-struct http_parser_settings {
-  http_cb      on_message_begin;
-  http_data_cb on_url;
-  http_data_cb on_status;
-  http_data_cb on_header_field;
-  http_data_cb on_header_value;
-  http_cb      on_headers_complete;
-  http_data_cb on_body;
-  http_cb      on_message_complete;
-};
+        /** PUBLIC **/
+        void* data; /* A pointer to get hook to the "connection" or "socket" object */
+    };
 
 
-enum http_parser_url_fields
-  { UF_SCHEMA           = 0
-  , UF_HOST             = 1
-  , UF_PORT             = 2
-  , UF_PATH             = 3
-  , UF_QUERY            = 4
-  , UF_FRAGMENT         = 5
-  , UF_USERINFO         = 6
-  , UF_MAX              = 7
-  };
+    struct http_parser_settings
+    {
+        http_cb on_message_begin;
+        http_data_cb on_url;
+        http_data_cb on_header_field;
+        http_data_cb on_header_value;
+        http_cb on_headers_complete;
+        http_data_cb on_body;
+        http_cb on_message_complete;
+    };
 
 
-/* Result structure for http_parser_parse_url().
- *
- * Callers should index into field_data[] with UF_* values iff field_set
- * has the relevant (1 << UF_*) bit set. As a courtesy to clients (and
- * because we probably have padding left over), we convert any port to
- * a uint16_t.
- */
-struct http_parser_url {
-  uint16_t field_set;           /* Bitmask of (1 << UF_*) values */
-  uint16_t port;                /* Converted UF_PORT string */
 
-  struct {
-    uint16_t off;               /* Offset into buffer in which field starts */
-    uint16_t len;               /* Length of run in buffer */
-  } field_data[UF_MAX];
-};
-
-
-/* Returns the library version. Bits 16-23 contain the major version number,
- * bits 8-15 the minor version number and bits 0-7 the patch level.
- * Usage example:
- *
- *   unsigned long version = http_parser_version();
- *   unsigned major = (version >> 16) & 255;
- *   unsigned minor = (version >> 8) & 255;
- *   unsigned patch = version & 255;
- *   printf("http_parser v%u.%u.%u\n", major, minor, patch);
- */
-unsigned long http_parser_version(void);
-
-void http_parser_init(http_parser *parser, enum http_parser_type type);
-
-/* Initialize http_parser_settings members to 0*/
-void http_parser_settings_init(http_parser_settings *settings);
-
-/* Executes the parser. Returns number of parsed bytes. Sets
- * `parser->http_errno` on error. */
-size_t http_parser_execute(http_parser *parser,
-                           const http_parser_settings *settings,
-                           const char *data,
-                           size_t len);
-
-
-/* If http_should_keep_alive() in the on_headers_complete or
- * on_message_complete callback returns 0, then this should be
- * the last message on the connection.
- * If you are the server, respond with the "Connection: close" header.
- * If you are the client, close the connection.
- */
-int http_should_keep_alive(const http_parser *parser);
-
-/* Returns a string version of the HTTP method. */
-const char *http_method_str(enum http_method m);
-
-/* Returns a string version of the HTTP status code. */
-const char *http_status_str(enum http_status s);
-
-/* Return a string name of the given error */
-const char *http_errno_name(enum http_errno err);
-
-/* Return a string description of the given error */
-const char *http_errno_description(enum http_errno err);
-
-/* Initialize all http_parser_url members to 0 */
-void http_parser_url_init(struct http_parser_url *u);
-
-/* Parse a URL; return nonzero on failure */
-int http_parser_parse_url(const char *buf, size_t buflen,
-                          int is_connect,
-                          struct http_parser_url *u);
-
-/* Pause or un-pause the parser; a nonzero value pauses */
-void http_parser_pause(http_parser *parser, int paused);
-
-/* Checks if this is the final chunk of the body. */
-int http_body_is_final(const http_parser *parser);
-
-/* Change the maximum header size provided at compile time. */
-void http_parser_set_max_header_size(uint32_t size);
-
-/*#include "http_parser.h"*/
-/* Based on src/http/ngx_http_parse.c from NGINX copyright Igor Sysoev
- *
- * Additional changes are licensed under the same terms as NGINX and
- * copyright Joyent, Inc. and other Node contributors. All rights reserved.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to
- * deal in the Software without restriction, including without limitation the
- * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
- * sell copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
- * IN THE SOFTWARE.
- */
+// SOURCE (.c) CODE
 #include <assert.h>
 #include <stddef.h>
 #include <ctype.h>
@@ -495,36 +214,24 @@ static uint32_t max_header_size = CROW_HTTP_MAX_HEADER_SIZE;
    (1 << ((unsigned int) (i) & 7))))
 #endif
 
-#ifndef CROW_ELEM_AT
-# define CROW_ELEM_AT(a, i, v) ((unsigned int) (i) < CROW_ARRAY_SIZE(a) ? (a)[(i)] : (v))
-#endif
-
 #define CROW_SET_ERRNO(e)                                            \
 do {                                                                 \
   parser->nread = nread;                                             \
   parser->http_errno = (e);                                          \
 } while(0)
 
-#ifdef __GNUC__
-# define CROW_LIKELY(X) __builtin_expect(!!(X), 1)
-# define CROW_UNLIKELY(X) __builtin_expect(!!(X), 0)
-#else
-# define CROW_LIKELY(X) (X)
-# define CROW_UNLIKELY(X) (X)
-#endif
-
 /* Run the notify callback FOR, returning ER if it fails */
 #define CROW_CALLBACK_NOTIFY_(FOR, ER)                               \
 do {                                                                 \
-  assert(CROW_HTTP_PARSER_ERRNO(parser) == HPE_OK);                  \
+  assert(CROW_HTTP_PARSER_ERRNO(parser) == CHPE_OK);                 \
                                                                      \
   if (CROW_LIKELY(settings->on_##FOR)) {                             \
     if (CROW_UNLIKELY(0 != settings->on_##FOR(parser))) {            \
-      CROW_SET_ERRNO(HPE_CB_##FOR);                                  \
+      CROW_SET_ERRNO(CHPE_CB_##FOR);                                 \
     }                                                                \
                                                                      \
     /* We either errored above or got paused; get out */             \
-    if (CROW_UNLIKELY(CROW_HTTP_PARSER_ERRNO(parser) != HPE_OK)) {   \
+    if (CROW_UNLIKELY(CROW_HTTP_PARSER_ERRNO(parser) != CHPE_OK)) {  \
       return (ER);                                                   \
     }                                                                \
   }                                                                  \
@@ -539,17 +246,17 @@ do {                                                                 \
 /* Run data callback FOR with LEN bytes, returning ER if it fails */
 #define CROW_CALLBACK_DATA_(FOR, LEN, ER)                            \
 do {                                                                 \
-  assert(CROW_HTTP_PARSER_ERRNO(parser) == HPE_OK);                  \
+  assert(CROW_HTTP_PARSER_ERRNO(parser) == CHPE_OK);                 \
                                                                      \
   if (FOR##_mark) {                                                  \
     if (CROW_LIKELY(settings->on_##FOR)) {                           \
       if (CROW_UNLIKELY(0 !=                                         \
           settings->on_##FOR(parser, FOR##_mark, (LEN)))) {          \
-        CROW_SET_ERRNO(HPE_CB_##FOR);                                \
+        CROW_SET_ERRNO(CHPE_CB_##FOR);                               \
       }                                                              \
                                                                      \
       /* We either errored above or got paused; get out */           \
-      if (CROW_UNLIKELY(CROW_HTTP_PARSER_ERRNO(parser) != HPE_OK)) { \
+      if (CROW_UNLIKELY(CROW_HTTP_PARSER_ERRNO(parser) != CHPE_OK)) {\
         return (ER);                                                 \
       }                                                              \
     }                                                                \
@@ -588,7 +295,7 @@ do {                                                                 \
 do {                                                                 \
   nread += (uint32_t)(V);                                            \
   if (CROW_UNLIKELY(nread > max_header_size)) {                      \
-    CROW_SET_ERRNO(HPE_HEADER_OVERFLOW);                             \
+    CROW_SET_ERRNO(CHPE_HEADER_OVERFLOW);                            \
     goto error;                                                      \
   }                                                                  \
 } while (0)
@@ -606,88 +313,78 @@ do {                                                                 \
 
 
 
+    enum state
+    {
+        s_dead = 1 /* important that this is > 0 */
 
-enum state
-  { s_dead = 1 /* important that this is > 0 */
+        ,
+        s_start_req
 
-  , s_start_req_or_res
-  , s_res_or_resp_H
-  , s_start_res
-  , s_res_H
-  , s_res_HT
-  , s_res_HTT
-  , s_res_HTTP
-  , s_res_http_major
-  , s_res_http_dot
-  , s_res_http_minor
-  , s_res_http_end
-  , s_res_first_status_code
-  , s_res_status_code
-  , s_res_status_start
-  , s_res_status
-  , s_res_line_almost_done
+        ,
+        s_req_method,
+        s_req_spaces_before_url,
+        s_req_schema,
+        s_req_schema_slash,
+        s_req_schema_slash_slash,
+        s_req_server_start,
+        s_req_server,             // }
+        s_req_server_with_at,     // |
+        s_req_path,               // | The parser recognizes how to switch between these states,
+        s_req_query_string_start, // | however it doesn't process them any differently.
+        s_req_query_string,       // }
+        s_req_http_start,
+        s_req_http_H,
+        s_req_http_HT,
+        s_req_http_HTT,
+        s_req_http_HTTP,
+        s_req_http_I,
+        s_req_http_IC,
+        s_req_http_major,
+        s_req_http_dot,
+        s_req_http_minor,
+        s_req_http_end,
+        s_req_line_almost_done
 
-  , s_start_req
+        ,
+        s_header_field_start,
+        s_header_field,
+        s_header_value_discard_ws,
+        s_header_value_discard_ws_almost_done,
+        s_header_value_discard_lws,
+        s_header_value_start,
+        s_header_value,
+        s_header_value_lws
 
-  , s_req_method
-  , s_req_spaces_before_url
-  , s_req_schema
-  , s_req_schema_slash
-  , s_req_schema_slash_slash
-  , s_req_server_start
-  , s_req_server
-  , s_req_server_with_at
-  , s_req_path
-  , s_req_query_string_start
-  , s_req_query_string
-  , s_req_fragment_start
-  , s_req_fragment
-  , s_req_http_start
-  , s_req_http_H
-  , s_req_http_HT
-  , s_req_http_HTT
-  , s_req_http_HTTP
-  , s_req_http_I
-  , s_req_http_IC
-  , s_req_http_major
-  , s_req_http_dot
-  , s_req_http_minor
-  , s_req_http_end
-  , s_req_line_almost_done
+        ,
+        s_header_almost_done
 
-  , s_header_field_start
-  , s_header_field
-  , s_header_value_discard_ws
-  , s_header_value_discard_ws_almost_done
-  , s_header_value_discard_lws
-  , s_header_value_start
-  , s_header_value
-  , s_header_value_lws
+        ,
+        s_chunk_size_start,
+        s_chunk_size,
+        s_chunk_parameters,
+        s_chunk_size_almost_done
 
-  , s_header_almost_done
+        ,
+        s_headers_almost_done,
+        s_headers_done
 
-  , s_chunk_size_start
-  , s_chunk_size
-  , s_chunk_parameters
-  , s_chunk_size_almost_done
+        /* Important: 's_headers_done' must be the last 'header' state. All
+         * states beyond this must be 'body' states. It is used for overflow
+         * checking. See the CROW_PARSING_HEADER() macro.
+         */
 
-  , s_headers_almost_done
-  , s_headers_done
+        ,
+        s_chunk_data,
+        s_chunk_data_almost_done,
+        s_chunk_data_done
 
-  /* Important: 's_headers_done' must be the last 'header' state. All
-   * states beyond this must be 'body' states. It is used for overflow
-   * checking. See the CROW_PARSING_HEADER() macro.
-   */
+        ,
+        s_body_identity,
+        s_body_identity_eof
 
-  , s_chunk_data
-  , s_chunk_data_almost_done
-  , s_chunk_data_done
-
-  , s_body_identity
-  , s_body_identity_eof
-
-  , s_message_done
-  };
+        ,
+        s_message_done
+    };
 
 
 #define CROW_PARSING_HEADER(state) (state <= s_headers_done)
@@ -741,59 +438,39 @@ enum http_host_state
 };
 
 /* Macros for character classes; depends on strict-mode  */
-#define CROW_CR                  '\r'
-#define CROW_LF                  '\n'
 #define CROW_LOWER(c)            (unsigned char)(c | 0x20)
 #define CROW_IS_ALPHA(c)         (CROW_LOWER(c) >= 'a' && CROW_LOWER(c) <= 'z')
 #define CROW_IS_NUM(c)           ((c) >= '0' && (c) <= '9')
 #define CROW_IS_ALPHANUM(c)      (CROW_IS_ALPHA(c) || CROW_IS_NUM(c))
-#define CROW_IS_HEX(c)           (CROW_IS_NUM(c) || (CROW_LOWER(c) >= 'a' && CROW_LOWER(c) <= 'f'))
+//#define CROW_IS_HEX(c)           (CROW_IS_NUM(c) || (CROW_LOWER(c) >= 'a' && CROW_LOWER(c) <= 'f'))
 #define CROW_IS_MARK(c)          ((c) == '-' || (c) == '_' || (c) == '.' || \
-  (c) == '!' || (c) == '~' || (c) == '*' || (c) == '\'' || (c) == '(' || \
+  (c) == '!' || (c) == '~' || (c) == '*' || (c) == '\'' || (c) == '(' ||    \
   (c) == ')')
 #define CROW_IS_USERINFO_CHAR(c) (CROW_IS_ALPHANUM(c) || CROW_IS_MARK(c) || (c) == '%' || \
-  (c) == ';' || (c) == ':' || (c) == '&' || (c) == '=' || (c) == '+' || \
+  (c) == ';' || (c) == ':' || (c) == '&' || (c) == '=' || (c) == '+' ||                   \
   (c) == '$' || (c) == ',')
 
-#if CROW_HTTP_PARSER_STRICT
 #define CROW_TOKEN(c)            (tokens[(unsigned char)c])
 #define CROW_IS_URL_CHAR(c)      (CROW_BIT_AT(normal_url_char, (unsigned char)c))
-#define CROW_IS_HOST_CHAR(c)     (CROW_IS_ALPHANUM(c) || (c) == '.' || (c) == '-')
-#else
-#define CROW_TOKEN(c)            ((c == ' ') ? ' ' : tokens[(unsigned char)c])
-#define CROW_IS_URL_CHAR(c)                                                         \
-  (CROW_BIT_AT(normal_url_char, (unsigned char)c) || ((c) & 0x80))
-#define CROW_IS_HOST_CHAR(c)                                                        \
-  (CROW_IS_ALPHANUM(c) || (c) == '.' || (c) == '-' || (c) == '_')
-#endif
+//#define CROW_IS_HOST_CHAR(c)     (CROW_IS_ALPHANUM(c) || (c) == '.' || (c) == '-')
 
   /**
  * Verify that a char is a valid visible (printable) US-ASCII
  * character or %x80-FF
  **/
 #define CROW_IS_HEADER_CHAR(ch)                                                     \
-  (ch == CROW_CR || ch == CROW_LF || ch == 9 || ((unsigned char)ch > 31 && ch != 127))
+  (ch == cr || ch == lf || ch == 9 || ((unsigned char)ch > 31 && ch != 127))
 
-#define CROW_start_state (parser->type == HTTP_REQUEST ? s_start_req : s_start_res)
+#define CROW_start_state s_start_req
 
-
-#if CROW_HTTP_PARSER_STRICT
-# define CROW_STRICT_CHECK(cond)                                          \
+# define CROW_STRICT_CHECK(cond)                                     \
 do {                                                                 \
   if (cond) {                                                        \
-    CROW_SET_ERRNO(HPE_STRICT);                                           \
+    CROW_SET_ERRNO(CHPE_STRICT);                                     \
     goto error;                                                      \
   }                                                                  \
 } while (0)
-# define CROW_NEW_MESSAGE() (http_should_keep_alive(parser) ? CROW_start_state : s_dead)
-#else
-# define CROW_STRICT_CHECK(cond)
-# define CROW_NEW_MESSAGE() CROW_start_state
-#endif
-
-
-
-int http_message_needs_eof(const http_parser *parser);
+#define CROW_NEW_MESSAGE() (CROW_start_state)
 
 /* Our URL parser.
  *
@@ -807,20 +484,16 @@ int http_message_needs_eof(const http_parser *parser);
  * URL and non-URL states by looking for these.
  */
 inline enum state
-parse_url_char(enum state s, const char ch)
+parse_url_char(enum state s, const char ch, http_parser *parser, const char* url_mark, const char* p)
 {
-#if CROW_HTTP_PARSER_STRICT
 # define CROW_T(v) 0
-#else
-# define CROW_T(v) v
-#endif
 
 
 static const uint8_t normal_url_char[32] = {
 /*   0 nul    1 soh    2 stx    3 etx    4 eot    5 enq    6 ack    7 bel  */
         0    |   0    |   0    |   0    |   0    |   0    |   0    |   0,
 /*   8 bs     9 ht    10 nl    11 vt    12 np    13 cr    14 so    15 si   */
-        0    | CROW_T(2)   |   0    |   0    | CROW_T(16)  |   0    |   0    |   0,
+        0    |CROW_T(2)|  0    |   0    |CROW_T(16)| 0    |   0    |   0,
 /*  16 dle   17 dc1   18 dc2   19 dc3   20 dc4   21 nak   22 syn   23 etb */
         0    |   0    |   0    |   0    |   0    |   0    |   0    |   0,
 /*  24 can   25 em    26 sub   27 esc   28 fs    29 gs    30 rs    31 us  */
@@ -855,12 +528,9 @@ static const uint8_t normal_url_char[32] = {
   if (ch == ' ' || ch == '\r' || ch == '\n') {
     return s_dead;
   }
-
-#if CROW_HTTP_PARSER_STRICT
   if (ch == '\t' || ch == '\f') {
     return s_dead;
   }
-#endif
 
   switch (s) {
     case s_req_spaces_before_url:
@@ -916,6 +586,7 @@ static const uint8_t normal_url_char[32] = {
       }
 
       if (ch == '?') {
+          parser->qs_point = p - url_mark;
         return s_req_query_string_start;
       }
 
@@ -933,13 +604,10 @@ static const uint8_t normal_url_char[32] = {
       if (CROW_IS_URL_CHAR(ch)) {
         return s;
       }
-
-      switch (ch) {
-        case '?':
+      else if (ch == '?')
+      {
+          parser->qs_point = p - url_mark;
           return s_req_query_string_start;
-
-        case '#':
-          return s_req_fragment_start;
       }
 
       break;
@@ -949,42 +617,9 @@ static const uint8_t normal_url_char[32] = {
       if (CROW_IS_URL_CHAR(ch)) {
         return s_req_query_string;
       }
-
-      switch (ch) {
-        case '?':
-          /* allow extra '?' in query string */
+      else if (ch == '?')
+      {
           return s_req_query_string;
-
-        case '#':
-          return s_req_fragment_start;
-      }
-
-      break;
-
-    case s_req_fragment_start:
-      if (CROW_IS_URL_CHAR(ch)) {
-        return s_req_fragment;
-      }
-
-      switch (ch) {
-        case '?':
-          return s_req_fragment;
-
-        case '#':
-          return s;
-      }
-
-      break;
-
-    case s_req_fragment:
-      if (CROW_IS_URL_CHAR(ch)) {
-        return s;
-      }
-
-      switch (ch) {
-        case '?':
-        case '#':
-          return s;
       }
 
       break;
@@ -1002,19 +637,13 @@ inline size_t http_parser_execute (http_parser *parser,
                             const char *data,
                             size_t len)
 {
-static const char *method_strings[] =
-  {
-#define CROW_XX(num, name, string) #string,
-  CROW_HTTP_METHOD_MAP(CROW_XX)
-#undef CROW_XX
-  };
 
 /* Tokens as defined by rfc 2616. Also lowercases them.
  *        token       = 1*<any CHAR except CTLs or separators>
  *     separators     = "(" | ")" | "<" | ">" | "@"
  *                    | "," | ";" | ":" | "\" | <">
  *                    | "/" | "[" | "]" | "?" | "="
- *                    | "{" | "}" | SP | HT
+ *                    | "{" | "}" | SP  | HT
  */
 static const char tokens[256] = {
 /*   0 nul    1 soh    2 stx    3 etx    4 eot    5 enq    6 ack    7 bel  */
@@ -1070,35 +699,31 @@ static const int8_t unhex[256] =
   const char *header_field_mark = 0;
   const char *header_value_mark = 0;
   const char *url_mark = 0;
+  const char *url_start_mark = 0;
   const char *body_mark = 0;
-  const char *status_mark = 0;
   const unsigned int lenient = parser->lenient_http_headers;
   const unsigned int allow_chunked_length = parser->allow_chunked_length;
   
   uint32_t nread = parser->nread;
 
   /* We're in an error state. Don't bother doing anything. */
-  if (CROW_HTTP_PARSER_ERRNO(parser) != HPE_OK) {
+  if (CROW_HTTP_PARSER_ERRNO(parser) != CHPE_OK) {
     return 0;
   }
 
   if (len == 0) {
     switch (parser->state) {
       case s_body_identity_eof:
-        /* Use of CROW_CALLBACK_NOTIFY() here would erroneously return 1 byte read if
-         * we got paused.
-         */
+        /* Use of CROW_CALLBACK_NOTIFY() here would erroneously return 1 byte read if we got paused. */
         CROW_CALLBACK_NOTIFY_NOADVANCE(message_complete);
         return 0;
 
       case s_dead:
-      case s_start_req_or_res:
-      case s_start_res:
       case s_start_req:
         return 0;
 
       default:
-        CROW_SET_ERRNO(HPE_INVALID_EOF_STATE);
+        CROW_SET_ERRNO(CHPE_INVALID_EOF_STATE);
         return 1;
     }
   }
@@ -1118,12 +743,7 @@ static const int8_t unhex[256] =
   case s_req_server_with_at:
   case s_req_query_string_start:
   case s_req_query_string:
-  case s_req_fragment_start:
-  case s_req_fragment:
     url_mark = data;
-    break;
-  case s_res_status:
-    status_mark = data;
     break;
   default:
     break;
@@ -1142,243 +762,45 @@ reexecute:
         /* this state is used after a 'Connection: close' message
          * the parser will error out if it reads another message
          */
-        if (CROW_LIKELY(ch == CROW_CR || ch == CROW_LF))
+        if (CROW_LIKELY(ch == cr || ch == lf))
           break;
 
-        CROW_SET_ERRNO(HPE_CLOSED_CONNECTION);
+        CROW_SET_ERRNO(CHPE_CLOSED_CONNECTION);
         goto error;
-
-      case s_start_req_or_res:
-      {
-        if (ch == CROW_CR || ch == CROW_LF)
-          break;
-        parser->flags = 0;
-        parser->uses_transfer_encoding = 0;
-        parser->content_length = CROW_ULLONG_MAX;
-
-        if (ch == 'H') {
-          parser->state = s_res_or_resp_H;
-
-          CROW_CALLBACK_NOTIFY(message_begin);
-        } else {
-          parser->type = HTTP_REQUEST;
-          parser->state = s_start_req;
-          CROW_REEXECUTE();
-        }
-
-        break;
-      }
-
-      case s_res_or_resp_H:
-        if (ch == 'T') {
-          parser->type = HTTP_RESPONSE;
-          parser->state = s_res_HT;
-        } else {
-          if (CROW_UNLIKELY(ch != 'E')) {
-            CROW_SET_ERRNO(HPE_INVALID_CONSTANT);
-            goto error;
-          }
-
-          parser->type = HTTP_REQUEST;
-          parser->method = HTTP_HEAD;
-          parser->index = 2;
-          parser->state = s_req_method;
-        }
-        break;
-
-      case s_start_res:
-      {
-        if (ch == CROW_CR || ch == CROW_LF)
-          break;
-        parser->flags = 0;
-        parser->uses_transfer_encoding = 0;
-        parser->content_length = CROW_ULLONG_MAX;
-        
-        if (ch == 'H') {
-          parser->state = s_res_H;
-        } else {
-          CROW_SET_ERRNO(HPE_INVALID_CONSTANT);
-          goto error;
-        }
-        
-        CROW_CALLBACK_NOTIFY(message_begin);
-        break;
-      }
-
-      case s_res_H:
-        CROW_STRICT_CHECK(ch != 'T');
-        parser->state = s_res_HT;
-        break;
-
-      case s_res_HT:
-        CROW_STRICT_CHECK(ch != 'T');
-        parser->state = s_res_HTT;
-        break;
-
-      case s_res_HTT:
-        CROW_STRICT_CHECK(ch != 'P');
-        parser->state = s_res_HTTP;
-        break;
-
-      case s_res_HTTP:
-        CROW_STRICT_CHECK(ch != '/');
-        parser->state = s_res_http_major;
-        break;
-
-      case s_res_http_major:
-        if (CROW_UNLIKELY(!CROW_IS_NUM(ch))) {
-          CROW_SET_ERRNO(HPE_INVALID_VERSION);
-          goto error;
-        }
-
-        parser->http_major = ch - '0';
-        parser->state = s_res_http_dot;
-        break;
-
-      case s_res_http_dot:
-      {
-        if (CROW_UNLIKELY(ch != '.')) {
-          CROW_SET_ERRNO(HPE_INVALID_VERSION);
-          goto error;
-        }
-
-        parser->state = s_res_http_minor;
-        break;
-      }
-
-      /* minor HTTP version */
-      case s_res_http_minor:
-        if (CROW_UNLIKELY(!CROW_IS_NUM(ch))) {
-          CROW_SET_ERRNO(HPE_INVALID_VERSION);
-          goto error;
-        }
-
-        parser->http_minor = ch - '0';
-        parser->state = s_res_http_end;
-        break;
-
-      /* end of request line */
-      case s_res_http_end:
-      {
-        if (CROW_UNLIKELY(ch != ' ')) {
-          CROW_SET_ERRNO(HPE_INVALID_VERSION);
-          goto error;
-        }
-
-        parser->state = s_res_first_status_code;
-        break;
-      }
-
-      case s_res_first_status_code:
-      {
-        if (!CROW_IS_NUM(ch)) {
-          if (ch == ' ') {
-            break;
-          }
-
-          CROW_SET_ERRNO(HPE_INVALID_STATUS);
-          goto error;
-        }
-        parser->status_code = ch - '0';
-        parser->state = s_res_status_code;
-        break;
-      }
-
-      case s_res_status_code:
-      {
-        if (!CROW_IS_NUM(ch)) {
-          switch (ch) {
-            case ' ':
-              parser->state = s_res_status_start;
-              break;
-            case CROW_CR:
-            case CROW_LF:
-              parser->state = s_res_status_start;
-              CROW_REEXECUTE();
-              break;
-            default:
-              CROW_SET_ERRNO(HPE_INVALID_STATUS);
-              goto error;
-          }
-          break;
-        }
-
-        parser->status_code *= 10;
-        parser->status_code += ch - '0';
-
-        if (CROW_UNLIKELY(parser->status_code > 999)) {
-          CROW_SET_ERRNO(HPE_INVALID_STATUS);
-          goto error;
-        }
-
-        break;
-      }
-
-      case s_res_status_start:
-      {
-        CROW_MARK(status);
-        parser->state = s_res_status;
-        parser->index = 0;
-
-        if (ch == CROW_CR || ch == CROW_CR)
-          CROW_REEXECUTE();
-
-        break;
-      }
-
-      case s_res_status:
-        if (ch == CROW_CR) {
-          parser->state = s_res_line_almost_done;
-          CROW_CALLBACK_DATA(status);
-          break;
-        }
-
-        if (ch == CROW_LF) {
-          parser->state = s_header_field_start;
-          CROW_CALLBACK_DATA(status);
-          break;
-        }
-
-        break;
-
-      case s_res_line_almost_done:
-        CROW_STRICT_CHECK(ch != CROW_LF);
-        parser->state = s_header_field_start;
-        break;
 
       case s_start_req:
       {
-        if (ch == CROW_CR || ch == CROW_LF)
+        if (ch == cr || ch == lf)
           break;
         parser->flags = 0;
         parser->uses_transfer_encoding = 0;
         parser->content_length = CROW_ULLONG_MAX;
 
         if (CROW_UNLIKELY(!CROW_IS_ALPHA(ch))) {
-          CROW_SET_ERRNO(HPE_INVALID_METHOD);
+          CROW_SET_ERRNO(CHPE_INVALID_METHOD);
           goto error;
         }
 
-        parser->method = static_cast<http_method>(0);
+        parser->method = 0;
         parser->index = 1;
         switch (ch) {
-          case 'A': parser->method = HTTP_ACL; break;
-          case 'B': parser->method = HTTP_BIND; break;
-          case 'C': parser->method = HTTP_CONNECT; /* or COPY, CHECKOUT */ break;
-          case 'D': parser->method = HTTP_DELETE; break;
-          case 'G': parser->method = HTTP_GET; break;
-          case 'H': parser->method = HTTP_HEAD; break;
-          case 'L': parser->method = HTTP_LOCK; /* or LINK */ break;
-          case 'M': parser->method = HTTP_MKCOL; /* or MOVE, MKACTIVITY, MERGE, M-SEARCH, MKCALENDAR */ break;
-          case 'N': parser->method = HTTP_NOTIFY; break;
-          case 'O': parser->method = HTTP_OPTIONS; break;
-          case 'P': parser->method = HTTP_POST; /* or PROPFIND|PROPPATCH|PUT|PATCH|PURGE */ break;
-          case 'R': parser->method = HTTP_REPORT; /* or REBIND */ break;
-          case 'S': parser->method = HTTP_SUBSCRIBE; /* or SEARCH, SOURCE */ break;
-          case 'T': parser->method = HTTP_TRACE; break;
-          case 'U': parser->method = HTTP_UNLOCK; /* or UNSUBSCRIBE, UNBIND, UNLINK */ break;
+          case 'A': parser->method = (unsigned)HTTPMethod::ACL;                                                              break;
+          case 'B': parser->method = (unsigned)HTTPMethod::BIND;                                                             break;
+          case 'C': parser->method = (unsigned)HTTPMethod::CONNECT;   /* or COPY, CHECKOUT */                                break;
+          case 'D': parser->method = (unsigned)HTTPMethod::DELETE;                                                           break;
+          case 'G': parser->method = (unsigned)HTTPMethod::GET;                                                              break;
+          case 'H': parser->method = (unsigned)HTTPMethod::HEAD;                                                             break;
+          case 'L': parser->method = (unsigned)HTTPMethod::LOCK;      /* or LINK */                                          break;
+          case 'M': parser->method = (unsigned)HTTPMethod::MKCOL;     /* or MOVE, MKACTIVITY, MERGE, M-SEARCH, MKCALENDAR */ break;
+          case 'N': parser->method = (unsigned)HTTPMethod::NOTIFY;                                                           break;
+          case 'O': parser->method = (unsigned)HTTPMethod::OPTIONS;                                                          break;
+          case 'P': parser->method = (unsigned)HTTPMethod::POST;      /* or PROPFIND|PROPPATCH|PUT|PATCH|PURGE */            break;
+          case 'R': parser->method = (unsigned)HTTPMethod::REPORT;    /* or REBIND */                                        break;
+          case 'S': parser->method = (unsigned)HTTPMethod::SUBSCRIBE; /* or SEARCH, SOURCE */                                break;
+          case 'T': parser->method = (unsigned)HTTPMethod::TRACE;                                                            break;
+          case 'U': parser->method = (unsigned)HTTPMethod::UNLOCK;    /* or UNSUBSCRIBE, UNBIND, UNLINK */                   break;
           default:
-            CROW_SET_ERRNO(HPE_INVALID_METHOD);
+            CROW_SET_ERRNO(CHPE_INVALID_METHOD);
             goto error;
         }
         parser->state = s_req_method;
@@ -1392,7 +814,7 @@ reexecute:
       {
         const char *matcher;
         if (CROW_UNLIKELY(ch == '\0')) {
-          CROW_SET_ERRNO(HPE_INVALID_METHOD);
+          CROW_SET_ERRNO(CHPE_INVALID_METHOD);
           goto error;
         }
 
@@ -1405,8 +827,8 @@ reexecute:
 
           switch (parser->method << 16 | parser->index << 8 | ch) {
 #define CROW_XX(meth, pos, ch, new_meth) \
-            case (HTTP_##meth << 16 | pos << 8 | ch): \
-              parser->method = HTTP_##new_meth; break;
+            case ((unsigned)HTTPMethod::meth << 16 | pos << 8 | ch): \
+              parser->method = (unsigned)HTTPMethod::new_meth; break;
 
             CROW_XX(POST,      1, 'U', PUT)
             CROW_XX(POST,      1, 'A', PATCH)
@@ -1429,11 +851,11 @@ reexecute:
             CROW_XX(UNLOCK,    3, 'I', UNLINK)
 #undef CROW_XX
             default:
-              CROW_SET_ERRNO(HPE_INVALID_METHOD);
+              CROW_SET_ERRNO(CHPE_INVALID_METHOD);
               goto error;
           }
         } else {
-          CROW_SET_ERRNO(HPE_INVALID_METHOD);
+          CROW_SET_ERRNO(CHPE_INVALID_METHOD);
           goto error;
         }
 
@@ -1446,13 +868,14 @@ reexecute:
         if (ch == ' ') break;
 
         CROW_MARK(url);
-        if (parser->method == HTTP_CONNECT) {
+        CROW_MARK(url_start);
+        if (parser->method == (unsigned)HTTPMethod::CONNECT) {
           parser->state = s_req_server_start;
         }
 
-        parser->state = parse_url_char(static_cast<state>(parser->state), ch);
+        parser->state = parse_url_char(static_cast<state>(parser->state), ch, parser, url_start_mark, p);
         if (CROW_UNLIKELY(parser->state == s_dead)) {
-          CROW_SET_ERRNO(HPE_INVALID_URL);
+          CROW_SET_ERRNO(CHPE_INVALID_URL);
           goto error;
         }
 
@@ -1467,14 +890,14 @@ reexecute:
         switch (ch) {
           /* No whitespace allowed here */
           case ' ':
-          case CROW_CR:
-          case CROW_LF:
-            CROW_SET_ERRNO(HPE_INVALID_URL);
+          case cr:
+          case lf:
+            CROW_SET_ERRNO(CHPE_INVALID_URL);
             goto error;
           default:
-            parser->state = parse_url_char(static_cast<state>(parser->state), ch);
+            parser->state = parse_url_char(static_cast<state>(parser->state), ch, parser, url_start_mark, p);
             if (CROW_UNLIKELY(parser->state == s_dead)) {
-              CROW_SET_ERRNO(HPE_INVALID_URL);
+              CROW_SET_ERRNO(CHPE_INVALID_URL);
               goto error;
             }
         }
@@ -1487,33 +910,31 @@ reexecute:
       case s_req_path:
       case s_req_query_string_start:
       case s_req_query_string:
-      case s_req_fragment_start:
-      case s_req_fragment:
       {
         switch (ch) {
           case ' ':
             parser->state = s_req_http_start;
             CROW_CALLBACK_DATA(url);
             break;
-          case CROW_CR:
-          case CROW_LF:
-            if (parser->method != HTTP_GET)
+          case cr: // No space after URL means no HTTP version. Which means the request is using HTTP/0.9
+          case lf:
+            if (CROW_UNLIKELY(parser->method != (unsigned)HTTPMethod::GET)) // HTTP/0.9 doesn't define any method other than GET
             {
-                parser->state = s_dead;
-                CROW_SET_ERRNO(HPE_INVALID_VERSION);
-                goto error;
+              parser->state = s_dead;
+              CROW_SET_ERRNO(CHPE_INVALID_VERSION);
+              goto error;
             }
             parser->http_major = 0;
             parser->http_minor = 9;
-            parser->state = (ch == CROW_CR) ?
+            parser->state = (ch == cr) ?
               s_req_line_almost_done :
               s_header_field_start;
             CROW_CALLBACK_DATA(url);
             break;
           default:
-            parser->state = parse_url_char(static_cast<state>(parser->state), ch);
+            parser->state = parse_url_char(static_cast<state>(parser->state), ch, parser, url_start_mark, p);
             if (CROW_UNLIKELY(parser->state == s_dead)) {
-              CROW_SET_ERRNO(HPE_INVALID_URL);
+              CROW_SET_ERRNO(CHPE_INVALID_URL);
               goto error;
             }
         }
@@ -1528,13 +949,13 @@ reexecute:
             parser->state = s_req_http_H;
             break;
           case 'I':
-            if (parser->method == HTTP_SOURCE) {
+            if (parser->method == (unsigned)HTTPMethod::SOURCE) {
               parser->state = s_req_http_I;
               break;
             }
             /* fall through */
           default:
-            CROW_SET_ERRNO(HPE_INVALID_CONSTANT);
+            CROW_SET_ERRNO(CHPE_INVALID_CONSTANT);
             goto error;
         }
         break;
@@ -1572,7 +993,7 @@ reexecute:
       /* dot */
       case s_req_http_major:
         if (CROW_UNLIKELY(!CROW_IS_NUM(ch))) {
-          CROW_SET_ERRNO(HPE_INVALID_VERSION);
+          CROW_SET_ERRNO(CHPE_INVALID_VERSION);
           goto error;
         }
 
@@ -1583,7 +1004,7 @@ reexecute:
       case s_req_http_dot:
       {
         if (CROW_UNLIKELY(ch != '.')) {
-          CROW_SET_ERRNO(HPE_INVALID_VERSION);
+          CROW_SET_ERRNO(CHPE_INVALID_VERSION);
           goto error;
         }
 
@@ -1594,7 +1015,7 @@ reexecute:
       /* minor HTTP version */
       case s_req_http_minor:
         if (CROW_UNLIKELY(!CROW_IS_NUM(ch))) {
-          CROW_SET_ERRNO(HPE_INVALID_VERSION);
+          CROW_SET_ERRNO(CHPE_INVALID_VERSION);
           goto error;
         }
 
@@ -1605,17 +1026,17 @@ reexecute:
       /* end of request line */
       case s_req_http_end:
       {
-        if (ch == CROW_CR) {
+        if (ch == cr) {
           parser->state = s_req_line_almost_done;
           break;
         }
 
-        if (ch == CROW_LF) {
+        if (ch == lf) {
           parser->state = s_header_field_start;
           break;
         }
 
-        CROW_SET_ERRNO(HPE_INVALID_VERSION);
+        CROW_SET_ERRNO(CHPE_INVALID_VERSION);
         goto error;
         break;
       }
@@ -1623,8 +1044,8 @@ reexecute:
       /* end of request line */
       case s_req_line_almost_done:
       {
-        if (CROW_UNLIKELY(ch != CROW_LF)) {
-          CROW_SET_ERRNO(HPE_LF_EXPECTED);
+        if (CROW_UNLIKELY(ch != lf)) {
+          CROW_SET_ERRNO(CHPE_LF_EXPECTED);
           goto error;
         }
 
@@ -1634,12 +1055,12 @@ reexecute:
 
       case s_header_field_start:
       {
-        if (ch == CROW_CR) {
+        if (ch == cr) {
           parser->state = s_headers_almost_done;
           break;
         }
 
-        if (ch == CROW_LF) {
+        if (ch == lf) {
           /* they might be just sending \n instead of \r\n so this would be
            * the second \n to denote the end of headers*/
           parser->state = s_headers_almost_done;
@@ -1649,7 +1070,7 @@ reexecute:
         c = CROW_TOKEN(ch);
 
         if (CROW_UNLIKELY(!c)) {
-          CROW_SET_ERRNO(HPE_INVALID_HEADER_TOKEN);
+          CROW_SET_ERRNO(CHPE_INVALID_HEADER_TOKEN);
           goto error;
         }
 
@@ -1731,8 +1152,7 @@ reexecute:
 
             case h_matching_connection:
               parser->index++;
-              if (parser->index > sizeof(CROW_CONNECTION)-1
-                  || c != CROW_CONNECTION[parser->index]) {
+              if (parser->index > sizeof(CROW_CONNECTION)-1 || c != CROW_CONNECTION[parser->index]) {
                 parser->header_state = h_general;
               } else if (parser->index == sizeof(CROW_CONNECTION)-2) {
                 parser->header_state = h_connection;
@@ -1743,8 +1163,7 @@ reexecute:
 
             case h_matching_proxy_connection:
               parser->index++;
-              if (parser->index > sizeof(CROW_PROXY_CONNECTION)-1
-                  || c != CROW_PROXY_CONNECTION[parser->index]) {
+              if (parser->index > sizeof(CROW_PROXY_CONNECTION)-1 || c != CROW_PROXY_CONNECTION[parser->index]) {
                 parser->header_state = h_general;
               } else if (parser->index == sizeof(CROW_PROXY_CONNECTION)-2) {
                 parser->header_state = h_connection;
@@ -1755,8 +1174,7 @@ reexecute:
 
             case h_matching_content_length:
               parser->index++;
-              if (parser->index > sizeof(CROW_CONTENT_LENGTH)-1
-                  || c != CROW_CONTENT_LENGTH[parser->index]) {
+              if (parser->index > sizeof(CROW_CONTENT_LENGTH)-1 || c != CROW_CONTENT_LENGTH[parser->index]) {
                 parser->header_state = h_general;
               } else if (parser->index == sizeof(CROW_CONTENT_LENGTH)-2) {
                 parser->header_state = h_content_length;
@@ -1767,8 +1185,7 @@ reexecute:
 
             case h_matching_transfer_encoding:
               parser->index++;
-              if (parser->index > sizeof(CROW_TRANSFER_ENCODING)-1
-                  || c != CROW_TRANSFER_ENCODING[parser->index]) {
+              if (parser->index > sizeof(CROW_TRANSFER_ENCODING)-1 || c != CROW_TRANSFER_ENCODING[parser->index]) {
                 parser->header_state = h_general;
               } else if (parser->index == sizeof(CROW_TRANSFER_ENCODING)-2) {
                 parser->header_state = h_transfer_encoding;
@@ -1780,8 +1197,7 @@ reexecute:
 
             case h_matching_upgrade:
               parser->index++;
-              if (parser->index > sizeof(CROW_UPGRADE)-1
-                  || c != CROW_UPGRADE[parser->index]) {
+              if (parser->index > sizeof(CROW_UPGRADE)-1 || c != CROW_UPGRADE[parser->index]) {
                 parser->header_state = h_general;
               } else if (parser->index == sizeof(CROW_UPGRADE)-2) {
                 parser->header_state = h_upgrade;
@@ -1815,31 +1231,31 @@ reexecute:
           break;
         }
 /* RFC-7230 Sec 3.2.4 expressly forbids line-folding in header field-names.
-        if (ch == CROW_CR) {
+        if (ch == cr) {
           parser->state = s_header_almost_done;
           CROW_CALLBACK_DATA(header_field);
           break;
         }
 
-        if (ch == CROW_LF) {
+        if (ch == lf) {
           parser->state = s_header_field_start;
           CROW_CALLBACK_DATA(header_field);
           break;
         }
 */
-        CROW_SET_ERRNO(HPE_INVALID_HEADER_TOKEN);
+        CROW_SET_ERRNO(CHPE_INVALID_HEADER_TOKEN);
         goto error;
       }
 
       case s_header_value_discard_ws:
         if (ch == ' ' || ch == '\t') break;
 
-        if (ch == CROW_CR) {
+        if (ch == cr) {
           parser->state = s_header_value_discard_ws_almost_done;
           break;
         }
 
-        if (ch == CROW_LF) {
+        if (ch == lf) {
           parser->state = s_header_value_discard_lws;
           break;
         }
@@ -1876,12 +1292,12 @@ reexecute:
 
           case h_content_length:
             if (CROW_UNLIKELY(!CROW_IS_NUM(ch))) {
-              CROW_SET_ERRNO(HPE_INVALID_CONTENT_LENGTH);
+              CROW_SET_ERRNO(CHPE_INVALID_CONTENT_LENGTH);
               goto error;
             }
             
             if (parser->flags & F_CONTENTLENGTH) {
-              CROW_SET_ERRNO(HPE_UNEXPECTED_CONTENT_LENGTH);
+              CROW_SET_ERRNO(CHPE_UNEXPECTED_CONTENT_LENGTH);
               goto error;
             }
             parser->flags |= F_CONTENTLENGTH;
@@ -1922,14 +1338,14 @@ reexecute:
         for (; p != data + len; p++) {
           ch = *p;
 
-          if (ch == CROW_CR) {
+          if (ch == cr) {
             parser->state = s_header_almost_done;
             parser->header_state = h_state;
             CROW_CALLBACK_DATA(header_value);
             break;
           }
 
-          if (ch == CROW_LF) {
+          if (ch == lf) {
             parser->state = s_header_almost_done;
             CROW_COUNT_HEADER_SIZE(p - start);
             parser->header_state = h_state;
@@ -1938,7 +1354,7 @@ reexecute:
           }
           
           if (!lenient && !CROW_IS_HEADER_CHAR(ch)) {
-            CROW_SET_ERRNO(HPE_INVALID_HEADER_TOKEN);
+            CROW_SET_ERRNO(CHPE_INVALID_HEADER_TOKEN);
             goto error;
           }
           
@@ -1952,12 +1368,12 @@ reexecute:
 
                 for (; p != pe; p++) {
                   ch = *p;
-                  if (ch == CROW_CR || ch == CROW_LF) {
+                  if (ch == cr || ch == lf) {
                     --p;
                     break;
                   }
                   if (!lenient && !CROW_IS_HEADER_CHAR(ch)) {
-                    CROW_SET_ERRNO(HPE_INVALID_HEADER_TOKEN);
+                    CROW_SET_ERRNO(CHPE_INVALID_HEADER_TOKEN);
                     goto error;
                   }
                 }
@@ -1986,7 +1402,7 @@ reexecute:
               }
 
               if (CROW_UNLIKELY(!CROW_IS_NUM(ch))) {
-                CROW_SET_ERRNO(HPE_INVALID_CONTENT_LENGTH);
+                CROW_SET_ERRNO(CHPE_INVALID_CONTENT_LENGTH);
                 parser->header_state = h_state;
                 goto error;
               }
@@ -1997,7 +1413,7 @@ reexecute:
 
               /* Overflow? Test against a conservative limit for simplicity. */
               if (CROW_UNLIKELY((CROW_ULLONG_MAX - 10) / 10 < parser->content_length)) {
-                CROW_SET_ERRNO(HPE_INVALID_CONTENT_LENGTH);
+                CROW_SET_ERRNO(CHPE_INVALID_CONTENT_LENGTH);
                 parser->header_state = h_state;
                 goto error;
               }
@@ -2008,7 +1424,7 @@ reexecute:
             
             case h_content_length_ws:
               if (ch == ' ') break;
-              CROW_SET_ERRNO(HPE_INVALID_CONTENT_LENGTH);
+              CROW_SET_ERRNO(CHPE_INVALID_CONTENT_LENGTH);
               parser->header_state = h_state;
               goto error;
 
@@ -2033,8 +1449,7 @@ reexecute:
 
             case h_matching_transfer_encoding_chunked:
               parser->index++;
-              if (parser->index > sizeof(CROW_CHUNKED)-1
-                  || c != CROW_CHUNKED[parser->index]) {
+              if (parser->index > sizeof(CROW_CHUNKED)-1 || c != CROW_CHUNKED[parser->index]) {
                 h_state = h_matching_transfer_encoding_token;
               } else if (parser->index == sizeof(CROW_CHUNKED)-2) {
                 h_state = h_transfer_encoding_chunked;
@@ -2051,8 +1466,7 @@ reexecute:
             /* looking for 'Connection: keep-alive' */
             case h_matching_connection_keep_alive:
               parser->index++;
-              if (parser->index > sizeof(CROW_KEEP_ALIVE)-1
-                  || c != CROW_KEEP_ALIVE[parser->index]) {
+              if (parser->index > sizeof(CROW_KEEP_ALIVE)-1 || c != CROW_KEEP_ALIVE[parser->index]) {
                 h_state = h_general;
               } else if (parser->index == sizeof(CROW_KEEP_ALIVE)-2) {
                 h_state = h_connection_keep_alive;
@@ -2096,8 +1510,8 @@ reexecute:
 
       case s_header_almost_done:
       {
-        if (CROW_UNLIKELY(ch != CROW_LF)) {
-          CROW_SET_ERRNO(HPE_LF_EXPECTED);
+        if (CROW_UNLIKELY(ch != lf)) {
+          CROW_SET_ERRNO(CHPE_LF_EXPECTED);
           goto error;
         }
 
@@ -2137,7 +1551,7 @@ reexecute:
 
       case s_header_value_discard_ws_almost_done:
       {
-        CROW_STRICT_CHECK(ch != CROW_LF);
+        CROW_STRICT_CHECK(ch != lf);
         parser->state = s_header_value_discard_lws;
         break;
       }
@@ -2158,7 +1572,7 @@ reexecute:
 
       case s_headers_almost_done:
       {
-        CROW_STRICT_CHECK(ch != CROW_LF);
+        CROW_STRICT_CHECK(ch != lf);
 
         if (parser->flags & F_TRAILING) {
           /* End of a chunked request */
@@ -2176,11 +1590,11 @@ reexecute:
            */
           if (parser->flags & F_CHUNKED) {
             if (!allow_chunked_length) {
-              CROW_SET_ERRNO(HPE_UNEXPECTED_CONTENT_LENGTH);
+              CROW_SET_ERRNO(CHPE_UNEXPECTED_CONTENT_LENGTH);
               goto error;
             }
           } else if (!lenient) {
-            CROW_SET_ERRNO(HPE_UNEXPECTED_CONTENT_LENGTH);
+            CROW_SET_ERRNO(CHPE_UNEXPECTED_CONTENT_LENGTH);
             goto error;
           }
         }
@@ -2189,7 +1603,7 @@ reexecute:
 
         /* Set this here so that on_headers_complete() callbacks can see it */
         parser->upgrade =
-          (parser->flags & F_UPGRADE || parser->method == HTTP_CONNECT);
+          (parser->flags & F_UPGRADE || parser->method == (unsigned)HTTPMethod::CONNECT);
 
         /* Here we call the headers_complete callback. This is somewhat
          * different than other callbacks because if the user returns 1, we
@@ -2215,13 +1629,13 @@ reexecute:
               break;
 
             default:
-              CROW_SET_ERRNO(HPE_CB_headers_complete);
+              CROW_SET_ERRNO(CHPE_CB_headers_complete);
               parser->nread = nread;
               return p - data; /* Error */
           }
         }
 
-        if (CROW_HTTP_PARSER_ERRNO(parser) != HPE_OK) {
+        if (CROW_HTTP_PARSER_ERRNO(parser) != CHPE_OK) {
           parser->nread = nread;
           return p - data;
         }
@@ -2231,7 +1645,7 @@ reexecute:
 
       case s_headers_done:
       {
-        CROW_STRICT_CHECK(ch != CROW_LF);
+        CROW_STRICT_CHECK(ch != lf);
 
         parser->nread = 0;
         nread = 0;
@@ -2251,47 +1665,54 @@ reexecute:
           /* chunked encoding - ignore Content-Length header,
            * prepare for a chunk */
             parser->state = s_chunk_size_start;
-        } else if (parser->uses_transfer_encoding == 1) {
-          if (parser->type == HTTP_REQUEST && !lenient) {
-            /* RFC 7230 3.3.3 */
+        }
+        else if (parser->uses_transfer_encoding == 1)
+        {
+            if (!lenient)
+            {
+                /* RFC 7230 3.3.3 */
 
-            /* If a Transfer-Encoding header field
+                /* If a Transfer-Encoding header field
              * is present in a request and the chunked transfer coding is not
              * the final encoding, the message body length cannot be determined
              * reliably; the server MUST respond with the 400 (Bad Request)
              * status code and then close the connection.
              */
-            CROW_SET_ERRNO(HPE_INVALID_TRANSFER_ENCODING);
-            parser->nread = nread;
-            return (p - data); /* Error */
-          } else {
-            /* RFC 7230 3.3.3 */
+                CROW_SET_ERRNO(CHPE_INVALID_TRANSFER_ENCODING);
+                parser->nread = nread;
+                return (p - data); /* Error */
+            }
+            else
+            {
+                /* RFC 7230 3.3.3 */
 
-            /* If a Transfer-Encoding header field is present in a response and
+                /* If a Transfer-Encoding header field is present in a response and
              * the chunked transfer coding is not the final encoding, the
              * message body length is determined by reading the connection until
              * it is closed by the server.
              */
-            parser->state = s_body_identity_eof;
-          }
-        } else {
-          if (parser->content_length == 0) {
-            /* Content-Length header given but zero: Content-Length: 0\r\n */
-            parser->state = CROW_NEW_MESSAGE();
-            CROW_CALLBACK_NOTIFY(message_complete);
-          } else if (parser->content_length != CROW_ULLONG_MAX) {
-            /* Content-Length header given and non-zero */
-            parser->state = s_body_identity;
-          } else {
-            if (!http_message_needs_eof(parser)) {
-              /* Assume content-length 0 - read the next */
-              parser->state = CROW_NEW_MESSAGE();
-              CROW_CALLBACK_NOTIFY(message_complete);
-            } else {
-              /* Read body until EOF */
-              parser->state = s_body_identity_eof;
+                parser->state = s_body_identity_eof;
             }
-          }
+        }
+        else
+        {
+            if (parser->content_length == 0)
+            {
+                /* Content-Length header given but zero: Content-Length: 0\r\n */
+                parser->state = CROW_NEW_MESSAGE();
+                CROW_CALLBACK_NOTIFY(message_complete);
+            }
+            else if (parser->content_length != CROW_ULLONG_MAX)
+            {
+                /* Content-Length header given and non-zero */
+                parser->state = s_body_identity;
+            }
+            else
+            {
+                /* Assume content-length 0 - read the next */
+                parser->state = CROW_NEW_MESSAGE();
+                CROW_CALLBACK_NOTIFY(message_complete);
+            }
         }
 
         break;
@@ -2352,7 +1773,7 @@ reexecute:
 
         unhex_val = unhex[static_cast<unsigned char>(ch)];
         if (CROW_UNLIKELY(unhex_val == -1)) {
-          CROW_SET_ERRNO(HPE_INVALID_CHUNK_SIZE);
+          CROW_SET_ERRNO(CHPE_INVALID_CHUNK_SIZE);
           goto error;
         }
 
@@ -2367,7 +1788,7 @@ reexecute:
 
         assert(parser->flags & F_CHUNKED);
 
-        if (ch == CROW_CR) {
+        if (ch == cr) {
           parser->state = s_chunk_size_almost_done;
           break;
         }
@@ -2380,7 +1801,7 @@ reexecute:
             break;
           }
 
-          CROW_SET_ERRNO(HPE_INVALID_CHUNK_SIZE);
+          CROW_SET_ERRNO(CHPE_INVALID_CHUNK_SIZE);
           goto error;
         }
 
@@ -2390,7 +1811,7 @@ reexecute:
 
         /* Overflow? Test against a conservative limit for simplicity. */
         if (CROW_UNLIKELY((CROW_ULLONG_MAX - 16) / 16 < parser->content_length)) {
-          CROW_SET_ERRNO(HPE_INVALID_CONTENT_LENGTH);
+          CROW_SET_ERRNO(CHPE_INVALID_CONTENT_LENGTH);
           goto error;
         }
 
@@ -2402,7 +1823,7 @@ reexecute:
       {
         assert(parser->flags & F_CHUNKED);
         /* just ignore this shit. TODO check for overflow */
-        if (ch == CROW_CR) {
+        if (ch == cr) {
           parser->state = s_chunk_size_almost_done;
           break;
         }
@@ -2412,7 +1833,7 @@ reexecute:
       case s_chunk_size_almost_done:
       {
         assert(parser->flags & F_CHUNKED);
-        CROW_STRICT_CHECK(ch != CROW_LF);
+        CROW_STRICT_CHECK(ch != lf);
 
         parser->nread = 0;
         nread = 0;
@@ -2452,14 +1873,14 @@ reexecute:
       case s_chunk_data_almost_done:
         assert(parser->flags & F_CHUNKED);
         assert(parser->content_length == 0);
-        CROW_STRICT_CHECK(ch != CROW_CR);
+        CROW_STRICT_CHECK(ch != cr);
         parser->state = s_chunk_data_done;
         CROW_CALLBACK_DATA(body);
         break;
 
       case s_chunk_data_done:
         assert(parser->flags & F_CHUNKED);
-        CROW_STRICT_CHECK(ch != CROW_LF);
+        CROW_STRICT_CHECK(ch != lf);
         parser->nread = 0;
         nread = 0;
         parser->state = s_chunk_size_start;
@@ -2467,7 +1888,7 @@ reexecute:
 
       default:
         assert(0 && "unhandled state");
-        CROW_SET_ERRNO(HPE_INVALID_INTERNAL_STATE);
+        CROW_SET_ERRNO(CHPE_INVALID_INTERNAL_STATE);
         goto error;
     }
   }
@@ -2485,121 +1906,40 @@ reexecute:
   assert(((header_field_mark ? 1 : 0) +
           (header_value_mark ? 1 : 0) +
           (url_mark ? 1 : 0)  +
-          (body_mark ? 1 : 0) +
-          (status_mark ? 1 : 0)) <= 1);
+          (body_mark ? 1 : 0)) <= 1);
 
   CROW_CALLBACK_DATA_NOADVANCE(header_field);
   CROW_CALLBACK_DATA_NOADVANCE(header_value);
   CROW_CALLBACK_DATA_NOADVANCE(url);
   CROW_CALLBACK_DATA_NOADVANCE(body);
-  CROW_CALLBACK_DATA_NOADVANCE(status);
 
   parser->nread = nread;
   return len;
 
 error:
-  if (CROW_HTTP_PARSER_ERRNO(parser) == HPE_OK) {
-    CROW_SET_ERRNO(HPE_UNKNOWN);
+  if (CROW_HTTP_PARSER_ERRNO(parser) == CHPE_OK) {
+    CROW_SET_ERRNO(CHPE_UNKNOWN);
   }
 
   parser->nread = nread;
   return (p - data);
 }
 
-
-/* Does the parser need to see an EOF to find the end of the message? */
-inline int
-http_message_needs_eof (const http_parser *parser)
-{
-  if (parser->type == HTTP_REQUEST) {
-    return 0;
-  }
-
-  /* See RFC 2616 section 4.4 */
-  if (parser->status_code / 100 == 1 || /* 1xx e.g. Continue */
-      parser->status_code == 204 ||     /* No Content */
-      parser->status_code == 304 ||     /* Not Modified */
-      parser->flags & F_SKIPBODY) {     /* response to a HEAD request */
-    return 0;
-  }
-
-  /* RFC 7230 3.3.3, see `s_headers_almost_done` */
-  if ((parser->uses_transfer_encoding == 1) &&
-      (parser->flags & F_CHUNKED) == 0) {
-    return 1;
-  }
-
-  if ((parser->flags & F_CHUNKED) || parser->content_length != CROW_ULLONG_MAX) {
-    return 0;
-  }
-
-  return 1;
-}
-
-
-inline int
-http_should_keep_alive (const http_parser *parser)
-{
-  if (parser->http_major > 0 && parser->http_minor > 0) {
-    /* HTTP/1.1 */
-    if (parser->flags & F_CONNECTION_CLOSE) {
-      return 0;
-    }
-  } else {
-    /* HTTP/1.0 or earlier */
-    if (!(parser->flags & F_CONNECTION_KEEP_ALIVE)) {
-      return 0;
-    }
-  }
-
-  return !http_message_needs_eof(parser);
-}
-
-
-inline const char *
-http_method_str (enum http_method m)
-{
-static const char *method_strings[] =
-  {
-#define CROW_XX(num, name, string) #string,
-  CROW_HTTP_METHOD_MAP(CROW_XX)
-#undef CROW_XX
-  };
-  return CROW_ELEM_AT(method_strings, m, "<unknown>");
-}
-
-inline const char *
-http_status_str (enum http_status s)
-{
-  switch (s) {
-#define CROW_XX(num, name, string) case HTTP_STATUS_##name: return #string;
-    HTTP_STATUS_MAP(CROW_XX)
-#undef CROW_XX
-    default: return "<unknown>";
-  }
-}
-
 inline void
-http_parser_init (http_parser *parser, enum http_parser_type t)
+  http_parser_init(http_parser* parser)
 {
   void *data = parser->data; /* preserve application data */
   memset(parser, 0, sizeof(*parser));
   parser->data = data;
-  parser->type = t;
-  parser->state = (t == HTTP_REQUEST ? s_start_req : (t == HTTP_RESPONSE ? s_start_res : s_start_req_or_res));
-  parser->http_errno = HPE_OK;
+  parser->state = s_start_req;
+  parser->http_errno = CHPE_OK;
 }
 
-inline void
-http_parser_settings_init(http_parser_settings *settings)
-{
-  memset(settings, 0, sizeof(*settings));
-}
-
+/* Return a string name of the given error */
 inline const char *
 http_errno_name(enum http_errno err) {
 /* Map errno values to strings for human-readable output */
-#define CROW_HTTP_STRERROR_GEN(n, s) { "HPE_" #n, s },
+#define CROW_HTTP_STRERROR_GEN(n, s) { "CHPE_" #n, s },
 static struct {
   const char *name;
   const char *description;
@@ -2611,10 +1951,11 @@ static struct {
   return http_strerror_tab[err].name;
 }
 
+/* Return a string description of the given error */
 inline const char *
 http_errno_description(enum http_errno err) {
 /* Map errno values to strings for human-readable output */
-#define CROW_HTTP_STRERROR_GEN(n, s) { "HPE_" #n, s },
+#define CROW_HTTP_STRERROR_GEN(n, s) { "CHPE_" #n, s },
 static struct {
   const char *name;
   const char *description;
@@ -2626,332 +1967,18 @@ static struct {
   return http_strerror_tab[err].description;
 }
 
-inline static enum http_host_state
-http_parse_host_char(enum http_host_state s, const char ch) {
-  switch(s) {
-    case s_http_userinfo:
-    case s_http_userinfo_start:
-      if (ch == '@') {
-        return s_http_host_start;
-      }
-
-      if (CROW_IS_USERINFO_CHAR(ch)) {
-        return s_http_userinfo;
-      }
-      break;
-
-    case s_http_host_start:
-      if (ch == '[') {
-        return s_http_host_v6_start;
-      }
-
-      if (CROW_IS_HOST_CHAR(ch)) {
-        return s_http_host;
-      }
-
-      break;
-
-    case s_http_host:
-      if (CROW_IS_HOST_CHAR(ch)) {
-        return s_http_host;
-      }
-
-    /* fall through */
-    case s_http_host_v6_end:
-      if (ch == ':') {
-        return s_http_host_port_start;
-      }
-
-      break;
-
-    case s_http_host_v6:
-      if (ch == ']') {
-        return s_http_host_v6_end;
-      }
-
-    /* fall through */
-    case s_http_host_v6_start:
-      if (CROW_IS_HEX(ch) || ch == ':' || ch == '.') {
-        return s_http_host_v6;
-      }
-      
-      if (s == s_http_host_v6 && ch == '%') {
-        return s_http_host_v6_zone_start;
-      }
-      break;
-
-    case s_http_host_v6_zone:
-      if (ch == ']') {
-        return s_http_host_v6_end;
-      }
-
-    /* fall through */
-    case s_http_host_v6_zone_start:
-      /* RFC 6874 Zone ID consists of 1*( unreserved / pct-encoded) */
-      if (CROW_IS_ALPHANUM(ch) || ch == '%' || ch == '.' || ch == '-' || ch == '_' ||
-          ch == '~') {
-        return s_http_host_v6_zone;
-      }
-      break;
-
-    case s_http_host_port:
-    case s_http_host_port_start:
-      if (CROW_IS_NUM(ch)) {
-        return s_http_host_port;
-      }
-
-      break;
-
-    default:
-      break;
-  }
-  return s_http_host_dead;
-}
-
-inline int
-http_parse_host(const char * buf, struct http_parser_url *u, int found_at) {
-  enum http_host_state s;
-
-  const char *p;
-  size_t buflen = u->field_data[UF_HOST].off + u->field_data[UF_HOST].len;
-  
-  assert(u->field_set & (1 << UF_HOST));
-  
-  u->field_data[UF_HOST].len = 0;
-
-  s = found_at ? s_http_userinfo_start : s_http_host_start;
-
-  for (p = buf + u->field_data[UF_HOST].off; p < buf + buflen; p++) {
-    enum http_host_state new_s = http_parse_host_char(s, *p);
-
-    if (new_s == s_http_host_dead) {
-      return 1;
-    }
-
-    switch(new_s) {
-      case s_http_host:
-        if (s != s_http_host) {
-          u->field_data[UF_HOST].off = (uint16_t)(p - buf);
-        }
-        u->field_data[UF_HOST].len++;
-        break;
-
-      case s_http_host_v6:
-        if (s != s_http_host_v6) {
-          u->field_data[UF_HOST].off = (uint16_t)(p - buf);
-        }
-        u->field_data[UF_HOST].len++;
-        break;
-        
-      case s_http_host_v6_zone_start:
-      case s_http_host_v6_zone:
-        u->field_data[UF_HOST].len++;
-        break;
-
-      case s_http_host_port:
-        if (s != s_http_host_port) {
-          u->field_data[UF_PORT].off = (uint16_t)(p - buf);
-          u->field_data[UF_PORT].len = 0;
-          u->field_set |= (1 << UF_PORT);
-        }
-        u->field_data[UF_PORT].len++;
-        break;
-
-      case s_http_userinfo:
-        if (s != s_http_userinfo) {
-          u->field_data[UF_USERINFO].off = (uint16_t)(p - buf);
-          u->field_data[UF_USERINFO].len = 0;
-          u->field_set |= (1 << UF_USERINFO);
-        }
-        u->field_data[UF_USERINFO].len++;
-        break;
-
-      default:
-        break;
-    }
-    s = new_s;
-  }
-
-  /* Make sure we don't end somewhere unexpected */
-  switch (s) {
-    case s_http_host_start:
-    case s_http_host_v6_start:
-    case s_http_host_v6:
-    case s_http_host_v6_zone_start:
-    case s_http_host_v6_zone:
-    case s_http_host_port_start:
-    case s_http_userinfo:
-    case s_http_userinfo_start:
-      return 1;
-    default:
-      break;
-  }
-
-  return 0;
-}
-
-inline void
-http_parser_url_init(struct http_parser_url *u) {
-  memset(u, 0, sizeof(*u));
-}
-
-inline int
-http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
-                      struct http_parser_url *u)
-{
-  enum state s;
-  const char *p;
-  enum http_parser_url_fields uf, old_uf;
-  int found_at = 0;
-  
-  if (buflen == 0) {
-    return 1;
-  }
-
-  u->port = u->field_set = 0;
-  s = is_connect ? s_req_server_start : s_req_spaces_before_url;
-  old_uf = UF_MAX;
-
-  for (p = buf; p < buf + buflen; p++) {
-    s = parse_url_char(s, *p);
-
-    /* Figure out the next field that we're operating on */
-    switch (s) {
-      case s_dead:
-        return 1;
-
-      /* Skip delimeters */
-      case s_req_schema_slash:
-      case s_req_schema_slash_slash:
-      case s_req_server_start:
-      case s_req_query_string_start:
-      case s_req_fragment_start:
-        continue;
-
-      case s_req_schema:
-        uf = UF_SCHEMA;
-        break;
-
-      case s_req_server_with_at:
-        found_at = 1;
-        break;
-
-      /* fall through */
-      case s_req_server:
-        uf = UF_HOST;
-        break;
-
-      case s_req_path:
-        uf = UF_PATH;
-        break;
-
-      case s_req_query_string:
-        uf = UF_QUERY;
-        break;
-
-      case s_req_fragment:
-        uf = UF_FRAGMENT;
-        break;
-
-      default:
-        assert(!"Unexpected state");
-        return 1;
-    }
-
-    /* Nothing's changed; soldier on */
-    if (uf == old_uf) {
-      u->field_data[uf].len++;
-      continue;
-    }
-
-    u->field_data[uf].off = (uint16_t)(p - buf);
-    u->field_data[uf].len = 1;
-
-    u->field_set |= (1 << uf);
-    old_uf = uf;
-  }
-
-  /* host must be present if there is a schema */
-  /* parsing http:///toto will fail */
-  if ((u->field_set & (1 << UF_SCHEMA)) &&
-      (u->field_set & (1 << UF_HOST)) == 0) {
-    return 1;
-  }
-
-  if (u->field_set & (1 << UF_HOST)) {
-    if (http_parse_host(buf, u, found_at) != 0) {
-      return 1;
-    }
-  }
-
-  /* CONNECT requests can only contain "hostname:port" */
-  if (is_connect && u->field_set != ((1 << UF_HOST)|(1 << UF_PORT))) {
-    return 1;
-  }
-
-  if (u->field_set & (1 << UF_PORT)) {
-    uint16_t off;
-    uint16_t len;
-    const char* p;
-    const char* end;
-    unsigned long v;
-
-    off = u->field_data[UF_PORT].off;
-    len = u->field_data[UF_PORT].len;
-    end = buf + off + len;
-
-    /* NOTE: The characters are already validated and are in the [0-9] range */
-    assert((size_t)(off + len) <= buflen && "Port number overflow");
-    v = 0;
-    for (p = buf + off; p < end; p++) {
-      v *= 10;
-      v += *p - '0';
-
-      /* Ports have a max value of 2^16 */
-      if (v > 0xffff) {
-        return 1;
-      }
-    }
-
-    u->port = static_cast<uint16_t>(v);
-  }
-
-  return 0;
-}
-
-inline void
-http_parser_pause(http_parser *parser, int paused) {
-  /* Users should only be pausing/unpausing a parser that is not in an error
-   * state. In non-debug builds, there's not much that we can do about this
-   * other than ignore it.
-   */
-  if (CROW_HTTP_PARSER_ERRNO(parser) == HPE_OK ||
-      CROW_HTTP_PARSER_ERRNO(parser) == HPE_PAUSED) {
-    uint32_t nread = parser->nread; /* used by the CROW_SET_ERRNO macro */
-    CROW_SET_ERRNO((paused) ? HPE_PAUSED : HPE_OK);
-  } else {
-    assert(0 && "Attempting to pause parser in error state");
-  }
-}
-
+/* Checks if this is the final chunk of the body. */
 inline int
 http_body_is_final(const struct http_parser *parser) {
     return parser->state == s_message_done;
 }
 
-inline unsigned long
-http_parser_version(void) {
-  return CROW_HTTP_PARSER_VERSION_MAJOR * 0x10000 |
-         CROW_HTTP_PARSER_VERSION_MINOR * 0x00100 |
-         CROW_HTTP_PARSER_VERSION_PATCH * 0x00001;
-}
-
+/* Change the maximum header size provided at compile time. */
 inline void
 http_parser_set_max_header_size(uint32_t size) {
   max_header_size = size;
 }
 
-#undef CROW_HTTP_METHOD_MAP
 #undef CROW_HTTP_ERRNO_MAP
 #undef CROW_SET_ERRNO
 #undef CROW_CALLBACK_NOTIFY_
@@ -2970,23 +1997,19 @@ http_parser_set_max_header_size(uint32_t size) {
 #undef CROW_KEEP_ALIVE
 #undef CROW_CLOSE
 #undef CROW_PARSING_HEADER
-#undef CROW_CR
-#undef CROW_LF
 #undef CROW_LOWER
 #undef CROW_IS_ALPHA
 #undef CROW_IS_NUM
 #undef CROW_IS_ALPHANUM
-#undef CROW_IS_HEX
+//#undef CROW_IS_HEX
 #undef CROW_IS_MARK
 #undef CROW_IS_USERINFO_CHAR
 #undef CROW_TOKEN
 #undef CROW_IS_URL_CHAR
-#undef CROW_IS_HOST_CHAR
+//#undef CROW_IS_HOST_CHAR
 #undef CROW_start_state
 #undef CROW_STRICT_CHECK
 #undef CROW_NEW_MESSAGE
 
-#ifdef __cplusplus
 }
-#endif
-#endif
+}

--- a/include/crow/http_parser_merged.h
+++ b/include/crow/http_parser_merged.h
@@ -125,7 +125,6 @@ enum http_connection_flags // This is basically 7 booleans placed into 1 integer
   CROW_XX(INVALID_CONSTANT, "invalid constant string")                                  \
   CROW_XX(INVALID_INTERNAL_STATE, "encountered unexpected internal state")              \
   CROW_XX(STRICT, "strict mode assertion failed")                                       \
-  /*CROW_XX(PAUSED, "parser is paused")*/ /*There's no need to pause the parser */      \
   CROW_XX(UNKNOWN, "an unknown error occurred")                                         \
   CROW_XX(INVALID_TRANSFER_ENCODING, "request has invalid transfer-encoding")           \
 

--- a/include/crow/http_request.h
+++ b/include/crow/http_request.h
@@ -20,8 +20,6 @@ namespace crow
         return empty;
     }
 
-    struct DetachHelper;
-
     /// An HTTP request.
     struct request
     {
@@ -32,6 +30,8 @@ namespace crow
         ci_map headers;
         std::string body;
         std::string remote_ip_address; ///< The IP address from which the request was sent.
+        unsigned char http_ver_major, http_ver_minor;
+        bool keep_alive, close_connection, upgrade;
 
         void* middleware_context{};
         boost::asio::io_service* io_service{};
@@ -42,8 +42,8 @@ namespace crow
         {}
 
         /// Construct a request with all values assigned.
-        request(HTTPMethod method, std::string raw_url, std::string url, query_string url_params, ci_map headers, std::string body):
-          method(method), raw_url(std::move(raw_url)), url(std::move(url)), url_params(std::move(url_params)), headers(std::move(headers)), body(std::move(body))
+        request(HTTPMethod method, std::string raw_url, std::string url, query_string url_params, ci_map headers, std::string body, unsigned char http_major, unsigned char http_minor, bool has_keep_alive, bool has_close_connection, bool is_upgrade):
+          method(method), raw_url(std::move(raw_url)), url(std::move(url)), url_params(std::move(url_params)), headers(std::move(headers)), body(std::move(body)), http_ver_major(http_major), http_ver_minor(http_minor), keep_alive(has_keep_alive), close_connection(has_close_connection), upgrade(is_upgrade)
         {}
 
         void add_header(std::string key, std::string value)
@@ -56,14 +56,19 @@ namespace crow
             return crow::get_header_value(headers, key);
         }
 
-        /// Send the request with a completion handler and return immediately.
+        bool check_version(unsigned char major, unsigned char minor) const
+        {
+            return http_ver_major == major && http_ver_minor == minor;
+        }
+
+        /// Send data to whoever made this request with a completion handler and return immediately.
         template<typename CompletionHandler>
         void post(CompletionHandler handler)
         {
             io_service->post(handler);
         }
 
-        /// Send the request with a completion handler.
+        /// Send data to whoever made this request with a completion handler.
         template<typename CompletionHandler>
         void dispatch(CompletionHandler handler)
         {

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -32,7 +32,7 @@ namespace crow
 #ifdef CROW_ENABLE_COMPRESSION
         bool compressed = true; ///< If compression is enabled and this is false, the individual response will not be compressed.
 #endif
-        bool is_head_response = false;     ///< Whether this is a response to a HEAD request.
+        bool skip_body = false;     ///< Whether this is a response to a HEAD request.
         bool manual_length_header = false; ///< Whether Crow should automatically add a "Content-Length" header.
 
         /// Set the value of an existing header in the response.
@@ -171,7 +171,7 @@ namespace crow
             if (!completed_)
             {
                 completed_ = true;
-                if (is_head_response)
+                if (skip_body)
                 {
                     set_header("Content-Length", std::to_string(body.size()));
                     body = "";

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -32,7 +32,7 @@ namespace crow
 #ifdef CROW_ENABLE_COMPRESSION
         bool compressed = true; ///< If compression is enabled and this is false, the individual response will not be compressed.
 #endif
-        bool skip_body = false;     ///< Whether this is a response to a HEAD request.
+        bool skip_body = false;            ///< Whether this is a response to a HEAD request.
         bool manual_length_header = false; ///< Whether Crow should automatically add a "Content-Length" header.
 
         /// Set the value of an existing header in the response.

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -1051,9 +1051,9 @@ namespace crow
                                 break;
                             default:
                                 if (CROW_LIKELY(state == NumberParsingState::ZeroFirst ||
-                                                     state == NumberParsingState::Digits ||
-                                                     state == NumberParsingState::DigitsAfterPoints ||
-                                                     state == NumberParsingState::DigitsAfterE))
+                                                state == NumberParsingState::Digits ||
+                                                state == NumberParsingState::DigitsAfterPoints ||
+                                                state == NumberParsingState::DigitsAfterE))
                                     return {type::Number, start, data};
                                 else
                                     return {};

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -18,7 +18,7 @@
 #include <vector>
 #include <math.h>
 
-#include "crow/common.h"
+#include "crow/utility.h"
 #include "crow/settings.h"
 #include "crow/returnable.h"
 #include "crow/logging.h"

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -17,16 +17,9 @@
 #include <boost/operators.hpp>
 #include <vector>
 
+#include "crow/common.h"
 #include "crow/settings.h"
 #include "crow/returnable.h"
-
-#if defined(__GNUG__) || defined(__clang__)
-#define crow_json_likely(x) __builtin_expect(x, 1)
-#define crow_json_unlikely(x) __builtin_expect(x, 0)
-#else
-#define crow_json_likely(x) x
-#define crow_json_unlikely(x) x
-#endif
 
 
 namespace crow
@@ -830,7 +823,7 @@ namespace crow
 
                 bool consume(char c)
                 {
-                    if (crow_json_unlikely(*data != c))
+                    if (CROW_UNLIKELY(*data != c))
                         return false;
                     data++;
                     return true;
@@ -844,13 +837,13 @@ namespace crow
 
                 rvalue decode_string()
                 {
-                    if (crow_json_unlikely(!consume('"')))
+                    if (CROW_UNLIKELY(!consume('"')))
                         return {};
                     char* start = data;
                     uint8_t has_escaping = 0;
                     while (1)
                     {
-                        if (crow_json_likely(*data != '"' && *data != '\\' && *data != '\0'))
+                        if (CROW_LIKELY(*data != '"' && *data != '\\' && *data != '\0'))
                         {
                             data++;
                         }
@@ -905,13 +898,13 @@ namespace crow
                 rvalue decode_list()
                 {
                     rvalue ret(type::List);
-                    if (crow_json_unlikely(!consume('[')))
+                    if (CROW_UNLIKELY(!consume('[')))
                     {
                         ret.set_error();
                         return ret;
                     }
                     ws_skip();
-                    if (crow_json_unlikely(*data == ']'))
+                    if (CROW_UNLIKELY(*data == ']'))
                     {
                         data++;
                         return ret;
@@ -920,7 +913,7 @@ namespace crow
                     while (1)
                     {
                         auto v = decode_value();
-                        if (crow_json_unlikely(!v))
+                        if (CROW_UNLIKELY(!v))
                         {
                             ret.set_error();
                             break;
@@ -932,7 +925,7 @@ namespace crow
                             data++;
                             break;
                         }
-                        if (crow_json_unlikely(!consume(',')))
+                        if (CROW_UNLIKELY(!consume(',')))
                         {
                             ret.set_error();
                             break;
@@ -957,7 +950,7 @@ namespace crow
                         DigitsAfterE,
                         Invalid,
                     } state{Minus};
-                    while (crow_json_likely(state != Invalid))
+                    while (CROW_LIKELY(state != Invalid))
                     {
                         switch (*data)
                         {
@@ -1054,7 +1047,7 @@ namespace crow
                                     return {};*/
                                 break;
                             default:
-                                if (crow_json_likely(state == NumberParsingState::ZeroFirst ||
+                                if (CROW_LIKELY(state == NumberParsingState::ZeroFirst ||
                                                      state == NumberParsingState::Digits ||
                                                      state == NumberParsingState::DigitsAfterPoints ||
                                                      state == NumberParsingState::DigitsAfterE))
@@ -1125,7 +1118,7 @@ namespace crow
                 rvalue decode_object()
                 {
                     rvalue ret(type::Object);
-                    if (crow_json_unlikely(!consume('{')))
+                    if (CROW_UNLIKELY(!consume('{')))
                     {
                         ret.set_error();
                         return ret;
@@ -1133,7 +1126,7 @@ namespace crow
 
                     ws_skip();
 
-                    if (crow_json_unlikely(*data == '}'))
+                    if (CROW_UNLIKELY(*data == '}'))
                     {
                         data++;
                         return ret;
@@ -1142,26 +1135,26 @@ namespace crow
                     while (1)
                     {
                         auto t = decode_string();
-                        if (crow_json_unlikely(!t))
+                        if (CROW_UNLIKELY(!t))
                         {
                             ret.set_error();
                             break;
                         }
 
                         ws_skip();
-                        if (crow_json_unlikely(!consume(':')))
+                        if (CROW_UNLIKELY(!consume(':')))
                         {
                             ret.set_error();
                             break;
                         }
 
-                        // TODO caching key to speed up (flyweight?)
+                        // TODO(ipkn) caching key to speed up (flyweight?)
                         // I have no idea how flyweight could apply here, but maybe some speedup can happen if we stopped checking type since decode_string returns a string anyway
                         auto key = t.s();
 
                         ws_skip();
                         auto v = decode_value();
-                        if (crow_json_unlikely(!v))
+                        if (CROW_UNLIKELY(!v))
                         {
                             ret.set_error();
                             break;
@@ -1170,12 +1163,12 @@ namespace crow
 
                         v.key_ = std::move(key);
                         ret.emplace_back(std::move(v));
-                        if (crow_json_unlikely(*data == '}'))
+                        if (CROW_UNLIKELY(*data == '}'))
                         {
                             data++;
                             break;
                         }
-                        if (crow_json_unlikely(!consume(',')))
+                        if (CROW_UNLIKELY(!consume(',')))
                         {
                             ret.set_error();
                             break;
@@ -1895,6 +1888,3 @@ namespace crow
         //}
     } // namespace json
 } // namespace crow
-
-#undef crow_json_likely
-#undef crow_json_unlikely

--- a/include/crow/multipart.h
+++ b/include/crow/multipart.h
@@ -96,10 +96,10 @@ namespace crow
                 size_t found = header.find("boundary=");
                 if (found)
                 {
-                    std::string to_return (header.substr(found + 9));
+                    std::string to_return(header.substr(found + 9));
                     if (to_return[0] == '\"')
                     {
-                        to_return = to_return.substr(1, to_return.length()-2);
+                        to_return = to_return.substr(1, to_return.length() - 2);
                     }
                     return to_return;
                 }

--- a/include/crow/multipart.h
+++ b/include/crow/multipart.h
@@ -93,10 +93,11 @@ namespace crow
         private:
             std::string get_boundary(const std::string& header) const
             {
-                size_t found = header.find("boundary=");
+                constexpr char boundary_text[] = "boundary=";
+                size_t found = header.find(boundary_text);
                 if (found)
                 {
-                    std::string to_return(header.substr(found + 9));
+                    std::string to_return(header.substr(found + strlen(boundary_text)));
                     if (to_return[0] == '\"')
                     {
                         to_return = to_return.substr(1, to_return.length() - 2);

--- a/include/crow/multipart.h
+++ b/include/crow/multipart.h
@@ -13,7 +13,6 @@ namespace crow
     namespace multipart
     {
         const std::string dd = "--";
-        const std::string crlf = "\r\n";
 
         /// The first part in a section, contains metadata about the part
         struct header
@@ -28,6 +27,7 @@ namespace crow
         /// It is usually separated from other sections by a `boundary`
         struct part
         {
+            //TODO(EDev): restructure this to an `unordered_map<string, header>` with string being `header::value.first`
             std::vector<header> headers; ///< (optional) The first part before the data, Contains information regarding the type of data and encoding
             std::string body;            ///< The actual data in the part
         };
@@ -35,7 +35,7 @@ namespace crow
         /// The parsed multipart request/response
         struct message : public returnable
         {
-            ci_map headers;
+            ci_map headers;          ///< The request/response headers
             std::string boundary;    ///< The text boundary that separates different `parts`
             std::vector<part> parts; ///< The individual parts of the message
 
@@ -95,7 +95,14 @@ namespace crow
             {
                 size_t found = header.find("boundary=");
                 if (found)
-                    return header.substr(found + 9);
+                {
+                    std::string to_return (header.substr(found + 9));
+                    if (to_return[0] == '\"')
+                    {
+                        to_return = to_return.substr(1, to_return.length()-2);
+                    }
+                    return to_return;
+                }
                 return std::string();
             }
 

--- a/include/crow/parser.h
+++ b/include/crow/parser.h
@@ -154,13 +154,13 @@ namespace crow
 
             // HTTP1.1 = always send keep_alive, HTTP1.0 = only send if header exists, HTTP?.? = never send
             keep_alive = (http_major == 1 && http_minor == 0) ?
-                                 ((flags & F_CONNECTION_KEEP_ALIVE) ? true : false) :
-                                 ((http_major == 1 && http_minor == 1) ? true : false);
+                           ((flags & F_CONNECTION_KEEP_ALIVE) ? true : false) :
+                           ((http_major == 1 && http_minor == 1) ? true : false);
 
             // HTTP1.1 = only close if close header exists, HTTP1.0 = always close unless keep_alive header exists, HTTP?.?= never close
             close_connection = (http_major == 1 && http_minor == 0) ?
-                                       ((flags & F_CONNECTION_KEEP_ALIVE) ? false : true) :
-                                       ((http_major == 1 && http_minor == 1) ? ((flags & F_CONNECTION_CLOSE) ? true : false) : false);
+                                 ((flags & F_CONNECTION_KEEP_ALIVE) ? false : true) :
+                                 ((http_major == 1 && http_minor == 1) ? ((flags & F_CONNECTION_CLOSE) ? true : false) : false);
         }
 
         /// Take the parsed HTTP request data and convert it to a \ref crow.request

--- a/include/crow/parser.h
+++ b/include/crow/parser.h
@@ -70,6 +70,18 @@ namespace crow
             {
                 self->headers.emplace(std::move(self->header_field), std::move(self->header_value));
             }
+            //NOTE(EDev): it seems that the problem is with crow's policy on closing the connection for HTTP_VERSION < 1.0, the behaviour for that in crow is "don't close the connection, but don't send a keep-alive either"
+
+            // HTTP1.1 = always send keep_alive, HTTP1.0 = only send if header exists, HTTP?.? = never send
+            self->keep_alive = (self->http_major == 1 && self->http_minor == 0) ?
+                                 ((self->flags & F_CONNECTION_KEEP_ALIVE) ? true : false) :
+                                 ((self->http_major == 1 && self->http_minor == 1) ? true : false);
+
+            // HTTP1.1 = only close if close header exists, HTTP1.0 = always close unless keep_alive header exists, HTTP?.?= never close
+            self->close_connection = (self->http_major == 1 && self->http_minor == 0) ?
+                                       ((self->flags & F_CONNECTION_KEEP_ALIVE) ? false : true) :
+                                       ((self->http_major == 1 && self->http_minor == 1) ? ((self->flags & F_CONNECTION_CLOSE) ? true : false) : false);
+
             self->process_header();
             return 0;
         }
@@ -84,7 +96,7 @@ namespace crow
             HTTPParser* self = static_cast<HTTPParser*>(self_);
 
             // url params
-            self->url = self->raw_url.substr(0, self->raw_url.find("?"));
+            self->url = self->raw_url.substr(0, self->qs_point != 0 ? self->qs_point : std::string::npos);
             self->url_params = query_string(self->raw_url);
 
             self->process_message();
@@ -93,7 +105,7 @@ namespace crow
         HTTPParser(Handler* handler):
           handler_(handler)
         {
-            http_parser_init(this, HTTP_REQUEST);
+            http_parser_init(this);
         }
 
         // return false on error
@@ -103,7 +115,6 @@ namespace crow
             const static http_parser_settings settings_{
               on_message_begin,
               on_url,
-              nullptr,
               on_header_field,
               on_header_value,
               on_headers_complete,
@@ -112,7 +123,7 @@ namespace crow
             };
 
             int nparsed = http_parser_execute(this, &settings_, buffer, length);
-            if (http_errno != HPE_OK)
+            if (http_errno != CHPE_OK)
             {
                 return false;
             }
@@ -136,12 +147,12 @@ namespace crow
             body.clear();
         }
 
-        void process_header()
+        inline void process_header()
         {
             handler_->handle_header();
         }
 
-        void process_message()
+        inline void process_message()
         {
             handler_->handle();
         }
@@ -149,17 +160,7 @@ namespace crow
         /// Take the parsed HTTP request data and convert it to a \ref crow.request
         request to_request() const
         {
-            return request{static_cast<HTTPMethod>(method), std::move(raw_url), std::move(url), std::move(url_params), std::move(headers), std::move(body)};
-        }
-
-        bool is_upgrade() const
-        {
-            return upgrade;
-        }
-
-        bool check_version(int major, int minor) const
-        {
-            return http_major == major && http_minor == minor;
+            return request{static_cast<HTTPMethod>(method), std::move(raw_url), std::move(url), std::move(url_params), std::move(headers), std::move(body), http_major, http_minor, keep_alive, close_connection, static_cast<bool>(upgrade)};
         }
 
         std::string raw_url;
@@ -171,6 +172,8 @@ namespace crow
         ci_map headers;
         query_string url_params; ///< What comes after the `?` in the URL.
         std::string body;
+        bool keep_alive;       ///< Whether or not the server should send a `connection: Keep-Alive` header to the client.
+        bool close_connection; ///< Whether or not the server should shut down the TCP connection once a response is sent.
 
         Handler* handler_; ///< This is currently an HTTP connection object (\ref crow.Connection).
     };

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -19,7 +19,7 @@
 namespace crow
 {
 
-    constexpr const uint16_t INVALID_BP_ID{0xFFFF};
+    constexpr const uint16_t INVALID_BP_ID{((uint16_t)-1)};
 
     /// A base class for all rules.
 
@@ -1399,7 +1399,7 @@ namespace crow
                 CROW_LOG_INFO << "Redirecting to a url with trailing slash: " << req.url;
                 res = response(301);
 
-                // TODO absolute url building
+                // TODO(ipkn) absolute url building
                 if (req.get_header_value("Host").empty())
                 {
                     res.add_header("Location", req.url + "/");
@@ -1515,7 +1515,7 @@ namespace crow
             else if (req.method == HTTPMethod::Head)
             {
                 method_actual = HTTPMethod::Get;
-                res.is_head_response = true;
+                res.skip_body = true;
             }
             else if (req.method == HTTPMethod::Options)
             {
@@ -1601,7 +1601,7 @@ namespace crow
                 CROW_LOG_INFO << "Redirecting to a url with trailing slash: " << req.url;
                 res = response(301);
 
-                // TODO absolute url building
+                // TODO(ipkn) absolute url building
                 if (req.get_header_value("Host").empty())
                 {
                     res.add_header("Location", req.url + "/");

--- a/include/crow/settings.h
+++ b/include/crow/settings.h
@@ -1,6 +1,6 @@
 #pragma once
 // settings for crow
-// TODO - replace with runtime config. libucl?
+// TODO(ipkn) replace with runtime config. libucl?
 
 /* #ifdef - enables debug mode */
 //#define CROW_ENABLE_DEBUG

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -702,8 +702,8 @@ namespace crow
                     data[i] = replacement;
                 }
                 else if ((c == '/') || (c == '\\'))
-                    {
-                    if (CROW_UNLIKELY( i == 0 )) //Prevent Unix Absolute Paths (Windows Absolute Paths are prevented with `(c == ':')`)
+                {
+                    if (CROW_UNLIKELY(i == 0)) //Prevent Unix Absolute Paths (Windows Absolute Paths are prevented with `(c == ':')`)
                     {
                         data[i] = replacement;
                     }
@@ -711,9 +711,9 @@ namespace crow
                     {
                         checkForSpecialEntries = true;
                     }
-                    }
                 }
             }
+        }
 
     } // namespace utility
 } // namespace crow

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -739,6 +739,7 @@ namespace crow
             boost::ireplace_all(data, "LPT7", str_replacement);
             boost::ireplace_all(data, "LPT8", str_replacement);
             boost::ireplace_all(data, "LPT9", str_replacement);
+
         }
 
     } // namespace utility

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -11,6 +11,15 @@
 
 #include "crow/settings.h"
 
+// TODO(EDev): Adding C++20's [[likely]] and [[unlikely]] attributes might be useful
+#if defined(__GNUG__) || defined(__clang__)
+#define CROW_LIKELY(X) __builtin_expect(!!(X), 1)
+#define CROW_UNLIKELY(X) __builtin_expect(!!(X), 0)
+#else
+#define CROW_LIKELY(X) (X)
+#define CROW_UNLIKELY(X) (X)
+#endif
+
 namespace crow
 {
     namespace black_magic
@@ -693,9 +702,8 @@ namespace crow
                     data[i] = replacement;
                 }
                 else if ((c == '/') || (c == '\\'))
-                {
-                    //TODO(EDev): uncomment below once #332 is merged
-                    if (/*CROW_UNLIKELY(*/ i == 0 /*)*/) //Prevent Unix Absolute Paths (Windows Absolute Paths are prevented with `(c == ':')`)
+                    {
+                    if (CROW_UNLIKELY( i == 0 )) //Prevent Unix Absolute Paths (Windows Absolute Paths are prevented with `(c == ':')`)
                     {
                         data[i] = replacement;
                     }
@@ -703,9 +711,9 @@ namespace crow
                     {
                         checkForSpecialEntries = true;
                     }
+                    }
                 }
             }
-        }
 
     } // namespace utility
 } // namespace crow

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -697,7 +697,6 @@ namespace crow
                     checkForSpecialEntries = true;
                 }
             }
-
         }
 
     } // namespace utility

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -230,7 +230,6 @@ namespace crow
                                             "Upgrade: websocket\r\n"
                                             "Connection: Upgrade\r\n"
                                             "Sec-WebSocket-Accept: ";
-                static std::string crlf = "\r\n";
                 write_buffers_.emplace_back(header);
                 write_buffers_.emplace_back(std::move(hello));
                 write_buffers_.emplace_back(crlf);

--- a/tests/ssl/ssltest.cpp
+++ b/tests/ssl/ssltest.cpp
@@ -10,7 +10,7 @@
 
 using namespace boost;
 
-//TODO SSL test with .pem file
+// TODO(EDev): SSL test with .pem file
 TEST_CASE("SSL")
 {
     static char buf[2048];

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -624,7 +624,7 @@ TEST_CASE("json_read")
     CHECK(1 == x.size());
     CHECK(false == x.has("mess"));
     REQUIRE_THROWS(x["mess"]);
-    // TODO returning false is better than exception
+    // TODO(ipkn) returning false is better than exception
     // ASSERT_THROW(3 == x["message"]);
     CHECK(12 == x["message"].size());
 
@@ -823,7 +823,7 @@ TEST_CASE("json_copy_r_to_w_to_w_to_r")
     CHECK("baz" == x["obj"]["other"]);
     CHECK("other" == x["obj"]["other"].key());
 } // json_copy_r_to_w_to_w_to_r
-//TODO maybe combine these
+//TODO(EDev): maybe combine these
 
 TEST_CASE("json::wvalue::wvalue(bool)")
 {
@@ -1779,16 +1779,14 @@ TEST_CASE("send_file")
         response res;
 
         req.url = "/jpg";
+        req.http_ver_major = 1;
 
         app.handle(req, res);
 
         CHECK(200 == res.code);
         CHECK("image/jpeg" == res.headers.find("Content-Type")->second);
-        CHECK(to_string(statbuf.st_size) ==
-              res.headers.find("Content-Length")->second);
+        CHECK(to_string(statbuf.st_size) == res.headers.find("Content-Length")->second);
     }
-
-    //TODO test content
 } // send_file
 
 TEST_CASE("stream_response")
@@ -1825,7 +1823,7 @@ TEST_CASE("stream_response")
 
         //Total bytes received
         unsigned int received = 0;
-        sendmsg = "GET /test\r\n\r\n";
+        sendmsg = "GET /test HTTP/1.0\r\n\r\n";
         {
             asio::streambuf b;
 
@@ -1859,7 +1857,7 @@ TEST_CASE("stream_response")
 
                 CHECK(key_response.substr(received - n, n) == s);
 
-                std::this_thread::sleep_for(std::chrono::milliseconds(20));
+                //std::this_thread::sleep_for(std::chrono::milliseconds(20));
             }
         }
         app.stop();
@@ -2452,7 +2450,7 @@ TEST_CASE("get_port")
 
     const std::uint16_t port = 12345;
 
-    std::thread runTest([&]() {
+    auto _ = async(launch::async, [&] {
         app.port(port).run();
     });
 
@@ -2460,7 +2458,6 @@ TEST_CASE("get_port")
     CHECK(app.port() == port);
     app.stop();
 
-    runTest.join();
 } // get_port
 
 TEST_CASE("timeout")

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1141,12 +1141,14 @@ TEST_CASE("template_basic")
 
 TEST_CASE("template_function")
 {
-  auto t = crow::mustache::compile("attack of {{func}}");
-  crow::mustache::context ctx;
-  ctx["name"] = "killer tomatoes";
-  ctx["func"] = [&](std::string){return std::string("{{name}}, IN SPACE!");};
-  auto result = t.render(ctx);
-  CHECK("attack of killer tomatoes, IN SPACE!" == result);
+    auto t = crow::mustache::compile("attack of {{func}}");
+    crow::mustache::context ctx;
+    ctx["name"] = "killer tomatoes";
+    ctx["func"] = [&](std::string) {
+        return std::string("{{name}}, IN SPACE!");
+    };
+    auto result = t.render(ctx);
+    CHECK("attack of killer tomatoes, IN SPACE!" == result);
 }
 
 TEST_CASE("template_load")
@@ -2135,14 +2137,14 @@ TEST_CASE("zlib_compression")
             std::string response_deflate;
             std::string response_gzip;
 
-            for (unsigned i{0}; i<2048; i++)
+            for (unsigned i{0}; i < 2048; i++)
             {
                 if (buf_deflate[i] == 0)
                 {
                     bool end = true;
-                    for(unsigned j=i;j<2048;j++)
+                    for (unsigned j = i; j < 2048; j++)
                     {
-                        if (buf_deflate[j]!=0)
+                        if (buf_deflate[j] != 0)
                         {
                             end = false;
                             break;
@@ -2158,14 +2160,14 @@ TEST_CASE("zlib_compression")
                 response_deflate.push_back(buf_deflate[i]);
             }
 
-            for (unsigned i{0}; i<2048; i++)
+            for (unsigned i{0}; i < 2048; i++)
             {
                 if (buf_gzip[i] == 0)
                 {
                     bool end = true;
-                    for(unsigned j=i;j<2048;j++)
+                    for (unsigned j = i; j < 2048; j++)
                     {
-                        if (buf_gzip[j]!=0)
+                        if (buf_gzip[j] != 0)
                         {
                             end = false;
                             break;
@@ -2181,8 +2183,8 @@ TEST_CASE("zlib_compression")
                 response_gzip.push_back(buf_gzip[i]);
             }
 
-            response_deflate = inflate_string(response_deflate.substr(response_deflate.find("\r\n\r\n")+4));
-            response_gzip = inflate_string(response_gzip.substr(response_gzip.find("\r\n\r\n")+4));
+            response_deflate = inflate_string(response_deflate.substr(response_deflate.find("\r\n\r\n") + 4));
+            response_gzip = inflate_string(response_gzip.substr(response_gzip.find("\r\n\r\n") + 4));
 
             socket[0].close();
             socket[1].close();

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2118,114 +2118,125 @@ TEST_CASE("zlib_compression")
         return inflated_string;
     };
 
-    std::string response_deflate;
-    std::string response_gzip;
-    std::string response_deflate_no_header;
-    std::string response_gzip_no_header;
-    std::string response_deflate_none;
-    std::string response_gzip_none;
-
-    auto on_body = [](http_parser* parser, const char* body, size_t body_length) -> int {
-        std::string* body_ptr = reinterpret_cast<std::string*>(parser->data);
-        *body_ptr = std::string(body, body + body_length);
-
-        return 0;
-    };
-
-    http_parser_settings settings{};
-    settings.on_body = on_body;
-
     asio::io_service is;
     {
-      // Compression
-      {
-        asio::ip::tcp::socket socket[2] = {asio::ip::tcp::socket(is), asio::ip::tcp::socket(is)};
-    socket[0].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-    socket[1].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
+        // Compression
+        {
+            asio::ip::tcp::socket socket[2] = {asio::ip::tcp::socket(is), asio::ip::tcp::socket(is)};
+            socket[0].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+            socket[1].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
 
-    socket[0].send(asio::buffer(test_compress_msg));
-    socket[1].send(asio::buffer(test_compress_msg));
+            socket[0].send(asio::buffer(test_compress_msg));
+            socket[1].send(asio::buffer(test_compress_msg));
 
-    size_t bytes_deflate = socket[0].receive(asio::buffer(buf_deflate, 2048));
-    size_t bytes_gzip = socket[1].receive(asio::buffer(buf_gzip, 2048));
+            socket[0].receive(asio::buffer(buf_deflate, 2048));
+            socket[1].receive(asio::buffer(buf_gzip, 2048));
 
-    http_parser parser[2] = {{}, {}};
-    http_parser_init(&parser[0], HTTP_RESPONSE);
-    http_parser_init(&parser[1], HTTP_RESPONSE);
-    parser[0].data = reinterpret_cast<void*>(&response_deflate);
-    parser[1].data = reinterpret_cast<void*>(&response_gzip);
+            std::string response_deflate;
+            std::string response_gzip;
 
-    http_parser_execute(&parser[0], &settings, buf_deflate, bytes_deflate);
-    http_parser_execute(&parser[1], &settings, buf_gzip, bytes_gzip);
+            for (unsigned i{0}; i<2048; i++)
+            {
+                if (buf_deflate[i] == 0)
+                {
+                    bool end = true;
+                    for(unsigned j=i;j<2048;j++)
+                    {
+                        if (buf_deflate[j]!=0)
+                        {
+                            end = false;
+                            break;
+                        }
+                    }
+                    if (end)
+                    {
+                        response_deflate.push_back(0);
+                        response_deflate.push_back(0);
+                        break;
+                    }
+                }
+                response_deflate.push_back(buf_deflate[i]);
+            }
 
-    response_deflate = inflate_string(response_deflate);
-    response_gzip = inflate_string(response_gzip);
+            for (unsigned i{0}; i<2048; i++)
+            {
+                if (buf_gzip[i] == 0)
+                {
+                    bool end = true;
+                    for(unsigned j=i;j<2048;j++)
+                    {
+                        if (buf_gzip[j]!=0)
+                        {
+                            end = false;
+                            break;
+                        }
+                    }
+                    if (end)
+                    {
+                        response_deflate.push_back(0);
+                        response_deflate.push_back(0);
+                        break;
+                    }
+                }
+                response_gzip.push_back(buf_gzip[i]);
+            }
 
-    socket[0].close();
-    socket[1].close();
-}
-// No Header (thus no compression)
-{
-    asio::ip::tcp::socket socket[2] = {asio::ip::tcp::socket(is), asio::ip::tcp::socket(is)};
-    socket[0].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-    socket[1].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
+            response_deflate = inflate_string(response_deflate.substr(response_deflate.find("\r\n\r\n")+4));
+            response_gzip = inflate_string(response_gzip.substr(response_gzip.find("\r\n\r\n")+4));
 
-    socket[0].send(asio::buffer(test_compress_no_header_msg));
-    socket[1].send(asio::buffer(test_compress_no_header_msg));
+            socket[0].close();
+            socket[1].close();
+            CHECK(expected_string == response_deflate);
+            CHECK(expected_string == response_gzip);
+        }
+        // No Header (thus no compression)
+        {
+            asio::ip::tcp::socket socket[2] = {asio::ip::tcp::socket(is), asio::ip::tcp::socket(is)};
+            socket[0].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+            socket[1].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
 
-    size_t bytes_deflate = socket[0].receive(asio::buffer(buf_deflate, 2048));
-    size_t bytes_gzip = socket[1].receive(asio::buffer(buf_gzip, 2048));
+            socket[0].send(asio::buffer(test_compress_no_header_msg));
+            socket[1].send(asio::buffer(test_compress_no_header_msg));
 
-    http_parser parser[2] = {{}, {}};
-    http_parser_init(&parser[0], HTTP_RESPONSE);
-    http_parser_init(&parser[1], HTTP_RESPONSE);
-    parser[0].data = reinterpret_cast<void*>(&response_deflate_no_header);
-    parser[1].data = reinterpret_cast<void*>(&response_gzip_no_header);
+            socket[0].receive(asio::buffer(buf_deflate, 2048));
+            socket[1].receive(asio::buffer(buf_gzip, 2048));
 
-    http_parser_execute(&parser[0], &settings, buf_deflate, bytes_deflate);
-    http_parser_execute(&parser[1], &settings, buf_gzip, bytes_gzip);
+            std::string response_deflate(buf_deflate);
+            std::string response_gzip(buf_gzip);
+            response_deflate = response_deflate.substr(98);
+            response_gzip = response_gzip.substr(98);
 
-    socket[0].close();
-    socket[1].close();
-}
-// No compression
-{
-    asio::ip::tcp::socket socket[2] = {asio::ip::tcp::socket(is), asio::ip::tcp::socket(is)};
-    socket[0].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-    socket[1].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
+            socket[0].close();
+            socket[1].close();
+            CHECK(expected_string == response_deflate);
+            CHECK(expected_string == response_gzip);
+        }
+        // No compression
+        {
+            asio::ip::tcp::socket socket[2] = {asio::ip::tcp::socket(is), asio::ip::tcp::socket(is)};
+            socket[0].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+            socket[1].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
 
-    socket[0].send(asio::buffer(test_none_msg));
-    socket[1].send(asio::buffer(test_none_msg));
+            socket[0].send(asio::buffer(test_none_msg));
+            socket[1].send(asio::buffer(test_none_msg));
 
-    size_t bytes_deflate = socket[0].receive(asio::buffer(buf_deflate, 2048));
-    size_t bytes_gzip = socket[1].receive(asio::buffer(buf_gzip, 2048));
+            socket[0].receive(asio::buffer(buf_deflate, 2048));
+            socket[1].receive(asio::buffer(buf_gzip, 2048));
 
-    http_parser parser[2] = {{}, {}};
-    http_parser_init(&parser[0], HTTP_RESPONSE);
-    http_parser_init(&parser[1], HTTP_RESPONSE);
-    parser[0].data = reinterpret_cast<void*>(&response_deflate_none);
-    parser[1].data = reinterpret_cast<void*>(&response_gzip_none);
+            std::string response_deflate(buf_deflate);
+            std::string response_gzip(buf_gzip);
+            response_deflate = response_deflate.substr(98);
+            response_gzip = response_gzip.substr(98);
 
-    http_parser_execute(&parser[0], &settings, buf_deflate, bytes_deflate);
-    http_parser_execute(&parser[1], &settings, buf_gzip, bytes_gzip);
+            socket[0].close();
+            socket[1].close();
+            CHECK(expected_string == response_deflate);
+            CHECK(expected_string == response_gzip);
+        }
+    }
 
-    socket[0].close();
-    socket[1].close();
-}
-}
-{
-    CHECK(expected_string == response_deflate);
-    CHECK(expected_string == response_gzip);
-
-    CHECK(expected_string == response_deflate_no_header);
-    CHECK(expected_string == response_gzip_no_header);
-
-    CHECK(expected_string == response_deflate_none);
-    CHECK(expected_string == response_gzip_none);
-}
-
-app_deflate.stop();
-app_gzip.stop();
+    app_deflate.stop();
+    app_gzip.stop();
 } // zlib_compression
 #endif
 


### PR DESCRIPTION
In a nutshell, This PR:
- Removes any code that parses HTTP responses.
- Integrates certain parts of the parser into the rest of the framework (such as the HTTP method list and string access function, and builtin_expect).
- Integrates existing framework parts into the parser (such as the HTTP method enum).
- Removes functions in the framework that are already carried out by the parser.
- Adds 2 HTTP version integers to the `request`.
- Fixes a problem where a Crow application would not be able to parse a multipart request made using .Net `HttpClient` (due to the boundary being wrapped with quotation marks (`"`)).
- Distinguishes between cleartext and SSL HTTP/2 headers.
- Fixes a problem introduced in (#292) where the connection is closed on every data transfer when a response is streamed (as opposed to once everything has been sent).
- Adds indications as to who wrote a `NOTE` or `TODO`.

More detailed explanation of the changes will be provided as review comments to make the code changes easy to digest.

Closes #306, #320, #331