### PR TITLE
Add extra log when status code is not defined.

### DIFF
--- a/docs/guides/routes.md
+++ b/docs/guides/routes.md
@@ -27,6 +27,52 @@ You can change the HTTP methods the route uses from just the default `GET` by us
 
     Crow handles `HEAD` and `OPTIONS` methods automatically. So adding those to your handler has no effect.
 
+Crow defines the following methods:
+```
+DELETE
+GET
+HEAD
+POST
+PUT
+
+CONNECT
+OPTIONS
+TRACE
+
+PATCH
+PURGE
+
+COPY
+LOCK
+MKCOL
+MOVE
+PROPFIND
+PROPPATCH
+SEARCH
+UNLOCK
+BIND
+REBIND
+UNBIND
+ACL
+
+REPORT
+MKACTIVITY
+CHECKOUT
+MERGE
+
+SEARCH
+NOTIFY
+SUBSCRIBE
+UNSUBSCRIBE
+
+MKCALENDAR
+
+LINK
+UNLINK
+
+SOURCE
+```
+
 ## Handler
 Basically a piece of code that gets executed whenever the client calls the associated route, usually in the form of a [lambda expression](https://en.cppreference.com/w/cpp/language/lambda). It can be as simple as `#!cpp ([](){return "Hello World"})`.<br><br>
 
@@ -45,10 +91,57 @@ Please note that in order to return a response defined as a parameter you'll nee
 Alternatively, you can define the response in the body and return it (`#!cpp ([](){return crow::response()})`).<br>
 
 For more information on `crow::response` go [here](../../reference/structcrow_1_1response.html).<br><br>
+    
+Crow defines the following status codes:
+```
+100 Continue
+101 Switching Protocols
+
+200 OK
+201 Created
+202 Accepted
+203 Non-Authoritative Information
+204 No Content
+205 Reset Content
+206 Partial Content
+
+300 Multiple Choices
+301 Moved Permanently
+302 Found
+303 See Other
+304 Not Modified
+307 Temporary Redirect
+308 Permanent Redirect
+
+400 Bad Request
+401 Unauthorized
+403 Forbidden
+404 Not Found
+405 Method Not Allowed
+407 Proxy Authentication Required
+409 Conflict
+410 Gone
+413 Payload Too Large
+415 Unsupported Media Type
+416 Range Not Satisfiable
+417 Expectation Failed
+428 Precondition Required
+429 Too Many Requests
+451 Unavailable For Legal Reasons
+
+500 Internal Server Error
+501 Not Implemented
+502 Bad Gateway
+503 Service Unavailable
+504 Gateway Timeout
+506 Variant Also Negotiates
+```
+
 !!! note
 
-    When your status code is not well-known e.g. crow::response(123) it will get converted into 500.
-    
+    If your status code is not defined in the list above (e.g. `crow::response(123)`) Crow will return `500 Internal Server Error` instead.
+
+
 ### Return statement
 A `crow::response` is very strictly tied to a route. If you can have something in a response constructor, you can return it in a handler.<br><br>
 The main return type is `std::string`, although you could also return a `crow::json::wvalue` or `crow::multipart::message` directly.<br><br>

--- a/docs/guides/routes.md
+++ b/docs/guides/routes.md
@@ -11,7 +11,7 @@ Using `/hello` means the client will need to access `http://example.com/hello` i
 A path can have parameters, for example `/hello/<int>` will allow a client to input an int into the url which will be in the handler (something like `http://example.com/hello/42`).<br>
 Parameters can be `<int>`, `<uint>`, `<double>`, `<string>`, or `<path>`.<br>
 It's worth noting that the parameters also need to be defined in the handler, an example of using parameters would be to add 2 numbers based on input:
-```cpp 
+```cpp
 CROW_ROUTE(app, "/add/<int>/<int>")
 ([](int a, int b)
 {
@@ -45,7 +45,10 @@ Please note that in order to return a response defined as a parameter you'll nee
 Alternatively, you can define the response in the body and return it (`#!cpp ([](){return crow::response()})`).<br>
 
 For more information on `crow::response` go [here](../../reference/structcrow_1_1response.html).<br><br>
+!!! note
 
+    When your status code is not well-known e.g. crow::response(123) it will get converted into 500.
+    
 ### Return statement
 A `crow::response` is very strictly tied to a route. If you can have something in a response constructor, you can return it in a handler.<br><br>
 The main return type is `std::string`, although you could also return a `crow::json::wvalue` or `crow::multipart::message` directly.<br><br>
@@ -60,14 +63,14 @@ to use the returnable class, you only need your class to publicly extend `crow::
 
 Your class should look like the following:
 ```cpp
-class a : public crow::returnable 
+class a : public crow::returnable
 {
     a() : returnable("text/plain"){};
-    
+
     ...
     ...
     ...
-    
+
     std::string dump() override
     {
         return this.as_string();

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -317,11 +317,15 @@ namespace crow
             buffers_.reserve(4 * (res.headers.size() + 5) + 3);
 
             if (!statusCodes.count(res.code))
-                res.code = 500;
             {
-                auto& status = statusCodes.find(res.code)->second;
-                buffers_.emplace_back(status.data(), status.size());
+                CROW_LOG_WARNING << this << " status code "
+                                 << "(" << res.code << ")"
+                                 << " not defined, returning 500 instead";
+                res.code = 500;
             }
+
+            auto& status = statusCodes.find(res.code)->second;
+            buffers_.emplace_back(status.data(), status.size());
 
             if (res.code >= 400 && res.body.empty())
                 res.body = statusCodes[res.code].substr(9);

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -587,7 +587,7 @@ TEST_CASE("undefined_status_code")
         return response(200, "ok");
     });
 
-    auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(0).run_async();
+    auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45471).run_async();
     app.wait_for_server_start();
 
     asio::io_service is;
@@ -2081,11 +2081,13 @@ TEST_CASE("send_file")
 
         CHECK(200 == res.code);
 
-        REQUIRE(res.headers.count("Content-Type"));
-        CHECK("image/jpeg" == res.headers.find("Content-Type")->second);
+        CHECK(res.headers.count("Content-Type"));
+        if (res.headers.count("Content-Type"))
+            CHECK("image/jpeg" == res.headers.find("Content-Type")->second);
 
-        REQUIRE(res.headers.count("Content-Length"));
-        CHECK(to_string(statbuf_cat.st_size) == res.headers.find("Content-Length")->second);
+        CHECK(res.headers.count("Content-Length"));
+        if (res.headers.count("Content-Length"))
+            CHECK(to_string(statbuf_cat.st_size) == res.headers.find("Content-Length")->second);
     }
 
     //Unknown extension check
@@ -2098,11 +2100,13 @@ TEST_CASE("send_file")
 
         CHECK_NOTHROW(app.handle(req, res));
         CHECK(200 == res.code);
-        REQUIRE(res.headers.count("Content-Type"));
-        CHECK("text/plain" == res.headers.find("Content-Type")->second);
+        CHECK(res.headers.count("Content-Type"));
+        if (res.headers.count("Content-Type"))
+            CHECK("text/plain" == res.headers.find("Content-Type")->second);
 
-        REQUIRE(res.headers.count("Content-Length"));
-        CHECK(to_string(statbuf_badext.st_size) == res.headers.find("Content-Length")->second);
+        CHECK(res.headers.count("Content-Length"));
+        if (res.headers.count("Content-Length"))
+            CHECK(to_string(statbuf_badext.st_size) == res.headers.find("Content-Length")->second);
     }
 } // send_file
 


### PR DESCRIPTION
This refers to https://github.com/CrowCpp/Crow/issues/430

Just to document behaviour when returning a status that is not well-known.
This issue could be fixed in a better way in the future, because for know it is only observed when using actual TCP connection - 
simple UT that uses app.handle(req, res) will return user defined status code.

Added some extra check on UT that caused segfault on my pc.