### PR TITLE
Cookieparser attributes

### DIFF
--- a/docs/guides/CORS.md
+++ b/docs/guides/CORS.md
@@ -1,7 +1,0 @@
-Crow Allows a developer to set CORS policies by using the `CORSHandler` middleware.<br><br>
-
-This middleware can be added to the app simply by defining a `#!cpp crow::App<crow::CORSHandler>`. This will use the default CORS rules globally<br><br>
-
-The CORS rules can be modified by first getting the middleware via `#!cpp auto& cors = app.get_middleware<crow::CORSHandler>();`. The rules can be set per URL prefix using `prefix()`, per blueprint using `blueprint()`, or globally via `global()`. These will return a `CORSRules` object which contains the actual rules for the prefix, blueprint, or application. For more details go [here](../../reference/structcrow_1_1_c_o_r_s_handler.html).
-
-`CORSRules` can  be modified using the methods `origin()`, `methods()`, `headers()`, `max_age()`, `allow_credentials()`, or `ignore()`. For more details on these methods and what default values they take go [here](../../reference/structcrow_1_1_c_o_r_s_rules.html).

--- a/docs/guides/included-middleware.md
+++ b/docs/guides/included-middleware.md
@@ -1,5 +1,5 @@
 Crow contains some middlewares that are ready to be used in your application.
-
+<br>
 Make sure you understand how to enable and use [middleware](../middleware/).
 
 ## Cookies
@@ -10,7 +10,7 @@ This middleware allows to read and write cookies by using `CookieParser`. Once e
 
 Cookies can be read and written with the middleware context. All cookie attributes can be changed as well.
 
-```c++
+```cpp
 auto& ctx = app.get_context<crow::CookieParser>(request);
 std::string value = ctx.get_cookie("key");
 ctx.set_cookie("key", "value")
@@ -18,7 +18,9 @@ ctx.set_cookie("key", "value")
     .max_age(120);
 ```
 
-**Note**: Make sure the CookieParser is listed before other middleware that relies on it
+!!! note
+
+    Make sure `CookieParser` is listed before any other middleware that relies on it.
 
 ## CORS
 Include: `crow/middlewares/cors.h` <br>
@@ -30,7 +32,7 @@ The CORS rules can be modified by first getting the middleware via `#!cpp auto& 
 
 `CORSRules` can  be modified using the methods `origin()`, `methods()`, `headers()`, `max_age()`, `allow_credentials()`, or `ignore()`. For more details on these methods and what default values they take go [here](../../reference/structcrow_1_1_c_o_r_s_rules.html).
 
-```c++
+```cpp
 auto& cors = app.get_middleware<crow::CORSHandler>();
 cors
   .global()

--- a/docs/guides/included-middleware.md
+++ b/docs/guides/included-middleware.md
@@ -1,0 +1,41 @@
+Crow contains some middlewares that are ready to be used in your application.
+
+Make sure you understand how to enable and use [middleware](../middleware/).
+
+## Cookies
+Include: `crow/middlewares/cookie_parser.h` <br>
+Examples: `examples/middlewars/example_cookies.cpp`
+
+This middleware allows to read and write cookies by using `CookieParser`. Once enabled, it parses all incoming cookies.
+
+Cookies can be read and written with the middleware context. All cookie attributes can be changed as well.
+
+```c++
+auto& ctx = app.get_context<crow::CookieParser>(request);
+std::string value = ctx.get_cookie("key");
+ctx.set_cookie("key", "value")
+    .path("/")
+    .max_age(120);
+```
+
+**Note**: Make sure the CookieParser is listed before other middleware that relies on it
+
+## CORS
+Include: `crow/middlewares/cors.h` <br>
+Examples: `examples/middlewars/example_cors.cpp`
+
+This middleware allows to set CORS policies by using `CORSHandler`. Once enabled, it will apply the default CORS rules globally.
+
+The CORS rules can be modified by first getting the middleware via `#!cpp auto& cors = app.get_middleware<crow::CORSHandler>();`. The rules can be set per URL prefix using `prefix()`, per blueprint using `blueprint()`, or globally via `global()`. These will return a `CORSRules` object which contains the actual rules for the prefix, blueprint, or application. For more details go [here](../../reference/structcrow_1_1_c_o_r_s_handler.html).
+
+`CORSRules` can  be modified using the methods `origin()`, `methods()`, `headers()`, `max_age()`, `allow_credentials()`, or `ignore()`. For more details on these methods and what default values they take go [here](../../reference/structcrow_1_1_c_o_r_s_rules.html).
+
+```c++
+auto& cors = app.get_middleware<crow::CORSHandler>();
+cors
+  .global()
+    .headers("X-Custom-Header", "Upgrade-Insecure-Requests")
+    .methods("POST"_method, "GET"_method)
+  .prefix("/cors")
+    .origin("example.com");
+```

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -87,6 +87,10 @@ add_executable(example_cors middlewares/example_cors.cpp)
 add_warnings_optimizations(example_cors)
 target_link_libraries(example_cors PUBLIC Crow::Crow)
 
