### PR TITLE
Split up operator""_method

### DIFF
--- a/include/crow/common.h
+++ b/include/crow/common.h
@@ -279,7 +279,7 @@ namespace crow
 
 // clang-format off
 #ifndef CROW_MSVC_WORKAROUND
-constexpr crow::HTTPMethod operator"" _method(const char* str, size_t /*len*/)
+constexpr crow::HTTPMethod method_from_string(const char* str) {
 {
     return crow::black_magic::is_equ_p(str, "GET", 3)    ? crow::HTTPMethod::Get :
            crow::black_magic::is_equ_p(str, "DELETE", 6) ? crow::HTTPMethod::Delete :
@@ -323,6 +323,11 @@ constexpr crow::HTTPMethod operator"" _method(const char* str, size_t /*len*/)
 
            crow::black_magic::is_equ_p(str, "SOURCE", 6) ? crow::HTTPMethod::Source :
                                                            throw std::runtime_error("invalid http method");
+}
+
+constexpr crow::HTTPMethod operator""_method(const char* str, size_t /*len*/) 
+{
+    return method_from_string( str );
 }
 #endif
 // clang-format on


### PR DESCRIPTION
When wrapping calls to crow from other code bases, I have had to call `operator""_method` explicitly.  Breaking it into two methods, `method_from_string` and `operator""_method` allows one to compose this code elsewhere.