### PR TITLE
fixed multiple definition problem

### DIFF
--- a/include/crow/common.h
+++ b/include/crow/common.h
@@ -107,7 +107,7 @@ namespace crow
         // should not add an item below this line: used for array count
     };
 
-    const char* method_strings[] =
+    constexpr const char* method_strings[] =
       {
         "DELETE",
         "GET",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 endif()
 
 add_subdirectory(template)
+add_subdirectory(multi_file)
 if (CROW_ENABLE_SSL)
 	add_subdirectory(ssl)
 endif()

--- a/tests/multi_file/CMakeLists.txt
+++ b/tests/multi_file/CMakeLists.txt
@@ -1,0 +1,6 @@
+project(test_multi_file)
+
+file (GLOB_RECURSE SRC ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+add_executable(${PROJECT_NAME} ${SRC})
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(${PROJECT_NAME} PUBLIC Crow::Crow)

--- a/tests/multi_file/main.cpp
+++ b/tests/multi_file/main.cpp
@@ -1,0 +1,15 @@
+// Test of a project containing more than 1 source file which includes Crow headers.
+// The test succeeds if the project is linked successfully.
+#include "crow.h"
+
+int main()
+{
+    crow::SimpleApp app;
+
+    CROW_ROUTE(app, "/")
+    ([]() {
+        return "Hello, world!";
+    });
+
+    app.port(18080).run();
+}

--- a/tests/multi_file/secondary.cpp
+++ b/tests/multi_file/secondary.cpp
@@ -1,0 +1,1 @@
+#include <crow.h>


### PR DESCRIPTION
Also added a test that fails to link in case of multiple definitions.

Thanks to @nekoffski for reporting the issue and providing the original test I based mine on.

Closes #350.