### PR TITLE
#380: Update CMake config.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,7 +34,7 @@ steps:
   - export CXX=/usr/bin/g++
   - mkdir build
   - cd build
-  - cmake .. -DCROW_ENABLE_COMPRESSION=ON -DCROW_ENABLE_SSL=ON -DCROW_AMALGAMATE=ON
+  - cmake .. -DCROW_FEATURES="ssl;compression" -DCROW_AMALGAMATE=ON
   - make -j4
   - ctest -V -j4
   - cd ..
@@ -48,7 +48,7 @@ steps:
   - export CXX=/usr/bin/clang++
   - mkdir build-clang
   - cd build-clang
-  - cmake .. -DCROW_ENABLE_COMPRESSION=ON -DCROW_ENABLE_SSL=ON -DCROW_AMALGAMATE=ON
+  - cmake .. -DCROW_FEATURES="ssl;compression" -DCROW_AMALGAMATE=ON
   - make -j4
   - ctest -V -j4
 
@@ -77,7 +77,7 @@ steps:
   - mkdir build
   - cd build
   - cmake --version
-  - cmake .. -DCROW_ENABLE_COMPRESSION=ON -DCROW_ENABLE_SSL=ON -DCROW_AMALGAMATE=ON
+  - cmake .. -DCROW_FEATURES="ssl;compression" -DCROW_AMALGAMATE=ON
   - make -j4
   - ctest -V -j4
   - cd ..
@@ -85,7 +85,7 @@ steps:
   - export CXX=/usr/bin/clang++
   - mkdir build-clang
   - cd build-clang
-  - cmake .. -DCROW_ENABLE_COMPRESSION=ON -DCROW_ENABLE_SSL=ON -DCROW_AMALGAMATE=ON
+  - cmake .. -DCROW_FEATURES="ssl;compression" -DCROW_AMALGAMATE=ON
   - make -j4
   - ctest -V -j4
 
@@ -133,7 +133,7 @@ steps:
   - export CXX=/usr/bin/g++
   - mkdir build
   - cd build
-  - cmake .. -DCROW_ENABLE_COMPRESSION=ON -DCROW_ENABLE_SSL=ON -DCROW_AMALGAMATE=ON
+  - cmake .. -DCROW_FEATURES="ssl;compression" -DCROW_AMALGAMATE=ON
   - make -j4
   - ctest -V -j4
   - cd ..
@@ -142,7 +142,7 @@ steps:
   - export CXX=/usr/bin/clang++
   - mkdir build-clang
   - cd build-clang
-  - cmake .. -DCROW_ENABLE_COMPRESSION=ON -DCROW_ENABLE_SSL=ON -DCROW_AMALGAMATE=ON
+  - cmake .. -DCROW_FEATURES="ssl;compression" -DCROW_AMALGAMATE=ON
   - make -j4
   - ctest -V -j4
   - cd ..
@@ -174,7 +174,7 @@ steps:
   - mkdir build
   - cd build
   - cmake --version
-  - cmake .. -DCROW_ENABLE_COMPRESSION=ON -DCROW_ENABLE_SSL=ON -DCROW_AMALGAMATE=ON
+  - cmake .. -DCROW_FEATURES="ssl;compression" -DCROW_AMALGAMATE=ON
   - make -j4
   - ctest -V -j4
   - cd ..
@@ -182,7 +182,7 @@ steps:
   - export CXX=/usr/bin/clang++
   - mkdir build-clang
   - cd build-clang
-  - cmake .. -DCROW_ENABLE_COMPRESSION=ON -DCROW_ENABLE_SSL=ON -DCROW_AMALGAMATE=ON
+  - cmake .. -DCROW_FEATURES="ssl;compression" -DCROW_AMALGAMATE=ON
   - make -j4
   - ctest -V -j4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
   - mkdir build
   - cd build
   - cmake --version
