### PR TITLE
Allow compiling on GCC 4.8

### DIFF
--- a/include/crow/common.h
+++ b/include/crow/common.h
@@ -325,7 +325,7 @@ constexpr crow::HTTPMethod method_from_string(const char* str)
                                                            throw std::runtime_error("invalid http method");
 }
 
-constexpr crow::HTTPMethod operator""_method(const char* str, size_t /*len*/) 
+constexpr crow::HTTPMethod operator"" _method(const char* str, size_t /*len*/)
 {
     return method_from_string( str );
 }

--- a/include/crow/middleware.h
+++ b/include/crow/middleware.h
@@ -200,39 +200,24 @@ namespace crow
             static const bool value = decltype(f<MW>(nullptr))::value;
         };
 
-        // wrapped_handler_call transparently wraps a handler call behind (req, res, args...)
         template<typename F, typename... Args>
-        typename std::enable_if<black_magic::is_callable<F, const crow::request, crow::response&, Args...>::value>::type
-          wrapped_handler_call(crow::request& req, crow::response& res, const F& f, Args&&... args)
-        {
-            static_assert(std::is_same<void, decltype(f(std::declval<crow::request>(), std::declval<crow::response&>(), std::declval<Args>()...))>::value,
-                          "Handler function with response argument should have void return type");
-
-            f(req, res, std::forward<Args>(args)...);
-        }
-
-        template<typename F, typename... Args>
-        typename std::enable_if<black_magic::is_callable<F, crow::request&, crow::response&, Args...>::value && !black_magic::is_callable<F, const crow::request, crow::response&, Args...>::value>::type
-          wrapped_handler_call(crow::request& req, crow::response& res, const F& f, Args&&... args)
-        {
-            static_assert(std::is_same<void, decltype(f(std::declval<crow::request&>(), std::declval<crow::response&>(), std::declval<Args>()...))>::value,
-                          "Handler function with response argument should have void return type");
-
-            f(req, res, std::forward<Args>(args)...);
-        }
-
-        template<typename F, typename... Args>
-        typename std::enable_if<black_magic::is_callable<F, crow::response&, Args...>::value>::type
+        //typename std::enable_if<black_magic::is_callable<F, Args...>::value>::type
+        typename std::enable_if<black_magic::CallHelper<F, black_magic::S<Args...>>::value, void>::type
           wrapped_handler_call(crow::request& /*req*/, crow::response& res, const F& f, Args&&... args)
         {
-            static_assert(std::is_same<void, decltype(f(std::declval<crow::response&>(), std::declval<Args>()...))>::value,
-                          "Handler function with response argument should have void return type");
+            static_assert(!std::is_same<void, decltype(f(std::declval<Args>()...))>::value,
+                          "Handler function cannot have void return type; valid return types: string, int, crow::response, crow::returnable");
 
-            f(res, std::forward<Args>(args)...);
+            res = crow::response(f(std::forward<Args>(args)...));
+            res.end();
         }
 
         template<typename F, typename... Args>
