### PR TITLE
Add reference to `Crow` in websocket connection 

### DIFF
--- a/examples/websocket/example_ws.cpp
+++ b/examples/websocket/example_ws.cpp
@@ -10,8 +10,7 @@ int main()
     std::mutex mtx;
     std::unordered_set<crow::websocket::connection*> users;
 
-    CROW_ROUTE(app, "/ws")
-      .websocket()
+    CROW_WEBSOCKET_ROUTE(app, "/ws")
       .onopen([&](crow::websocket::connection& conn) {
           CROW_LOG_INFO << "new websocket connection from " << conn.get_remote_ip();
           std::lock_guard<std::mutex> _(mtx);

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -29,6 +29,7 @@
 #else
 #define CROW_ROUTE(app, url) app.route<crow::black_magic::get_parameter_tag(url)>(url)
 #define CROW_BP_ROUTE(blueprint, url) blueprint.new_rule_tagged<crow::black_magic::get_parameter_tag(url)>(url)
+#define CROW_WEBSOCKET_ROUTE(app, url) app.route<crow::black_magic::get_parameter_tag(url)>(url).websocket<decltype(app)>(&app)
 #define CROW_MIDDLEWARES(app, ...) middlewares<std::remove_reference<decltype(app)>::type, __VA_ARGS__>()
 #endif
 #define CROW_CATCHALL_ROUTE(app) app.catchall_route()

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -417,6 +417,7 @@ namespace crow
             {
                 is_writing = true;
                 boost::asio::write(adaptor_.socket(), buffers_); // Write the response start / headers
+                cancel_deadline_timer();
                 if (res.body.length() > 0)
                 {
                     std::string buf;

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -368,13 +368,15 @@ namespace crow
 
     ///
     /// Provides the interface for the user to put in the necessary handlers for a websocket to work.
+    template<typename App>
     class WebSocketRule : public BaseRule
     {
         using self_t = WebSocketRule;
 
     public:
-        WebSocketRule(std::string rule):
-          BaseRule(std::move(rule))
+        WebSocketRule(std::string rule, App* app):
+          BaseRule(std::move(rule)),
+          app_(app)
         {}
 
         void validate() override
@@ -388,12 +390,12 @@ namespace crow
 
         void handle_upgrade(const request& req, response&, SocketAdaptor&& adaptor) override
         {
-            new crow::websocket::Connection<SocketAdaptor>(req, std::move(adaptor), open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_);
+            new crow::websocket::Connection<SocketAdaptor, App>(req, std::move(adaptor), app_, open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_);
         }
 #ifdef CROW_ENABLE_SSL
         void handle_upgrade(const request& req, response&, SSLAdaptor&& adaptor) override
         {
-            new crow::websocket::Connection<SSLAdaptor>(req, std::move(adaptor), open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_);
+            new crow::websocket::Connection<SSLAdaptor, App>(req, std::move(adaptor), app_, open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_);
         }
 #endif
 
@@ -433,6 +435,7 @@ namespace crow
         }
 
     protected:
+        App* app_;
         std::function<void(crow::websocket::connection&)> open_handler_;
         std::function<void(crow::websocket::connection&, const std::string&, bool)> message_handler_;
         std::function<void(crow::websocket::connection&, const std::string&)> close_handler_;
@@ -448,9 +451,11 @@ namespace crow
     struct RuleParameterTraits
     {
         using self_t = T;
-        WebSocketRule& websocket()
+
+        template<typename App>
+        WebSocketRule<App>& websocket(App* app)
         {
-            auto p = new WebSocketRule(static_cast<self_t*>(this)->rule_);
+            auto p = new WebSocketRule<App>(static_cast<self_t*>(this)->rule_, app);
             static_cast<self_t*>(this)->rule_to_upgrade_.reset(p);
             return *p;
         }

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -60,7 +60,7 @@ namespace crow
         //
 
         /// A websocket connection.
-        template<typename Adaptor>
+        template<typename Adaptor, typename Handler>
         class Connection : public connection
         {
         public:
@@ -69,14 +69,19 @@ namespace crow
             ///
             /// Requires a request with an "Upgrade: websocket" header.<br>
             /// Automatically handles the handshake.
-            Connection(const crow::request& req, Adaptor&& adaptor,
+            Connection(const crow::request& req, Adaptor&& adaptor, Handler* handler,
                        std::function<void(crow::websocket::connection&)> open_handler,
                        std::function<void(crow::websocket::connection&, const std::string&, bool)> message_handler,
                        std::function<void(crow::websocket::connection&, const std::string&)> close_handler,
                        std::function<void(crow::websocket::connection&)> error_handler,
                        std::function<bool(const crow::request&)> accept_handler):
               adaptor_(std::move(adaptor)),
-              open_handler_(std::move(open_handler)), message_handler_(std::move(message_handler)), close_handler_(std::move(close_handler)), error_handler_(std::move(error_handler)), accept_handler_(std::move(accept_handler))
+              handler_(handler),
+              open_handler_(std::move(open_handler)),
+              message_handler_(std::move(message_handler)),
+              close_handler_(std::move(close_handler)),
+              error_handler_(std::move(error_handler)),
+              accept_handler_(std::move(accept_handler))
             {
                 if (!boost::iequals(req.get_header_value("upgrade"), "websocket"))
                 {
@@ -609,6 +614,7 @@ namespace crow
 
         private:
             Adaptor adaptor_;
+            Handler* handler_;
 
             std::vector<std::string> sending_buffers_;
             std::vector<std::string> write_buffers_;

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2058,8 +2058,6 @@ TEST_CASE("stream_response")
     for (size_t i = 0; i < repetitions; i++)
         key_response += keyword_;
 
-    CROW_LOG_CRITICAL << "RES LENGTH: " << key_response.length();
-
     CROW_ROUTE(app, "/test")
     ([&key_response](const crow::request&, crow::response& res) {
         res.body = key_response;


### PR DESCRIPTION
Allow app to be passed to websocket.

Not ready for merging just yet because response streaming test was failing for some reason..

Snuck in: Cancel timeout timer for file and response streaming (should fix the problem where downloads timeout after 5 seconds)

Closes #422.