### PR TITLE
Add `std::remove_reference` to CROW_MIDDLEWARES

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -29,7 +29,7 @@
 #else
 #define CROW_ROUTE(app, url) app.route<crow::black_magic::get_parameter_tag(url)>(url)
 #define CROW_BP_ROUTE(blueprint, url) blueprint.new_rule_tagged<crow::black_magic::get_parameter_tag(url)>(url)
-#define CROW_MIDDLEWARES(app, ...) middlewares<decltype(app), __VA_ARGS__>()
+#define CROW_MIDDLEWARES(app, ...) middlewares<std::remove_reference<decltype(app)>::type, __VA_ARGS__>()
 #endif
 #define CROW_CATCHALL_ROUTE(app) app.catchall_route()
 #define CROW_BP_CATCHALL_ROUTE(blueprint) blueprint.catchall_rule()


### PR DESCRIPTION
Fixed issue where Crow wouldn't compile when using `CROW_MIDDLEWARES` with a pass-by-reference app.

Fixes #391.