-        typename std::enable_if<black_magic::is_callable<F, crow::request, Args...>::value>::type
+        //typename std::enable_if<black_magic::is_callable<F, crow::request, Args...>::value>::type
+        typename std::enable_if<
+          !black_magic::CallHelper<F, black_magic::S<Args...>>::value &&
+            black_magic::CallHelper<F, black_magic::S<crow::request&, Args...>>::value,
+          void>::type
           wrapped_handler_call(crow::request& req, crow::response& res, const F& f, Args&&... args)
         {
             static_assert(!std::is_same<void, decltype(f(std::declval<crow::request>(), std::declval<Args>()...))>::value,
@@ -243,14 +228,51 @@ namespace crow
         }
 
         template<typename F, typename... Args>
-        typename std::enable_if<black_magic::is_callable<F, Args...>::value>::type
+        //typename std::enable_if<black_magic::is_callable<F, crow::response&, Args...>::value>::type
+        typename std::enable_if<
+          !black_magic::CallHelper<F, black_magic::S<Args...>>::value &&
+            !black_magic::CallHelper<F, black_magic::S<crow::request&, Args...>>::value &&
+            black_magic::CallHelper<F, black_magic::S<crow::response&, Args...>>::value,
+          void>::type
           wrapped_handler_call(crow::request& /*req*/, crow::response& res, const F& f, Args&&... args)
         {
-            static_assert(!std::is_same<void, decltype(f(std::declval<Args>()...))>::value,
-                          "Handler function cannot have void return type; valid return types: string, int, crow::response, crow::returnable");
+            static_assert(std::is_same<void, decltype(f(std::declval<crow::response&>(), std::declval<Args>()...))>::value,
+                          "Handler function with response argument should have void return type");
 
-            res = crow::response(f(std::forward<Args>(args)...));
-            res.end();
+            f(res, std::forward<Args>(args)...);
+        }
+
+        template<typename F, typename... Args>
+        //typename std::enable_if<black_magic::is_callable<F, crow::request&, crow::response&, Args...>::value && !black_magic::is_callable<F, const crow::request, crow::response&, Args...>::value>::type
+        typename std::enable_if<
+          !black_magic::CallHelper<F, black_magic::S<Args...>>::value &&
+            !black_magic::CallHelper<F, black_magic::S<crow::request&, Args...>>::value &&
+            !black_magic::CallHelper<F, black_magic::S<crow::response&, Args...>>::value &&
+          black_magic::CallHelper<F, black_magic::S<const crow::request&, crow::response&, Args...>>::value,
+          void>::type
+          wrapped_handler_call(crow::request& req, crow::response& res, const F& f, Args&&... args)
+        {
+            static_assert(std::is_same<void, decltype(f(std::declval<crow::request&>(), std::declval<crow::response&>(), std::declval<Args>()...))>::value,
+                          "Handler function with response argument should have void return type");
+
+            f(req, res, std::forward<Args>(args)...);
+        }
+
+        // wrapped_handler_call transparently wraps a handler call behind (req, res, args...)
+        template<typename F, typename... Args>
+        typename std::enable_if<
+          !black_magic::CallHelper<F, black_magic::S<Args...>>::value &&
+            !black_magic::CallHelper<F, black_magic::S<crow::request&, Args...>>::value &&
+            !black_magic::CallHelper<F, black_magic::S<crow::response&, Args...>>::value &&
+            !black_magic::CallHelper<F, black_magic::S<const crow::request&, crow::response&, Args...>>::value,
+          void>::type
+          //typename std::enable_if<black_magic::is_callable<F, const crow::request, crow::response&, Args...>::value>::type
+          wrapped_handler_call(crow::request& req, crow::response& res, const F& f, Args&&... args)
+        {
+            static_assert(std::is_same<void, decltype(f(std::declval<crow::request&>(), std::declval<crow::response&>(), std::declval<Args>()...))>::value,
+                          "Handler function with response argument should have void return type");
+
+            f(req, res, std::forward<Args>(args)...);
         }
 
         template<typename F, typename App, typename... Middlewares>

--- a/include/crow/middleware.h
+++ b/include/crow/middleware.h
@@ -248,7 +248,7 @@ namespace crow
           !black_magic::CallHelper<F, black_magic::S<Args...>>::value &&
             !black_magic::CallHelper<F, black_magic::S<crow::request&, Args...>>::value &&
             !black_magic::CallHelper<F, black_magic::S<crow::response&, Args...>>::value &&
-          black_magic::CallHelper<F, black_magic::S<const crow::request&, crow::response&, Args...>>::value,
+            black_magic::CallHelper<F, black_magic::S<const crow::request&, crow::response&, Args...>>::value,
           void>::type
           wrapped_handler_call(crow::request& req, crow::response& res, const F& f, Args&&... args)
         {

--- a/include/crow/middleware.h
+++ b/include/crow/middleware.h
@@ -201,7 +201,6 @@ namespace crow
         };
 
         template<typename F, typename... Args>
-        //typename std::enable_if<black_magic::is_callable<F, Args...>::value>::type
         typename std::enable_if<black_magic::CallHelper<F, black_magic::S<Args...>>::value, void>::type
           wrapped_handler_call(crow::request& /*req*/, crow::response& res, const F& f, Args&&... args)
         {
@@ -213,7 +212,6 @@ namespace crow
         }
 
         template<typename F, typename... Args>
-        //typename std::enable_if<black_magic::is_callable<F, crow::request, Args...>::value>::type
         typename std::enable_if<
           !black_magic::CallHelper<F, black_magic::S<Args...>>::value &&
             black_magic::CallHelper<F, black_magic::S<crow::request&, Args...>>::value,
@@ -228,7 +226,6 @@ namespace crow
         }
 
         template<typename F, typename... Args>
