### PR TITLE
Fixed issue where SSL websockets wouldn't run due to HTTP upgrade

### DIFF
--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -129,27 +129,12 @@ namespace crow
                 }
                 if (req.upgrade)
                 {
-#ifdef CROW_ENABLE_SSL
-                    if (handler_->ssl_used())
-                    {
-                        if (req.get_header_value("upgrade") == "h2")
-                        {
-                            // TODO(ipkn): HTTP/2
-                            // currently, ignore upgrade header
-                        }
-                    }
-                    else if (req.get_header_value("upgrade") == "h2c")
+                    // h2 or h2c headers
+                    if (req.get_header_value("upgrade").substr(0, 2) == "h2")
                     {
                         // TODO(ipkn): HTTP/2
                         // currently, ignore upgrade header
                     }
-#else
-                    if (req.get_header_value("upgrade") == "h2c")
-                    {
-                        // TODO(ipkn): HTTP/2
-                        // currently, ignore upgrade header
-                    }
-#endif
                     else
                     {
                         close_connection_ = true;


### PR DESCRIPTION
originally reported by @jeanbiber on [Gitter](https://gitter.im/crowfork/community). This PR also simplifies the process of detecting the HTTP/2 upgrade header.