-  - cmake .. -DCROW_ENABLE_COMPRESSION=ON -DCROW_ENABLE_SSL=ON -DCROW_AMALGAMATE=ON
+  - cmake .. -DCROW_FEATURES="ssl;compression" -DCROW_AMALGAMATE=ON
 
 script: make -j4 && ctest -V -j4
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,8 @@ option(CROW_BUILD_TESTS        "Build the tests in the project"         ${CROW_I
 option(CROW_AMALGAMATE         "Combine all headers into one"           OFF)
 option(CROW_INSTALL            "Add install step for Crow"              ON )
 
-option(CROW_ENABLE_SSL         "Enable SSL capabilities (OpenSSL)"      OFF)
-option(CROW_ENABLE_COMPRESSION "Enable compression capabilities (ZLIB)" OFF)
+# Possible values: ssl, compression
+option(CROW_FEATURES					 "Enable features extending Crow's abilities" "")
 
 #####################################
 # Define Targets
@@ -61,13 +61,13 @@ target_link_libraries(Crow
 		Threads::Threads
 )
 
-if(CROW_ENABLE_COMPRESSION)
+if("compression" IN_LIST CROW_FEATURES)
 	find_package(ZLIB REQUIRED)
 	target_link_libraries(Crow INTERFACE ZLIB::ZLIB)
 	target_compile_definitions(Crow INTERFACE CROW_ENABLE_COMPRESSION)
 endif()
 
-if(CROW_ENABLE_SSL)
+if("ssl" IN_LIST CROW_FEATURES)
 	find_package(OpenSSL REQUIRED)
 	target_link_libraries(Crow INTERFACE OpenSSL::SSL)
 	target_compile_definitions(Crow INTERFACE CROW_ENABLE_SSL)
@@ -92,11 +92,11 @@ endif()
 
 # Tests
 if(NOT MSVC AND CROW_BUILD_TESTS)
-	if(NOT CROW_ENABLE_COMPRESSION)
-		message(STATUS "Compression tests are omitted. (Configure with CROW_ENABLE_COMPRESSION=ON to enable them)")
+	if(NOT "compression" IN_LIST CROW_FEATURES)
+		message(STATUS "Compression tests are omitted. (Configure with CROW_FEATURES containing 'compression' to enable them)")
 	endif()
-	if(NOT CROW_ENABLE_SSL)
-		message(STATUS "SSL tests are omitted. (Configure with CROW_ENABLE_SSL=ON to enable them)")
+	if(NOT "ssl" IN_LIST CROW_FEATURES)
+		message(STATUS "SSL tests are omitted. (Configure with CROW_FEATURES containing 'ssl' to enable them)")
 	else()
 		add_test(NAME ssl_test COMMAND ${CMAKE_CURRENT_BINARY_DIR}/tests/ssl/ssltest)
 	endif()

--- a/cmake/CrowConfig.cmake.in
+++ b/cmake/CrowConfig.cmake.in
@@ -4,11 +4,17 @@ include(CMakeFindDependencyMacro)
 find_dependency(Boost 1.64 COMPONENTS system date_time)
 find_dependency(Threads)
 
-if(CROW_ENABLE_COMPRESSION)
+set(CROW_INSTALLED_FEATURES "@CROW_FEATURES@")
+
+if(NOT DEFINED CROW_FEATURES)
+  set(CROW_FEATURES ${CROW_INSTALLED_FEATURES})
+endif()
+
+if("compression" IN_LIST CROW_FEATURES)
   find_dependency(ZLIB)
 endif()
 
-if(CROW_ENABLE_SSL)
+if("ssl" IN_LIST CROW_FEATURES)
   find_dependency(OpenSSL)
 endif()
 
@@ -21,12 +27,12 @@ get_target_property(_CROW_ICD Crow::Crow INTERFACE_COMPILE_DEFINITIONS)
 list(REMOVE_ITEM _CROW_ILL "ZLIB::ZLIB" "OpenSSL::SSL")
 list(REMOVE_ITEM _CROW_ICD "CROW_ENABLE_SSL" "CROW_ENABLE_COMPRESSION")
 
-if(CROW_ENABLE_COMPRESSION)
+if("compression" IN_LIST CROW_FEATURES)
   list(APPEND _CROW_ILL "ZLIB::ZLIB")
   list(APPEND _CROW_ICD "CROW_ENABLE_COMPRESSION")
 endif()
 
-if(CROW_ENABLE_SSL)
+if("ssl" IN_LIST CROW_FEATURES)
   list(APPEND _CROW_ILL "OpenSSL::SSL")
   list(APPEND _CROW_ICD "CROW_ENABLE_SSL")
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,7 +8,7 @@ add_warnings_optimizations(helloworld)
 target_link_libraries(helloworld PUBLIC Crow::Crow)
 
 # If compression is enabled, the example will be built
-if(CROW_ENABLE_COMPRESSION)
+if("compression" IN_LIST CROW_FEATURES)
   add_executable(example_compression example_compression.cpp)
   add_warnings_optimizations(example_compression)
   target_link_libraries(example_compression Crow::Crow)
@@ -17,7 +17,7 @@ else()
 endif()
 
 # If SSL is enabled, the example will be built
-if(CROW_ENABLE_SSL)
+if("ssl" IN_LIST CROW_FEATURES)
   add_executable(example_ssl ssl/example_ssl.cpp)
   add_warnings_optimizations(example_ssl)
   target_link_libraries(example_ssl PUBLIC Crow::Crow)

--- a/include/crow/settings.h
+++ b/include/crow/settings.h
@@ -8,9 +8,6 @@
 /* #ifdef - enables logging */
 #define CROW_ENABLE_LOGGING
 
-/* #ifdef - enables ssl */
-//#define CROW_ENABLE_SSL
-
 /* #ifdef - enforces section 5.2 and 6.1 of RFC6455 (only accepting masked messages from clients) */
 //#define CROW_ENFORCE_WS_SPEC
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 
 add_subdirectory(template)
 add_subdirectory(multi_file)
-if (CROW_ENABLE_SSL)
+if ("ssl" IN_LIST CROW_FEATURES)
 	add_subdirectory(ssl)
 endif()
 add_subdirectory(img)


### PR DESCRIPTION
This is the follow-up of and partially fixes #380.

Crow's features (ssl and compression) can now be enabled through `CROW_FEATURES` instead of their own CMake variables.
The default features are the ones Crow was installed with but can be overridden by setting `CROW_FEATURES` before the `find_package` call.

```cmake
cmake_minimum_required(VERSION 3.17)
project(CrowTest)

add_executable(test main.cpp)

# Some examples:
# set(CROW_FEATURES "")
# set(CROW_FEATURES "ssl;compression")
# set(CROW_FEATURES ssl compression)
# set(CROW_FEATURES ssl)
find_package(Crow REQUIRED)
target_link_libraries(test Crow::Crow)
```

Using the CMake CLI features are given as a semicolon-separated list:
```bash
cmake .. -DCROW_FEATURES="ssl;compression"
```

Documentation needs an update to align with the changes made in this PR.

Signed-off-by: Luca Schlecker <luca.schlecker@hotmail.com>