+add_executable(example_cookies middlewares/example_cookies.cpp)
+add_warnings_optimizations(example_cookies)
+target_link_libraries(example_cookies PUBLIC Crow::Crow)
+
 if(MSVC)
   add_executable(example_vs example_vs.cpp)
   add_warnings_optimizations(example_vs)

--- a/examples/middlewares/example_cookies.cpp
+++ b/examples/middlewares/example_cookies.cpp
@@ -1,0 +1,32 @@
+#include "crow.h"
+#include "crow/middlewares/cookie_parser.h"
+
+int main()
+{
+    // Include CookieParser middleware
+    crow::App<crow::CookieParser> app;
+
+    CROW_ROUTE(app, "/read")
+    ([&](const crow::request& req) {
+        auto& ctx = app.get_context<crow::CookieParser>(req);
+        // Read cookies with get_cookie
+        auto value = ctx.get_cookie("key");
+        return "value: " + value;
+    });
+
+    CROW_ROUTE(app, "/write")
+    ([&](const crow::request& req) {
+        auto& ctx = app.get_context<crow::CookieParser>(req);
+        // Store cookies with set_cookie
+        ctx.set_cookie("key", "word")
+          // configure additional parameters
+          .path("/")
+          .max_age(120)
+          .httponly();
+        return "ok!";
+    });
+
+    app.port(18080).run();
+
+    return 0;
+}

--- a/include/crow/middlewares/cookie_parser.h
+++ b/include/crow/middlewares/cookie_parser.h
@@ -58,8 +58,8 @@ namespace crow
                 std::stringstream ss;
                 ss << key_ << '=';
                 ss << (value_.empty() ? "\"\"" : value_);
-                dumpString(ss, !domain_.empty(), "Domain=", {domain_});
-                dumpString(ss, !path_.empty(), "Path=", {path_});
+                dumpString(ss, !domain_.empty(), "Domain=", domain_);
+                dumpString(ss, !path_.empty(), "Path=", path_);
                 dumpString(ss, secure_, "Secure");
                 dumpString(ss, httponly_, "HttpOnly");
                 if (expires_at_)
@@ -143,13 +143,12 @@ namespace crow
             Cookie() = default;
 
             static void dumpString(std::stringstream& ss, bool cond, const char* prefix,
-                                   boost::optional<const std::string&> value = boost::none)
+                                   const std::string& value = "")
             {
                 if (cond)
                 {
-                    ss << DIVIDER << prefix;
-                    if (value) ss << *value;
-                };
+                    ss << DIVIDER << prefix << value;
+                }
             }
 
         private:

--- a/include/crow/middlewares/cookie_parser.h
+++ b/include/crow/middlewares/cookie_parser.h
@@ -50,7 +50,6 @@ namespace crow
                 value_ = std::forward<U>(value);
             }
 
-
             // format cookie to HTTP header format
             std::string format() const
             {
@@ -67,7 +66,7 @@ namespace crow
                     ss.imbue(std::locale(std::locale::classic(), HTTP_FACET));
                     ss << *expires_at_;
                 }
