### PR TITLE
CORS Middleware

### DIFF
--- a/examples/middlewares/cors.h
+++ b/examples/middlewares/cors.h
@@ -1,0 +1,33 @@
+#include "crow.h"
+#include "crow/middlewares/cors.h"
+
+
+int main()
+{
+    // Enable CORS
+    crow::App<crow::CORSHandler> app;
+
+    // Customize CORS
+    auto& cors = app.get_middleware<crow::CORSHandler>();
+    // Default rules
+    cors.global()
+      .methods("POST"_method, "GET"_method);
+    // Rules for prefix /cors
+    cors.prefix("/cors")
+      .origin("example.com");
+
+
+    CROW_ROUTE(app, "/")
+    ([]() {
+        return "Check Access-Control-Allow-Methods header";
+    });
+
+    CROW_ROUTE(app, "/cors")
+    ([]() {
+        return "Check Access-Control-Allow-Origin header";
+    });
+
+    app.port(18080).run();
+
+    return 0;
+}

--- a/examples/middlewares/cors.h
+++ b/examples/middlewares/cors.h
@@ -9,13 +9,17 @@ int main()
 
     // Customize CORS
     auto& cors = app.get_middleware<crow::CORSHandler>();
-    // Default rules
-    cors.global()
-      .methods("POST"_method, "GET"_method);
-    // Rules for prefix /cors
-    cors.prefix("/cors")
-      .origin("example.com");
 
