### PR TITLE
Fix for SecBug cpp/comparison-with-wider-type

### DIFF
--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -182,7 +182,9 @@ namespace crow
             uint16_t min_queue_idx = 0;
 
             // TODO improve load balancing
-            for (uint16_t i = 1; i < task_queue_length_pool_.size() && task_queue_length_pool_[min_queue_idx] > 0; i++)
+            // size_t is used here to avoid the security issue https://codeql.github.com/codeql-query-help/cpp/cpp-comparison-with-wider-type/
+            // even though the max value of this can be only uint16_t as concurrency is uint16_t.
+            for (size_t i = 1; i < task_queue_length_pool_.size() && task_queue_length_pool_[min_queue_idx] > 0; i++)
             // No need to check other io_services if the current one has no tasks
             {
                 if (task_queue_length_pool_[i] < task_queue_length_pool_[min_queue_idx])


### PR DESCRIPTION
The return type for vector.size() is `size_t` which is larger than `uint16_t` and hence an overflow can cause infinite loop.

Fixes this security bug https://codeql.github.com/codeql-query-help/cpp/cpp-comparison-with-wider-type/