### PR TITLE
Concatenate log into one string and sending to std::cerr instead of multiple << operator

### DIFF
--- a/include/crow/logging.h
+++ b/include/crow/logging.h
@@ -60,7 +60,7 @@ namespace crow
                     prefix = "CRITICAL";
                     break;
             }
-            std::cerr << "(" << timestamp() << ") [" << prefix << "] " << message << std::endl;
+            std::cerr << std::string("(") + timestamp() + std::string(") [") + prefix + std::string("] ") + message << std::endl;
         }
 
     private:


### PR DESCRIPTION
During my test, under high concurrency, stderr log from multiple thread will be splitted into multiple line. After concat string into one string, output to stderr then flush buffer, stderr log becomes one full string.