-        //typename std::enable_if<black_magic::is_callable<F, crow::response&, Args...>::value>::type
         typename std::enable_if<
           !black_magic::CallHelper<F, black_magic::S<Args...>>::value &&
             !black_magic::CallHelper<F, black_magic::S<crow::request&, Args...>>::value &&
@@ -243,7 +240,6 @@ namespace crow
         }
 
         template<typename F, typename... Args>
-        //typename std::enable_if<black_magic::is_callable<F, crow::request&, crow::response&, Args...>::value && !black_magic::is_callable<F, const crow::request, crow::response&, Args...>::value>::type
         typename std::enable_if<
           !black_magic::CallHelper<F, black_magic::S<Args...>>::value &&
             !black_magic::CallHelper<F, black_magic::S<crow::request&, Args...>>::value &&
@@ -266,7 +262,6 @@ namespace crow
             !black_magic::CallHelper<F, black_magic::S<crow::response&, Args...>>::value &&
             !black_magic::CallHelper<F, black_magic::S<const crow::request&, crow::response&, Args...>>::value,
           void>::type
-          //typename std::enable_if<black_magic::is_callable<F, const crow::request, crow::response&, Args...>::value>::type
           wrapped_handler_call(crow::request& req, crow::response& res, const F& f, Args&&... args)
         {
             static_assert(std::is_same<void, decltype(f(std::declval<crow::request&>(), std::declval<crow::response&>(), std::declval<Args>()...))>::value,

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -233,6 +233,8 @@ namespace crow
             template<template<typename... Args> class U>
             using rebind = U<T...>;
         };
+
+        // Check whether the template function can be called with specific arguments
         template<typename F, typename Set>
         struct CallHelper;
         template<typename F, typename... Args>
@@ -262,19 +264,6 @@ namespace crow
         template<typename T, typename... Ts>
         struct has_type<T, std::tuple<T, Ts...>> : std::true_type
         {};
-
-        // Check F is callable with Args
-        template<typename F, typename... Args>
-        struct is_callable
-        {
-            template<typename F2, typename... Args2>
-            static std::true_type __test(decltype(std::declval<F2>()(std::declval<Args2>()...))*);
-
-            template<typename F2, typename... Args2>
-            static std::false_type __test(...);
-
-            static constexpr bool value = decltype(__test<F, Args...>(nullptr))::value;
-        };
 
         // Kind of fold expressions in C++11
         template<bool...>

--- a/tests/ssl/ssltest.cpp
+++ b/tests/ssl/ssltest.cpp
@@ -73,7 +73,7 @@ TEST_CASE("SSL")
         }
         else
         {
-            CHECK(std::string("Hello world, I'm keycrt.").substr((z*-1)) == to_test);
+            CHECK(std::string("Hello world, I'm keycrt.").substr((z * -1)) == to_test);
         }
     }
 

--- a/tests/ssl/ssltest.cpp
+++ b/tests/ssl/ssltest.cpp
@@ -55,6 +55,7 @@ TEST_CASE("SSL")
 
         size_t x = 0;
         size_t y = 0;
+        long z = 0;
 
         while (x < 121)
         {
@@ -63,7 +64,17 @@ TEST_CASE("SSL")
             buf[y] = '\0';
         }
 
-        CHECK(std::string("Hello world, I'm keycrt.") == std::string(buf));
+        std::string to_test(buf);
+
+        if ((z = to_test.length() - 24) >= 0)
+        {
+
+            CHECK(std::string("Hello world, I'm keycrt.") == to_test.substr(z));
+        }
+        else
+        {
+            CHECK(std::string("Hello world, I'm keycrt.").substr((z*-1)) == to_test);
+        }
     }
 
     /*


### PR DESCRIPTION
For some reason, `is_callable` does not work with GCC 4.8. This is most likely a bug with g++ itself.
`CallHelper`, which `is_callable` was meant to replace seems to work fine while compiling on g++ 4.8. I've run the tests and compiled the examples, everything seems to be fine.

@dranikpg I would very much appreciate your opinion on this since you wrote `is_callable` and have more experience with templates than myself.

This PR is a draft because I'm not 100% sure the changes I made are sound and won't introduce bugs down the line.

Fixes #386.