+    // clang-format off
+    cors
+      .global()
+        .headers("X-Custom-Header", "Upgrade-Insecure-Requests")
+        .methods("POST"_method, "GET"_method)
+      .prefix("/cors")
+        .origin("example.com")
+      .prefix("/nocors")
+        .ignore();
+    // clang-format on
 
     CROW_ROUTE(app, "/")
     ([]() {

--- a/include/crow/middlewares/cors.h
+++ b/include/crow/middlewares/cors.h
@@ -10,8 +10,8 @@ namespace crow
     struct CORSRules
     {
         friend struct crow::CORSHandler;
-        // Set Access-Control-Allow-Origin. Default is "*"
 
+        // Set Access-Control-Allow-Origin. Default is "*"
         CORSRules& origin(const std::string& origin)
         {
             origin_ = origin;
@@ -64,13 +64,14 @@ namespace crow
             return *this;
         }
 
-        // Ignore CORS
+        // Ignore CORS and don't send any headers
         void ignore()
         {
             ignore_ = true;
         }
 
     private:
+        // build comma separated list
         void add_list_item(std::string& list, const std::string& val)
         {
             if (list == "*") list = "";
@@ -78,6 +79,7 @@ namespace crow
             list += val;
         }
 
+        // Set header `key` to `value` if it is not set
         void set_header(const std::string& key, const std::string& value, crow::response& res)
         {
             if (value.size() == 0) return;
@@ -85,6 +87,7 @@ namespace crow
             res.add_header(key, value);
         }
 
+        // Set response headers
         void apply(crow::response& res)
         {
             if (ignore_) return;
@@ -96,6 +99,7 @@ namespace crow
         }
 
         bool ignore_ = false;
+        // TODO: support multiple origins that are dynamically selected
         std::string origin_ = "*";
         std::string methods_ = "*";
         std::string headers_ = "*";
@@ -103,7 +107,11 @@ namespace crow
         bool allow_credentials_ = false;
     };
 
-    // CORSHandler is used for enforcing CORS policies
+    /// CORSHandler is a global middleware for setting CORS headers.
+    ///
+    /// By default, it sets Access-Control-Allow-Origin/Methods/Headers to "*".
+    /// The default behaviour can be changed with the `global()` cors rule.
+    /// Additional rules for prexies can be added with `prefix()`.
     struct CORSHandler
     {
         struct context

--- a/include/crow/middlewares/cors.h
+++ b/include/crow/middlewares/cors.h
@@ -1,0 +1,151 @@
+#pragma once
+#include "crow/http_request.h"
+#include "crow/http_response.h"
+
+namespace crow
+{
+    struct CORSHandler;
+
+    // CORSRules is used for tuning cors policies
+    struct CORSRules
+    {
+        friend struct crow::CORSHandler;
+        // Set Access-Control-Allow-Origin. Default is "*"
+
+        CORSRules& origin(const std::string& origin)
+        {
+            origin_ = origin;
+            return *this;
+        }
+
+        // Set Access-Control-Allow-Methods. Default is "*"
+        CORSRules& methods(crow::HTTPMethod method)
+        {
+            add_list_item(methods_, crow::method_name(method));
+            return *this;
+        }
+
+        // Set Access-Control-Allow-Methods. Default is "*"
+        template<typename... Methods>
+        CORSRules& methods(crow::HTTPMethod method, Methods... method_list)
+        {
+            add_list_item(methods_, crow::method_name(method));
+            methods(method_list...);
+            return *this;
+        }
+
+        // Set Access-Control-Allow-Headers. Default is "*"
+        CORSRules& headers(const std::string& header)
+        {
+            add_list_item(headers_, header);
+            return *this;
+        }
+
+        // Set Access-Control-Allow-Headers. Default is "*"
+        template<typename... Headers>
+        CORSRules& headers(const std::string& header, Headers... header_list)
+        {
+            add_list_item(headers_, header);
+            headers(header_list...);
+            return *this;
+        }
+
+        // Set Access-Control-Max-Age. Default is none
+        CORSRules& max_age(int max_age)
+        {
+            max_age_ = std::to_string(max_age);
+            return *this;
+        }
+
+        // Enable Access-Control-Allow-Credentials
+        CORSRules& allow_credentials()
+        {
+            allow_credentials_ = true;
+            return *this;
+        }
+
+        // Ignore CORS
+        void ignore()
+        {
+            ignore_ = true;
+        }
+
+    private:
+        void add_list_item(std::string& list, const std::string& val)
+        {
+            if (list == "*") list = "";
+            if (list.size() > 0) list += ", ";
+            list += val;
+        }
+
+        void set_header(const std::string& key, const std::string& value, crow::response& res)
+        {
+            if (value.size() == 0) return;
+            if (!get_header_value(res.headers, key).empty()) return;
+            res.add_header(key, value);
+        }
+
+        void apply(crow::response& res)
+        {
+            if (ignore_) return;
+            set_header("Access-Control-Allow-Origin", origin_, res);
+            set_header("Access-Control-Allow-Methods", methods_, res);
+            set_header("Access-Control-Allow-Headers", headers_, res);
+            set_header("Access-Control-Max-Age", max_age_, res);
+            if (allow_credentials_) set_header("Access-Control-Allow-Credentials", "true", res);
+        }
+
+        bool ignore_ = false;
+        std::string origin_ = "*";
+        std::string methods_ = "*";
+        std::string headers_ = "*";
+        std::string max_age_;
+        bool allow_credentials_ = false;
+    };
+
+    // CORSHandler is used for enforcing CORS policies
+    struct CORSHandler
+    {
+        struct context
+        {};
+
+        void before_handle(crow::request& /*req*/, crow::response& /*res*/, context& /*ctx*/)
+        {}
+
+        void after_handle(crow::request& req, crow::response& res, context& /*ctx*/)
+        {
+            auto& rule = find_rule(req.url);
+            rule.apply(res);
+        }
+
+        // Handle CORS on specific prefix path
+        CORSRules& prefix(const std::string& prefix)
+        {
+            rules.emplace_back(prefix, CORSRules{});
+            return rules.back().second;
+        }
+
+        // Global CORS policy
+        CORSRules& global()
+        {
+            return default_;
+        }
+
+    private:
+        CORSRules& find_rule(const std::string& path)
+        {
+            for (auto& rule : rules)
+            {
+                if (path.rfind(rule.first, 0) == 0)
+                {
+                    return rule.second;
+                }
+            }
+            return default_;
+        }
+
+        std::vector<std::pair<std::string, CORSRules>> rules;
+        CORSRules default_;
+    };
+
+} // namespace crow

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1531,7 +1531,7 @@ TEST_CASE("middleware_cors")
 
     auto& cors = app.get_middleware<crow::CORSHandler>();
     cors.prefix("/origin")
-        .origin("test.test");
+      .origin("test.test");
 
     CROW_ROUTE(app, "/")
     ([&](const request& req) {


### PR DESCRIPTION
Hi! I've implemented middleware for supporting CORS headers like discussed [here](https://github.com/CrowCpp/Crow/issues/224).

### What it looks like

CORSHandler is responsible for setting headers in after_handle. By default, it already enables CORS after being included as a middleware. The global rules and rules for certain prefixes can be changed as follows:

```c++
    crow::App<crow::CORSHandler> app;

    auto& cors = app.get_middleware<crow::CORSHandler>();

    cors
      .global()
        .methods("POST"_method, "GET"_method)
      .prefix("/cors")
        .origin("example.com")
        .headers("X-Custom-Header")
      .blueprint(bp)
        .ignore();
```

It resembles [Flasks resource specific CORS](https://flask-cors.readthedocs.io/en/latest/#resource-specific-cors) to some extent. But with a builder instead of dicts 🙂 

### What I've changed

`middlewares/cors.h` now contains the CORSHandler with CORSRules.

`examples/middlewares/cors.h` has a simple example for setting cors rules.

I've also added a simple test.

### Issues

1. Middleware is initialized by the app. This means that an additional 
```c++
auto& cors = app.get_middleware<crow::CORSHandler>();
```
is required for setting specific rules.

I also though of implementing a custom cors handler, which extends the default one

```c++
class MyCORS : public CORSHandler 
{
  MyCORS() 
  {
    // customize here
  }
}
``` 
This makes the code less imperative, but it makes it more difficult to customize it's behaviour dynamically (i.e. use variables from the main scope). This would also allow overwriting rules for handlers with local middleware.

2. Only one origin can be specified (The origin header can return only one). But at least some web frameworks allow specifying multiple, from which the one is automatically selected (if its the same origin)

3. There is no inheritance from global to prefix rules, i.e. rules are applied either from a prefix **or** the global handler. Should global rules be applied always? Or should they be independent from prefix rules? 