-                if (max_age_ > 0) ss << DIVIDER << "Max-Age=" << max_age_;
+                if (max_age_) ss << DIVIDER << "Max-Age=" << *max_age_;
                 if (!domain_.empty()) ss << DIVIDER << "Domain=" << domain_;
                 if (!path_.empty()) ss << DIVIDER << "Path=" << path_;
                 if (secure_) ss << DIVIDER << "Secure";
@@ -152,7 +151,7 @@ namespace crow
         private:
             std::string key_;
             std::string value_;
-            long long max_age_ = 0;
+            boost::optional<long long> max_age_{};
             std::string domain_ = "";
             std::string path_ = "";
             bool secure_ = false;

--- a/include/crow/middlewares/cookie_parser.h
+++ b/include/crow/middlewares/cookie_parser.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <boost/date_time.hpp>
+#include <iomanip>
 #include <boost/optional.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include "crow/http_request.h"
@@ -54,8 +54,7 @@ namespace crow
             std::string format() const
             {
                 const static std::string DIVIDER = "; ";
-                const static auto* HTTP_FACET =
-                  new boost::posix_time::time_facet("%a, %d %b %Y %H:%M:%S GMT");
+                const static char* HTTP_DATE_FORMAT = "%a, %d %b %Y %H:%M:%S GMT";
 
                 std::stringstream ss;
                 ss << key_ << '=';
@@ -63,8 +62,7 @@ namespace crow
                 if (expires_at_)
                 {
                     ss << DIVIDER << "Expires=";
-                    ss.imbue(std::locale(std::locale::classic(), HTTP_FACET));
-                    ss << *expires_at_;
+                    ss << std::put_time(expires_at_.get_ptr(), HTTP_DATE_FORMAT);
                 }
                 if (max_age_) ss << DIVIDER << "Max-Age=" << *max_age_;
                 if (!domain_.empty()) ss << DIVIDER << "Domain=" << domain_;
@@ -91,22 +89,16 @@ namespace crow
             }
 
             // Expires attribute
-            Cookie& expires(const boost::posix_time::ptime& time)
+            Cookie& expires(const std::tm& time)
             {
                 expires_at_ = time;
                 return *this;
             }
 
             // Max-Age attribute
-            Cookie& max_age(long long age)
+            Cookie& max_age(long long seconds)
             {
-                max_age_ = age;
-                return *this;
-            }
-
-            Cookie& max_age(const boost::posix_time::time_duration& dt)
-            {
-                max_age_ = dt.seconds();
+                max_age_ = seconds;
                 return *this;
             }
 
@@ -156,7 +148,7 @@ namespace crow
             std::string path_ = "";
             bool secure_ = false;
             bool httponly_ = false;
-            boost::optional<boost::posix_time::ptime> expires_at_{};
+            boost::optional<std::tm> expires_at_{};
             boost::optional<SameSitePolicy> same_site_{};
         };
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,7 +55,7 @@ nav:
             - Writing Tests: guides/testing.md
         - Using Crow:
             - HTTP Authorization: guides/auth.md
-            - CORS Setup: guides/CORS.md
+            - Included Middlewares: guides/included-middleware.md
         - Server setup:
             - Proxies: guides/proxies.md
             - Systemd run on startup: guides/syste.md

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1452,7 +1452,7 @@ TEST_CASE("local_middleware")
     app.stop();
 } // local_middleware
 
-TEST_CASE("middleware_cookieparser")
+TEST_CASE("middleware_cookieparser_parse")
 {
     static char buf[2048];
 
@@ -1499,8 +1499,55 @@ TEST_CASE("middleware_cookieparser")
         CHECK("val\"ue4" == value4);
     }
     app.stop();
-} // middleware_cookieparser
+} // middleware_cookieparser_parse
 
