### PR TITLE
Multiple small changes

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -2129,7 +2129,10 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = 
+PREDEFINED             = CROW_ENABLE_SSL \
+                         CROW_ENABLE_COMPRESSION \
+                         CROW_ENABLE_DEBUG \
+                         CROW_ENABLE_LOGGING
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/examples/example_static_file.cpp
+++ b/examples/example_static_file.cpp
@@ -1,4 +1,4 @@
-//#define CROW_STATIC_DRIECTORY "alternative_directory/"
+//#define CROW_STATIC_DIRECTORY "alternative_directory/"
 //#define CROW_STATIC_ENDPOINT "/alternative_endpoint/<path>"
 //#define CROW_DISABLE_STATIC_DIR
 #include "crow.h"

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -61,7 +61,7 @@ namespace crow
         /// Process an Upgrade request
 
         ///
-        /// Currently used to upgrrade an HTTP connection to a WebSocket connection
+        /// Currently used to upgrade an HTTP connection to a WebSocket connection
         template<typename Adaptor>
         void handle_upgrade(const request& req, response& res, Adaptor&& adaptor)
         {
@@ -342,7 +342,7 @@ namespace crow
 
 #ifdef CROW_ENABLE_SSL
 
-        /// use certificate and key files for SSL
+        /// Use certificate and key files for SSL
         self_t& ssl_file(const std::string& crt_filename, const std::string& key_filename)
         {
             ssl_used_ = true;
@@ -355,7 +355,7 @@ namespace crow
             return *this;
         }
 
-        /// use .pem file for SSL
+        /// Use .pem file for SSL
         self_t& ssl_file(const std::string& pem_filename)
         {
             ssl_used_ = true;

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -376,10 +376,7 @@ namespace crow
             ssl_context_.use_certificate_chain_file(crt_filename);
             ssl_context_.use_private_key_file(key_filename, ssl_context_t::pem);
             ssl_context_.set_options(
-              boost::asio::ssl::context::default_workarounds
-              | boost::asio::ssl::context::no_sslv2
-              | boost::asio::ssl::context::no_sslv3
-              );
+              boost::asio::ssl::context::default_workarounds | boost::asio::ssl::context::no_sslv2 | boost::asio::ssl::context::no_sslv3);
             return *this;
         }
 

--- a/include/crow/multipart.h
+++ b/include/crow/multipart.h
@@ -42,7 +42,7 @@ namespace crow
             return empty;
         }
 
-        /// Same as \ref get_header_value_Object() but for \ref multipart.header
+        /// Same as \ref get_header_value_object() but for \ref multipart.header
         template<typename T>
         inline const header& get_header_object(const T& headers, const std::string& key)
         {

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -1468,7 +1468,6 @@ namespace crow
                     allow = allow.substr(0, allow.size() - 2);
                     res = response(204);
                     res.set_header("Allow", allow);
-                    res.manual_length_header = true;
                     res.end();
                     return;
                 }
@@ -1486,7 +1485,6 @@ namespace crow
                         allow = allow.substr(0, allow.size() - 2);
                         res = response(204);
                         res.set_header("Allow", allow);
-                        res.manual_length_header = true;
                         res.end();
                         return;
                     }

--- a/include/crow/settings.h
+++ b/include/crow/settings.h
@@ -59,6 +59,6 @@
 #if __cplusplus > 201103L
 #define CROW_GCC83_WORKAROUND
 #else
-#error "GCC 8.1 - 8.3 has a bug that prevents crow from compiling with C++11. Please update GCC to > 8.3 or use C++ > 11."
+#error "GCC 8.1 - 8.3 has a bug that prevents Crow from compiling with C++11. Please update GCC to > 8.3 or use C++ > 11."
 #endif
 #endif


### PR DESCRIPTION
This PR introduces multiple changes that I felt were too small to put into 4 different branches.

Changes are as follows:
1. Allow SSL certificate chain files (closes #387)
2. have OPTIONS responses report content-length (fixes #402)
3. Allow Doxygen to document SSL, compression, logging, and debug parts of Crow.
4. fixed several typos (overrides #382)

Special Thanks to @jeanbiber for pointing out and fixing 1 and 2, and to @stephanecharette for pointing out some of the typos in 4.

Once this PR is merged, I'll copy some of the changes over to the `v1.0` branch and prepare the release of `v1.0+2`