### PR TITLE
erase websocket::connection from vector in App::remove_websocket()

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -370,7 +370,7 @@ namespace crow
 
         void remove_websocket(crow::websocket::connection* conn)
         {
-            std::remove(websockets_.begin(), websockets_.end(), conn);
+            websockets_.erase(std::remove(websockets_.begin(), websockets_.end(), conn), websockets_.end());
         }
 
         /// Print the routing paths defined for each HTTP method


### PR DESCRIPTION
As requested, this is the fix for https://github.com/CrowCpp/Crow/issues/449