+
+TEST_CASE("middleware_cookieparser_format")
+{
+    using Cookie = CookieParser::Cookie;
+
+    auto valid = [](const std::string& s, int parts) {
+        return std::count(s.begin(), s.end(), ';') == parts - 1;
+    };
+
+    // basic
+    {
+        auto c = Cookie("key", "value");
+        auto s = c.format();
+        CHECK(valid(s, 1));
+        CHECK(s == "key=value");
+    }
+    // max-age + domain
+    {
+        auto c = Cookie("key", "value")
+                   .max_age(123)
+                   .domain("example.com");
+        auto s = c.format();
+        CHECK(valid(s, 3));
+        CHECK(s.find("key=value") != std::string::npos);
+        CHECK(s.find("Max-Age=123") != std::string::npos);
+        CHECK(s.find("Domain=example.com") != std::string::npos);
+    }
+    // samesite + secure
+    {
+        auto c = Cookie("key", "value")
+                   .secure()
+                   .same_site(Cookie::SameSitePolicy::None);
+        auto s = c.format();
+        CHECK(valid(s, 3));
+        CHECK(s.find("Secure") != std::string::npos);
+        CHECK(s.find("SameSite=None") != std::string::npos);
+    }
+    // expires
+    {
+        auto tp = boost::posix_time::time_from_string("2000-11-01 23:59:59.000");
+        auto c = Cookie("key", "value")
+                   .expires(tp);
+        auto s = c.format();
+        CHECK(valid(s, 2));
+        CHECK(s.find("Expires=Wed, 01 Nov 2000 23:59:59 GMT") != std::string::npos);
+    }
+} // middleware_cookieparser_format
 
 TEST_CASE("middleware_cors")
 {

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1542,7 +1542,7 @@ TEST_CASE("middleware_cookieparser_format")
     {
         auto tp = boost::posix_time::time_from_string("2000-11-01 23:59:59.000");
         auto c = Cookie("key", "value")
-                   .expires(tp);
+                   .expires(boost::posix_time::to_tm(tp));
         auto s = c.format();
         CHECK(valid(s, 2));
         CHECK(s.find("Expires=Wed, 01 Nov 2000 23:59:59 GMT") != std::string::npos);

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1513,7 +1513,7 @@ TEST_CASE("middleware_cookieparser_format")
     // basic
     {
         auto c = Cookie("key", "value");
-        auto s = c.format();
+        auto s = c.dump();
         CHECK(valid(s, 1));
         CHECK(s == "key=value");
     }
@@ -1522,7 +1522,7 @@ TEST_CASE("middleware_cookieparser_format")
         auto c = Cookie("key", "value")
                    .max_age(123)
                    .domain("example.com");
-        auto s = c.format();
+        auto s = c.dump();
         CHECK(valid(s, 3));
         CHECK(s.find("key=value") != std::string::npos);
         CHECK(s.find("Max-Age=123") != std::string::npos);
@@ -1533,7 +1533,7 @@ TEST_CASE("middleware_cookieparser_format")
         auto c = Cookie("key", "value")
                    .secure()
                    .same_site(Cookie::SameSitePolicy::None);
-        auto s = c.format();
+        auto s = c.dump();
         CHECK(valid(s, 3));
         CHECK(s.find("Secure") != std::string::npos);
         CHECK(s.find("SameSite=None") != std::string::npos);
@@ -1543,7 +1543,7 @@ TEST_CASE("middleware_cookieparser_format")
         auto tp = boost::posix_time::time_from_string("2000-11-01 23:59:59.000");
         auto c = Cookie("key", "value")
                    .expires(boost::posix_time::to_tm(tp));
-        auto s = c.format();
+        auto s = c.dump();
         CHECK(valid(s, 2));
         CHECK(s.find("Expires=Wed, 01 Nov 2000 23:59:59 GMT") != std::string::npos);
     }


### PR DESCRIPTION
Crows cookie_parser currently doesn't support setting any attributes on cookies (most importantly expires and path). I've added support for all available HTTP cookie attributes.

This helps #406 

Cookie parsers context allows now to set attributes in a builder style:
```c++
auto& cookie_ctx = app.get_context<crow::CookieParser>(req);
cookie_ctx.set_cookie("key", "value")
    .max_age(60)
    .path("/")
    .secure();
```

I've chosen boost for timepoints and durations as Crow already depends on it and `std::time_t`/`std::tm` are just horribly difficult to use.
