### PR TITLE
Support for `CROW_USE_LOCALTIMEZONE` for using localtime in logs

### DIFF
--- a/include/crow/logging.h
+++ b/include/crow/logging.h
@@ -72,9 +72,17 @@ namespace crow
             tm my_tm;
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
+#ifdef CROW_USE_LOCALTIMEZONE
+            localtime_s(&my_tm, &t);
+#else
             gmtime_s(&my_tm, &t);
+#endif
+#else
+#ifdef CROW_USE_LOCALTIMEZONE
+            localtime_r(&t, &my_tm);
 #else
             gmtime_r(&t, &my_tm);
+#endif
 #endif
 
             size_t sz = strftime(date, sizeof(date), "%Y-%m-%d %H:%M:%S", &my_tm);


### PR DESCRIPTION
Hi @The-EDev 

This changes `gmtime_*` to `localtime_*` to use local dates in the logs. Most other HTTP servers usually use local date time by default, hence changing this. 

Also wanted your views if this should be configurable or not using a `#ifdef`? What do you think?