### PR TITLE
Deboostify Crow

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
   - export TRAVIS_JOB_ID=$DRONE_BUILD_NUMBER
   - export COVERALLS_PULL_REQUEST=$DRONE_PULL_REQUEST
   - apt-get -y update
-  - apt-get -y install libboost-all-dev doxygen mkdocs graphviz zlib1g-dev gcc clang clang-format make cmake python3 python3-pip git openssl libssl-dev jq wget curl
+  - apt-get -y install libasio-dev doxygen mkdocs graphviz zlib1g-dev gcc clang clang-format make cmake python3 python3-pip git openssl libssl-dev jq wget curl
   - git clone https://github.com/CrowCpp/cpp-coveralls.git
   - cd cpp-coveralls
   - pip3 install . --no-input
@@ -73,7 +73,7 @@ steps:
   commands:
   - export DEBIAN_FRONTEND=noninteractive
   - apt-get -y update
-  - apt-get -y install libboost-all-dev zlib1g-dev gcc clang make cmake python3 openssl libssl-dev
+  - apt-get -y install libasio-dev zlib1g-dev gcc clang make cmake python3 openssl libssl-dev
   - mkdir build
   - cd build
   - cmake --version
@@ -123,7 +123,7 @@ steps:
   - export TRAVIS_BRANCH=$DRONE_REPO_BRANCH
   - export TRAVIS_JOB_ID=$DRONE_BUILD_NUMBER
   - apt-get -y update
-  - apt-get -y install libboost-all-dev doxygen mkdocs graphviz zlib1g-dev gcc clang make cmake python3 python3-pip git openssl libssl-dev
+  - apt-get -y install libasio-dev doxygen mkdocs graphviz zlib1g-dev gcc clang make cmake python3 python3-pip git openssl libssl-dev
   - pip3 install mkdocs-material mkdocs-redirects pyyaml mkdocs-meta-descriptions-plugin --no-input
   - git clone https://github.com/CrowCpp/cpp-coveralls.git
   - cd cpp-coveralls
@@ -170,7 +170,7 @@ steps:
   commands:
   - export DEBIAN_FRONTEND=noninteractive
   - apt-get -y update
-  - apt-get -y install libboost-all-dev zlib1g-dev gcc clang make cmake python3 openssl libssl-dev
+  - apt-get -y install libasio-dev zlib1g-dev gcc clang make cmake python3 openssl libssl-dev
   - mkdir build
   - cd build
   - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
 addons:
   apt:
     packages:
-      - libboost-all-dev
+      - libasio-dev
       - doxygen
       - mkdocs
       - graphviz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,13 +52,16 @@ target_include_directories(Crow
 		$<INSTALL_INTERFACE:include>
 )
 
-find_package(asio REQUIRED)
+find_path(ASIO_INCLUDE_DIR asio.hpp REQUIRED)
 find_package(Threads REQUIRED)
 
 target_link_libraries(Crow
 	INTERFACE
-		asio::asio
 		Threads::Threads
+)
+target_include_directories(Crow
+	INTERFACE
+		${ASIO_INCLUDE_DIR}
 )
 
 if("compression" IN_LIST CROW_FEATURES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,11 +53,13 @@ target_include_directories(Crow
 )
 
 find_package(Boost 1.64 COMPONENTS system date_time REQUIRED)
+find_package(asio REQUIRED)
 find_package(Threads REQUIRED)
 
 target_link_libraries(Crow
 	INTERFACE
 		Boost::boost Boost::system Boost::date_time
+		asio::asio
 		Threads::Threads
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,13 +52,11 @@ target_include_directories(Crow
 		$<INSTALL_INTERFACE:include>
 )
 
-find_package(Boost 1.64 COMPONENTS system date_time REQUIRED)
 find_package(asio REQUIRED)
 find_package(Threads REQUIRED)
 
 target_link_libraries(Crow
 	INTERFACE
-		Boost::boost Boost::system Boost::date_time
 		asio::asio
 		Threads::Threads
 )

--- a/cmake/CrowConfig.cmake.in
+++ b/cmake/CrowConfig.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(asio)
+find_path(ASIO_INCLUDE_DIR asio.hpp REQUIRED)
 find_dependency(Threads)
 
 set(CROW_INSTALLED_FEATURES "@CROW_FEATURES@")
@@ -40,4 +40,9 @@ endif()
 set_target_properties(Crow::Crow PROPERTIES
   INTERFACE_COMPILE_DEFINITIONS "${_CROW_ICD}"
   INTERFACE_LINK_LIBRARIES "${_CROW_ILL}"
+)
+
+target_include_directories(Crow::Crow
+  INTERFACE
+    ${ASIO_INCLUDE_DIR}
 )

--- a/cmake/CrowConfig.cmake.in
+++ b/cmake/CrowConfig.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Boost 1.64 COMPONENTS system date_time)
+find_dependency(asio)
 find_dependency(Threads)
 
 set(CROW_INSTALLED_FEATURES "@CROW_FEATURES@")

--- a/docs/getting_started/setup/linux.md
+++ b/docs/getting_started/setup/linux.md
@@ -3,7 +3,7 @@ Here's how you can install Crow on your favorite GNU/Linux distro.
 
 ### Requirements
  - C++ compiler with at least C++11 support.
- - boost library & development headers (1.64 or later).
+ - Asio development headers.
  - **(optional)** ZLib for HTTP Compression.
  - **(optional)** OpenSSL for HTTPS support.
  - **(optional)** CMake for building tests, examples, and/or installing Crow.
@@ -91,6 +91,3 @@ All you need to do is run the following command:
 g++ main.cpp -lpthread
 ```
 You can use arguments like `-DCROW_ENABLE_DEBUG`, `-DCROW_ENABLE_COMPRESSION -lz` for HTTP Compression, or `-DCROW_ENABLE_SSL -lssl` for HTTPS support, or even replace g++ with clang++.
-!!! warning
-
-    If you're using a version of boost prior to 1.69, you'll need to add the argument `-lboost_system` in order for you Crow application to compile correctly.

--- a/docs/getting_started/setup/linux.md
+++ b/docs/getting_started/setup/linux.md
@@ -3,7 +3,7 @@ Here's how you can install Crow on your favorite GNU/Linux distro.
 
 ### Requirements
  - C++ compiler with at least C++11 support.
- - Asio development headers.
+ - Asio development headers (1.10.9 or later).
  - **(optional)** ZLib for HTTP Compression.
  - **(optional)** OpenSSL for HTTPS support.
  - **(optional)** CMake for building tests, examples, and/or installing Crow.

--- a/docs/getting_started/setup/macos.md
+++ b/docs/getting_started/setup/macos.md
@@ -24,20 +24,20 @@ This will generate a `crow_all.h` file which you can use in the following steps
 ## Setting up your Crow project
 ### Using XCode
 1. Download and install [Homebrew](https://brew.sh).
-2. Run `brew install boost` in your terminal.
+2. Run `brew install asio` in your terminal.
 3. Create a new XCode project (macOS -> Command Line Tool).
 4. Change the following project settings:
 
     === "Multiple Headers"
 
-        1. Add header search paths for crow's include folder and boost's folder (`/usr/local/include`, `/usr/local/Cellar/boost/include`, and where you placed Crow's `include` folder)
-        2. Add linker flags (`-lpthread` and `-lboost_system` if you're running an old version of boost)
+        1. Add header search paths for crow's include folder and asio's folder (`/usr/local/include`, `/usr/local/Cellar/asio/include`, and where you placed Crow's `include` folder)
+        2. Add linker flags (`-lpthread`)
 
     === "Single Header"
 
         1. Place `crow_all.h` inside your project folder and add it to the project in XCode (you need to use File -> Add files to "project_name")
-        2. Add header search paths for boost's folder (`/usr/local/include`, and `/usr/local/Cellar/boost/include`)
-        3. Add linker flags (`-lpthread` and `-lboost_system` if you're running an old version of boost)
+        2. Add header search paths for asio's folder (`/usr/local/include`, and `/usr/local/Cellar/asio/include`)
+        3. Add linker flags (`-lpthread`)
 
 5. Write your Crow application in `main.cpp` (something like the Hello World example will work).
 6. Press `▶` to compile and run your Crow application.
@@ -49,7 +49,7 @@ This will generate a `crow_all.h` file which you can use in the following steps
     This tutorial can be used for Crow projects built with CMake as well
 
 1. Download and install [Homebrew](https://brew.sh).
-2. Run `brew install cmake boost` in your terminal.
+2. Run `brew install cmake asio` in your terminal.
 3. Get Crow's source code (the entire source code).
 3. Run the following Commands:
     1. `mkdir build`
@@ -70,6 +70,3 @@ g++ main.cpp -lpthread
     You'll need to install GCC via `brew install gcc`. the Clang compiler should be part of XCode or XCode command line tools.
 
 You can use arguments like `-DCROW_ENABLE_DEBUG`, `-DCROW_ENABLE_COMPRESSION -lz` for HTTP Compression, or `-DCROW_ENABLE_SSL -lssl` for HTTPS support, or even replace g++ with clang++.
-!!! warning
-
-    If you're using a version of boost prior to 1.69, you'll need to add the argument `-lboost_system` in order for you Crow application to compile correctly.

--- a/docs/guides/ssl.md
+++ b/docs/guides/ssl.md
@@ -10,8 +10,8 @@ To enable SSL, first your application needs to define either a `.crt` and `.key`
 
 You also need to define `CROW_ENABLE_SSL` in your compiler definitions (`g++ main.cpp -DCROW_ENABLE_SSL` for example) or `set(CROW_FEATURES ssl)` in `CMakeLists.txt`.
 
-You can also set your own SSL context (by using `boost::asio::ssl::context ctx`) and then applying it via the `#!cpp app.ssl(ctx)` method.<br><br>
+You can also set your own SSL context (by using `asio::ssl::context ctx`) and then applying it via the `#!cpp app.ssl(ctx)` method.<br><br>
 
 !!! warning
-    
+
     If you plan on using a proxy like Nginx or Apache2, **DO NOT** use SSL in crow, instead define it in your proxy and keep the connection between the proxy and Crow non-SSL.

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -41,14 +41,14 @@ This method involves creating a simple [ASIO](https://think-async.com/Asio/) cli
   app.wait_for_server_start();
 
   std::string sendmsg = "GET /\r\nContent-Length:3\r\nX-HeaderTest: 123\r\n\r\nA=B\r\n";
-  asio::io_service is;
+  boost::asio::io_service is;
   {
-    asio::ip::tcp::socket c(is);
-    c.connect(asio::ip::tcp::endpoint(asio::ip::address::from_string("127.0.0.1"), 45451));
+    boost::asio::ip::tcp::socket c(is);
+    c.connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string("127.0.0.1"), 45451));
 
-    c.send(asio::buffer(sendmsg));
+    c.send(boost::asio::buffer(sendmsg));
 
-    size_t recved = c.receive(asio::buffer(buf, 2048));
+    size_t recved = c.receive(boost::asio::buffer(buf, 2048));
     CHECK('A' == buf[recved - 1]); //This is specific to catch2 testing library, but it should give a general idea of how to read the response.
   }
 

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -41,14 +41,14 @@ This method involves creating a simple [ASIO](https://think-async.com/Asio/) cli
   app.wait_for_server_start();
 
   std::string sendmsg = "GET /\r\nContent-Length:3\r\nX-HeaderTest: 123\r\n\r\nA=B\r\n";
-  boost::asio::io_service is;
+  asio::io_service is;
   {
-    boost::asio::ip::tcp::socket c(is);
-    c.connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string("127.0.0.1"), 45451));
+    asio::ip::tcp::socket c(is);
+    c.connect(asio::ip::tcp::endpoint(asio::ip::address::from_string("127.0.0.1"), 45451));
 
-    c.send(boost::asio::buffer(sendmsg));
+    c.send(asio::buffer(sendmsg));
 
-    size_t recved = c.receive(boost::asio::buffer(buf, 2048));
+    size_t recved = c.receive(asio::buffer(buf, 2048));
     CHECK('A' == buf[recved - 1]); //This is specific to catch2 testing library, but it should give a general idea of how to read the response.
   }
 

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -1,7 +1,5 @@
 #include "crow.h"
 
-#include <sstream>
-
 class ExampleLogHandler : public crow::ILogHandler
 {
 public:
@@ -179,7 +177,7 @@ int main()
         // To see in action submit something like '/params?pew=42'
         if (req.url_params.get("pew") != nullptr)
         {
-            double countD = boost::lexical_cast<double>(req.url_params.get("pew"));
+            double countD = crow::utility::lexical_cast<double>(req.url_params.get("pew"));
             os << "The value of 'pew' is " << countD << '\n';
         }
 

--- a/examples/example_vs.cpp
+++ b/examples/example_vs.cpp
@@ -1,7 +1,5 @@
 #include "crow.h"
 
-#include <sstream>
-
 class ExampleLogHandler : public crow::ILogHandler
 {
 public:
@@ -110,7 +108,7 @@ int main()
         os << "The key 'foo' was " << (req.url_params.get("foo") == nullptr ? "not " : "") << "found.\n";
         if (req.url_params.get("pew") != nullptr)
         {
-            double countD = boost::lexical_cast<double>(req.url_params.get("pew"));
+            double countD = crow::utility::lexical_cast<double>(req.url_params.get("pew"));
             os << "The value of 'pew' is " << countD << '\n';
         }
         auto count = req.url_params.get_list("count");

--- a/examples/example_with_all.cpp
+++ b/examples/example_with_all.cpp
@@ -1,7 +1,5 @@
 #include "crow_all.h"
 
-#include <sstream>
-
 class ExampleLogHandler : public crow::ILogHandler
 {
 public:
@@ -100,7 +98,7 @@ int main()
         os << "The key 'foo' was " << (req.url_params.get("foo") == nullptr ? "not " : "") << "found.\n";
         if (req.url_params.get("pew") != nullptr)
         {
-            double countD = boost::lexical_cast<double>(req.url_params.get("pew"));
+            double countD = crow::utility::lexical_cast<double>(req.url_params.get("pew"));
             os << "The value of 'pew' is " << countD << '\n';
         }
         auto count = req.url_params.get_list("count");

--- a/examples/ssl/example_ssl.cpp
+++ b/examples/ssl/example_ssl.cpp
@@ -14,7 +14,7 @@ int main()
     // Use .pem file
     //app.port(18080).ssl_file("test.pem").run();
 
-    // Use custom context; see boost::asio::ssl::context
+    // Use custom context; see asio::ssl::context
     /*
      * crow::ssl_context_t ctx;
      * ctx.set_verify_mode(...)

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -39,7 +39,7 @@
 namespace crow
 {
 #ifdef CROW_ENABLE_SSL
-    using ssl_context_t = boost::asio::ssl::context;
+    using ssl_context_t = asio::ssl::context;
 #endif
     /// The main server application
 
@@ -379,12 +379,12 @@ namespace crow
         self_t& ssl_file(const std::string& crt_filename, const std::string& key_filename)
         {
             ssl_used_ = true;
-            ssl_context_.set_verify_mode(boost::asio::ssl::verify_peer);
-            ssl_context_.set_verify_mode(boost::asio::ssl::verify_client_once);
+            ssl_context_.set_verify_mode(asio::ssl::verify_peer);
+            ssl_context_.set_verify_mode(asio::ssl::verify_client_once);
             ssl_context_.use_certificate_file(crt_filename, ssl_context_t::pem);
             ssl_context_.use_private_key_file(key_filename, ssl_context_t::pem);
             ssl_context_.set_options(
-              boost::asio::ssl::context::default_workarounds | boost::asio::ssl::context::no_sslv2 | boost::asio::ssl::context::no_sslv3);
+              asio::ssl::context::default_workarounds | asio::ssl::context::no_sslv2 | asio::ssl::context::no_sslv3);
             return *this;
         }
 
@@ -392,11 +392,11 @@ namespace crow
         self_t& ssl_file(const std::string& pem_filename)
         {
             ssl_used_ = true;
-            ssl_context_.set_verify_mode(boost::asio::ssl::verify_peer);
-            ssl_context_.set_verify_mode(boost::asio::ssl::verify_client_once);
+            ssl_context_.set_verify_mode(asio::ssl::verify_peer);
+            ssl_context_.set_verify_mode(asio::ssl::verify_client_once);
             ssl_context_.load_verify_file(pem_filename);
             ssl_context_.set_options(
-              boost::asio::ssl::context::default_workarounds | boost::asio::ssl::context::no_sslv2 | boost::asio::ssl::context::no_sslv3);
+              asio::ssl::context::default_workarounds | asio::ssl::context::no_sslv2 | asio::ssl::context::no_sslv3);
             return *this;
         }
 
@@ -404,16 +404,16 @@ namespace crow
         self_t& ssl_chainfile(const std::string& crt_filename, const std::string& key_filename)
         {
             ssl_used_ = true;
-            ssl_context_.set_verify_mode(boost::asio::ssl::verify_peer);
-            ssl_context_.set_verify_mode(boost::asio::ssl::verify_client_once);
+            ssl_context_.set_verify_mode(asio::ssl::verify_peer);
+            ssl_context_.set_verify_mode(asio::ssl::verify_client_once);
             ssl_context_.use_certificate_chain_file(crt_filename);
             ssl_context_.use_private_key_file(key_filename, ssl_context_t::pem);
             ssl_context_.set_options(
-              boost::asio::ssl::context::default_workarounds | boost::asio::ssl::context::no_sslv2 | boost::asio::ssl::context::no_sslv3);
+              asio::ssl::context::default_workarounds | asio::ssl::context::no_sslv2 | asio::ssl::context::no_sslv3);
             return *this;
         }
 
-        self_t& ssl(boost::asio::ssl::context&& ctx)
+        self_t& ssl(asio::ssl::context&& ctx)
         {
             ssl_used_ = true;
             ssl_context_ = std::move(ctx);
@@ -540,7 +540,7 @@ namespace crow
 #ifdef CROW_ENABLE_SSL
         std::unique_ptr<ssl_server_t> ssl_server_;
         bool ssl_used_{false};
-        ssl_context_t ssl_context_{boost::asio::ssl::context::sslv23};
+        ssl_context_t ssl_context_{asio::ssl::context::sslv23};
 #endif
 
         std::unique_ptr<server_t> server_;

--- a/include/crow/ci_map.h
+++ b/include/crow/ci_map.h
@@ -3,6 +3,7 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/functional/hash.hpp>
 #include <unordered_map>
+#include "crow/utility.h"
 
 namespace crow
 {
@@ -28,7 +29,7 @@ namespace crow
     {
         bool operator()(const std::string& l, const std::string& r) const
         {
-            return boost::iequals(l, r);
+            return utility::string_equals(l, r);
         }
     };
 

--- a/include/crow/ci_map.h
+++ b/include/crow/ci_map.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/functional/hash.hpp>
+#include <locale>
 #include <unordered_map>
 #include "crow/utility.h"
 
@@ -16,11 +15,16 @@ namespace crow
             std::locale locale;
 
             for (auto c : key)
-            {
-                boost::hash_combine(seed, std::toupper(c, locale));
-            }
+                hash_combine(seed, std::toupper(c, locale));
 
             return seed;
+        }
+
+    private:
+        static inline void hash_combine(std::size_t& seed, char v)
+        {
+            std::hash<char> hasher;
+            seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
         }
     };
 

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -1,8 +1,6 @@
 #pragma once
 #define ASIO_STANDALONE
 #include <asio.hpp>
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/array.hpp>
 #include <atomic>
 #include <chrono>
 #include <vector>
@@ -590,7 +588,7 @@ namespace crow
         Adaptor adaptor_;
         Handler* handler_;
 
-        boost::array<char, 4096> buffer_;
+        std::array<char, 4096> buffer_;
 
         HTTPParser<Connection> parser_;
         request req_;

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -21,8 +21,7 @@
 
 namespace crow
 {
-    using namespace boost;
-    using tcp = asio::ip::tcp;
+    using tcp = boost::asio::ip::tcp;
 
 
 #ifdef CROW_ENABLE_DEBUG
@@ -382,7 +381,7 @@ namespace crow
                 char buf[16384];
                 while (is.read(buf, sizeof(buf)).gcount() > 0)
                 {
-                    std::vector<asio::const_buffer> buffers;
+                    std::vector<boost::asio::const_buffer> buffers;
                     buffers.push_back(boost::asio::buffer(buf));
                     do_write_sync(buffers);
                 }
@@ -425,7 +424,7 @@ namespace crow
                 if (res.body.length() > 0)
                 {
                     std::string buf;
-                    std::vector<asio::const_buffer> buffers;
+                    std::vector<boost::asio::const_buffer> buffers;
 
                     while (res.body.length() > 16384)
                     {
@@ -536,7 +535,7 @@ namespace crow
               });
         }
 
-        inline void do_write_sync(std::vector<asio::const_buffer>& buffers)
+        inline void do_write_sync(std::vector<boost::asio::const_buffer>& buffers)
         {
 
             boost::asio::write(adaptor_.socket(), buffers, [&](std::error_code ec, std::size_t) {

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -2,7 +2,6 @@
 #define ASIO_STANDALONE
 #include <asio.hpp>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/lexical_cast.hpp>
 #include <boost/array.hpp>
 #include <atomic>
 #include <chrono>
@@ -19,6 +18,7 @@
 #include "crow/middleware.h"
 #include "crow/socket_adaptors.h"
 #include "crow/compression.h"
+#include "crow/utility.h"
 
 namespace crow
 {
@@ -144,7 +144,7 @@ namespace crow
                 }
             }
 
-            CROW_LOG_INFO << "Request: " << boost::lexical_cast<std::string>(adaptor_.remote_endpoint()) << " " << this << " HTTP/" << (char)(req.http_ver_major + '0') << "." << (char)(req.http_ver_minor + '0') << ' ' << method_name(req.method) << " " << req.url;
+            CROW_LOG_INFO << "Request: " << utility::lexical_cast<std::string>(adaptor_.remote_endpoint()) << " " << this << " HTTP/" << (char)(req.http_ver_major + '0') << "." << (char)(req.http_ver_minor + '0') << ' ' << method_name(req.method) << " " << req.url;
 
 
             need_to_call_after_handlers_ = false;

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -77,7 +77,7 @@ namespace crow
 
         void start()
         {
-            adaptor_.start([this](const std::error_code& ec) {
+            adaptor_.start([this](const asio::error_code& ec) {
                 if (!ec)
                 {
                     start_deadline();
@@ -464,7 +464,7 @@ namespace crow
             is_reading = true;
             adaptor_.socket().async_read_some(
               asio::buffer(buffer_),
-              [this](const std::error_code& ec, std::size_t bytes_transferred) {
+              [this](const asio::error_code& ec, std::size_t bytes_transferred) {
                   bool error_while_reading = true;
                   if (!ec)
                   {
@@ -512,7 +512,7 @@ namespace crow
             is_writing = true;
             asio::async_write(
               adaptor_.socket(), buffers_,
-              [&](const std::error_code& ec, std::size_t /*bytes_transferred*/) {
+              [&](const asio::error_code& ec, std::size_t /*bytes_transferred*/) {
                   is_writing = false;
                   res.clear();
                   res_body_copy_.clear();
@@ -537,7 +537,7 @@ namespace crow
         inline void do_write_sync(std::vector<asio::const_buffer>& buffers)
         {
 
-            asio::write(adaptor_.socket(), buffers, [&](std::error_code ec, std::size_t) {
+            asio::write(adaptor_.socket(), buffers, [&](asio::error_code ec, std::size_t) {
                 if (!ec)
                 {
                     return false;

--- a/include/crow/http_request.h
+++ b/include/crow/http_request.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <boost/asio.hpp>
+#define ASIO_STANDALONE
+#include <asio.hpp>
 
 #include "crow/common.h"
 #include "crow/ci_map.h"
@@ -35,7 +36,7 @@ namespace crow
 
         void* middleware_context{};
         void* middleware_container{};
-        boost::asio::io_service* io_service{};
+        asio::io_service* io_service{};
 
         /// Construct an empty request. (sets the method to `GET`)
         request():

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <chrono>
-#include <boost/date_time/posix_time/posix_time.hpp>
 #define ASIO_STANDALONE
 #include <asio.hpp>
 #ifdef CROW_ENABLE_SSL

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -49,8 +49,8 @@ namespace crow
         void on_tick()
         {
             tick_function_();
-            tick_timer_.expires_from_now(boost::posix_time::milliseconds(tick_interval_.count()));
-            tick_timer_.async_wait([this](const boost::system::error_code& ec) {
+            tick_timer_.expires_after(std::chrono::milliseconds(tick_interval_.count()));
+            tick_timer_.async_wait([this](const std::error_code& ec) {
                 if (ec)
                     return;
                 on_tick();
@@ -124,9 +124,9 @@ namespace crow
 
             if (tick_function_ && tick_interval_.count() > 0)
             {
-                tick_timer_.expires_from_now(boost::posix_time::milliseconds(tick_interval_.count()));
+                tick_timer_.expires_after(std::chrono::milliseconds(tick_interval_.count()));
                 tick_timer_.async_wait(
-                  [this](const boost::system::error_code& ec) {
+                  [this](const std::error_code& ec) {
                       if (ec)
                           return;
                       on_tick();
@@ -263,7 +263,8 @@ namespace crow
         std::condition_variable cv_started_;
         std::mutex start_mutex_;
         boost::asio::signal_set signals_;
-        boost::asio::deadline_timer tick_timer_;
+
+        boost::asio::basic_waitable_timer<std::chrono::high_resolution_clock> tick_timer_;
 
         Handler* handler_;
         uint16_t concurrency_{2};

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -50,7 +50,7 @@ namespace crow
         {
             tick_function_();
             tick_timer_.expires_after(std::chrono::milliseconds(tick_interval_.count()));
-            tick_timer_.async_wait([this](const std::error_code& ec) {
+            tick_timer_.async_wait([this](const asio::error_code& ec) {
                 if (ec)
                     return;
                 on_tick();
@@ -126,7 +126,7 @@ namespace crow
             {
                 tick_timer_.expires_after(std::chrono::milliseconds(tick_interval_.count()));
                 tick_timer_.async_wait(
-                  [this](const std::error_code& ec) {
+                  [this](const asio::error_code& ec) {
                       if (ec)
                           return;
                       on_tick();
@@ -141,7 +141,7 @@ namespace crow
             CROW_LOG_INFO << "Call `app.loglevel(crow::LogLevel::Warning)` to hide Info level logs.";
 
             signals_.async_wait(
-              [&](const std::error_code& /*error*/, int /*signal_number*/) {
+              [&](const asio::error_code& /*error*/, int /*signal_number*/) {
                   stop();
               });
 
@@ -225,7 +225,7 @@ namespace crow
 
                 acceptor_.async_accept(
                   p->socket(),
-                  [this, p, &is, service_idx](std::error_code ec) {
+                  [this, p, &is, service_idx](asio::error_code ec) {
                       if (!ec)
                       {
                           is.post(

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -19,8 +19,7 @@
 
 namespace crow
 {
-    using namespace boost;
-    using tcp = asio::ip::tcp;
+    using tcp = boost::asio::ip::tcp;
 
     template<typename Handler, typename Adaptor = SocketAdaptor, typename... Middlewares>
     class Server
@@ -216,7 +215,7 @@ namespace crow
             if (!shutting_down_)
             {
                 uint16_t service_idx = pick_io_service_idx();
-                asio::io_service& is = *io_service_pool_[service_idx];
+                boost::asio::io_service& is = *io_service_pool_[service_idx];
                 task_queue_length_pool_[service_idx]++;
                 CROW_LOG_DEBUG << &is << " {" << service_idx << "} queue length: " << task_queue_length_pool_[service_idx];
 
@@ -254,8 +253,8 @@ namespace crow
         }
 
     private:
-        asio::io_service io_service_;
-        std::vector<std::unique_ptr<asio::io_service>> io_service_pool_;
+        boost::asio::io_service io_service_;
+        std::vector<std::unique_ptr<boost::asio::io_service>> io_service_pool_;
         std::vector<detail::task_timer*> task_timer_pool_;
         std::vector<std::function<std::string()>> get_cached_date_str_pool_;
         tcp::acceptor acceptor_;

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -200,6 +200,11 @@ namespace crow
                 return std::lexicographical_compare(l.begin(), l.end(), r.begin(), r.end());
             }
 
+            inline bool operator>(const r_string& l, const r_string& r)
+            {
+                return std::lexicographical_compare(l.begin(), l.end(), r.begin(), r.end());
+            }
+
             inline bool operator>(const r_string& l, const std::string& r)
             {
                 return std::lexicographical_compare(l.begin(), l.end(), r.begin(), r.end());

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -1898,7 +1898,7 @@ namespace crow
 
 
 
-        //std::vector<boost::asio::const_buffer> dump_ref(wvalue& v)
+        //std::vector<asio::const_buffer> dump_ref(wvalue& v)
         //{
         //}
     } // namespace json

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -12,7 +12,6 @@
 #include <iostream>
 #include <algorithm>
 #include <memory>
-#include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/operators.hpp>
 #include <vector>
@@ -349,13 +348,13 @@ namespace crow
                 {
                     case type::Number:
                     case type::String:
-                        return boost::lexical_cast<int64_t>(start_, end_ - start_);
+                        return utility::lexical_cast<int64_t>(start_, end_ - start_);
                     default:
                         const std::string msg = "expected number, got: " + std::string(get_type_str(t()));
                         throw std::runtime_error(msg);
                 }
 #endif
-                return boost::lexical_cast<int64_t>(start_, end_ - start_);
+                return utility::lexical_cast<int64_t>(start_, end_ - start_);
             }
 
             /// The unsigned integer value.
@@ -366,12 +365,12 @@ namespace crow
                 {
                     case type::Number:
                     case type::String:
-                        return boost::lexical_cast<uint64_t>(start_, end_ - start_);
+                        return utility::lexical_cast<uint64_t>(start_, end_ - start_);
                     default:
                         throw std::runtime_error(std::string("expected number, got: ") + get_type_str(t()));
                 }
 #endif
-                return boost::lexical_cast<uint64_t>(start_, end_ - start_);
+                return utility::lexical_cast<uint64_t>(start_, end_ - start_);
             }
 
             /// The double precision floating-point number value.
@@ -381,7 +380,7 @@ namespace crow
                 if (t() != type::Number)
                     throw std::runtime_error("value is not number");
 #endif
-                return boost::lexical_cast<double>(start_, end_ - start_);
+                return utility::lexical_cast<double>(start_, end_ - start_);
             }
 
             /// The boolean value.

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -968,8 +968,8 @@ namespace crow
                                 {
                                     state = NumberParsingState::ZeroFirst;
                                 }
-                                else if (state == NumberParsingState::Digits || 
-                                    state == NumberParsingState::DigitsAfterE || 
+                                else if (state == NumberParsingState::Digits ||
+                                    state == NumberParsingState::DigitsAfterE ||
                                     state == NumberParsingState::DigitsAfterPoints)
                                 {
                                     // ok; pass
@@ -997,8 +997,8 @@ namespace crow
                                 {
                                     state = NumberParsingState::Digits;
                                 }
-                                else if (state == NumberParsingState::Digits || 
-                                    state == NumberParsingState::DigitsAfterE || 
+                                else if (state == NumberParsingState::Digits ||
+                                    state == NumberParsingState::DigitsAfterE ||
                                     state == NumberParsingState::DigitsAfterPoints)
                                 {
                                     // ok; pass
@@ -1046,12 +1046,12 @@ namespace crow
                             case 'e':
                             case 'E':
                                 state = static_cast<NumberParsingState>("\7\7\7\5\5\7\7"[state]);
-                                /*if (state == NumberParsingState::Digits || 
+                                /*if (state == NumberParsingState::Digits ||
                                     state == NumberParsingState::DigitsAfterPoints)
                                 {
                                     state = NumberParsingState::E;
                                 }
-                                else 
+                                else
                                     return {};*/
                                 break;
                             default:

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -183,6 +183,25 @@ namespace crow
                     owned_ = 1;
                 }
                 friend rvalue crow::json::load(const char* data, size_t size);
+
+                friend bool operator==(const r_string& l, const r_string& r);
+                friend bool operator==(const std::string& l, const r_string& r);
+                friend bool operator==(const r_string& l, const std::string& r);
+
+                template<typename T, typename U>
+                inline static bool equals(const T& l, const U& r)
+                {
+                    if (l.size() != r.size())
+                        return false;
+
+                    for (size_t i = 0; i < l.size(); i++)
+                    {
+                        if (*(l.begin() + i) != *(r.begin() + i))
+                            return false;
+                    }
+
+                    return true;
+                }
             };
 
             inline bool operator<(const r_string& l, const r_string& r)
@@ -217,44 +236,17 @@ namespace crow
 
             inline bool operator==(const r_string& l, const r_string& r)
             {
-                if (l.size() != r.size())
-                    return false;
-
-                for (size_t i = 0; i < l.size(); i++)
-                {
-                    if (*(l.begin() + i) != *(r.begin() + i))
-                        return false;
-                }
-
-                return true;
+                return r_string::equals(l, r);
             }
 
             inline bool operator==(const r_string& l, const std::string& r)
             {
-                if (l.size() != r.size())
-                    return false;
-
-                for (size_t i = 0; i < l.size(); i++)
-                {
-                    if (*(l.begin() + i) != *(r.begin() + i))
-                        return false;
-                }
-
-                return true;
+                return r_string::equals(l, r);
             }
 
             inline bool operator==(const std::string& l, const r_string& r)
             {
-                if (l.size() != r.size())
-                    return false;
-
-                for (size_t i = 0; i < l.size(); i++)
-                {
-                    if (*(l.begin() + i) != *(r.begin() + i))
-                        return false;
-                }
-
-                return true;
+                return r_string::equals(l, r);
             }
 
             inline bool operator!=(const r_string& l, const r_string& r)

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -212,17 +212,44 @@ namespace crow
 
             inline bool operator==(const r_string& l, const r_string& r)
             {
-                return std::equal(l.begin(), l.end(), r.begin(), r.end());
+                if (l.size() != r.size())
+                    return false;
+
+                for (size_t i = 0; i < l.size(); i++)
+                {
+                    if (*(l.begin() + i) != *(r.begin() + i))
+                        return false;
+                }
+
+                return true;
             }
 
             inline bool operator==(const r_string& l, const std::string& r)
             {
-                return std::equal(l.begin(), l.end(), r.begin(), r.end());
+                if (l.size() != r.size())
+                    return false;
+
+                for (size_t i = 0; i < l.size(); i++)
+                {
+                    if (*(l.begin() + i) != *(r.begin() + i))
+                        return false;
+                }
+
+                return true;
             }
 
             inline bool operator==(const std::string& l, const r_string& r)
             {
-                return std::equal(l.begin(), l.end(), r.begin(), r.end());
+                if (l.size() != r.size())
+                    return false;
+
+                for (size_t i = 0; i < l.size(); i++)
+                {
+                    if (*(l.begin() + i) != *(r.begin() + i))
+                        return false;
+                }
+
+                return true;
             }
 
             inline bool operator!=(const r_string& l, const r_string& r)

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -12,8 +12,6 @@
 #include <iostream>
 #include <algorithm>
 #include <memory>
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/operators.hpp>
 #include <vector>
 #include <cmath>
 
@@ -116,7 +114,7 @@ namespace crow
         namespace detail
         {
             /// A read string implementation with comparison functionality.
-            struct r_string : boost::less_than_comparable<r_string>, boost::less_than_comparable<r_string, std::string>, boost::equality_comparable<r_string>, boost::equality_comparable<r_string, std::string>
+            struct r_string
             {
                 r_string(){};
                 r_string(char* s, char* e):
@@ -189,27 +187,57 @@ namespace crow
 
             inline bool operator<(const r_string& l, const r_string& r)
             {
-                return boost::lexicographical_compare(l, r);
+                return std::lexicographical_compare(l.begin(), l.end(), r.begin(), r.end());
             }
 
             inline bool operator<(const r_string& l, const std::string& r)
             {
-                return boost::lexicographical_compare(l, r);
+                return std::lexicographical_compare(l.begin(), l.end(), r.begin(), r.end());
+            }
+
+            inline bool operator<(const std::string& l, const r_string& r)
+            {
+                return std::lexicographical_compare(l.begin(), l.end(), r.begin(), r.end());
             }
 
             inline bool operator>(const r_string& l, const std::string& r)
             {
-                return boost::lexicographical_compare(r, l);
+                return std::lexicographical_compare(l.begin(), l.end(), r.begin(), r.end());
+            }
+
+            inline bool operator>(const std::string& l, const r_string& r)
+            {
+                return std::lexicographical_compare(l.begin(), l.end(), r.begin(), r.end());
             }
 
             inline bool operator==(const r_string& l, const r_string& r)
             {
-                return boost::equals(l, r);
+                return std::equal(l.begin(), l.end(), r.begin(), r.end());
             }
 
             inline bool operator==(const r_string& l, const std::string& r)
             {
-                return boost::equals(l, r);
+                return std::equal(l.begin(), l.end(), r.begin(), r.end());
+            }
+
+            inline bool operator==(const std::string& l, const r_string& r)
+            {
+                return std::equal(l.begin(), l.end(), r.begin(), r.end());
+            }
+
+            inline bool operator!=(const r_string& l, const r_string& r)
+            {
+                return !(l == r);
+            }
+
+            inline bool operator!=(const r_string& l, const std::string& r)
+            {
+                return !(l == r);
+            }
+
+            inline bool operator!=(const std::string& l, const r_string& r)
+            {
+                return !(l == r);
             }
         } // namespace detail
 

--- a/include/crow/middlewares/cookie_parser.h
+++ b/include/crow/middlewares/cookie_parser.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <iomanip>
-#include <boost/algorithm/string/trim.hpp>
+#include "crow/utility.h"
 #include "crow/http_request.h"
 #include "crow/http_response.h"
 
@@ -234,7 +234,7 @@ namespace crow
                 if (pos_equal == cookies.npos)
                     break;
                 std::string name = cookies.substr(pos, pos_equal - pos);
-                boost::trim(name);
+                utility::trim(name);
                 pos = pos_equal + 1;
                 while (pos < cookies.size() && cookies[pos] == ' ')
                     pos++;
@@ -244,7 +244,7 @@ namespace crow
                 size_t pos_semicolon = cookies.find(';', pos);
                 std::string value = cookies.substr(pos, pos_semicolon - pos);
 
-                boost::trim(value);
+                utility::trim(value);
                 if (value[0] == '"' && value[value.size() - 1] == '"')
                 {
                     value = value.substr(1, value.size() - 2);

--- a/include/crow/middlewares/cookie_parser.h
+++ b/include/crow/middlewares/cookie_parser.h
@@ -225,17 +225,15 @@ namespace crow
                 if (pos_equal == cookies.npos)
                     break;
                 std::string name = cookies.substr(pos, pos_equal - pos);
-                utility::trim(name);
+                name = utility::trim(name);
                 pos = pos_equal + 1;
-                while (pos < cookies.size() && cookies[pos] == ' ')
-                    pos++;
                 if (pos == cookies.size())
                     break;
 
                 size_t pos_semicolon = cookies.find(';', pos);
                 std::string value = cookies.substr(pos, pos_semicolon - pos);
 
-                utility::trim(value);
+                value = utility::trim(value);
                 if (value[0] == '"' && value[value.size() - 1] == '"')
                 {
                     value = value.substr(1, value.size() - 2);
@@ -247,8 +245,6 @@ namespace crow
                 if (pos == cookies.npos)
                     break;
                 pos++;
-                while (pos < cookies.size() && cookies[pos] == ' ')
-                    pos++;
             }
         }
 

--- a/include/crow/mustache.h
+++ b/include/crow/mustache.h
@@ -258,7 +258,7 @@ namespace crow
                                 }
                                 break;
                                 default:
-                                    throw std::runtime_error("not implemented tag type" + boost::lexical_cast<std::string>(static_cast<int>(ctx.t())));
+                                    throw std::runtime_error("not implemented tag type" + utility::lexical_cast<std::string>(static_cast<int>(ctx.t())));
                             }
                         }
                         break;
@@ -324,7 +324,7 @@ namespace crow
                                     current = action.pos;
                                     break;
                                 default:
-                                    throw std::runtime_error("{{#: not implemented context type: " + boost::lexical_cast<std::string>(static_cast<int>(ctx.t())));
+                                    throw std::runtime_error("{{#: not implemented context type: " + utility::lexical_cast<std::string>(static_cast<int>(ctx.t())));
                                     break;
                             }
                             break;
@@ -333,7 +333,7 @@ namespace crow
                             stack.pop_back();
                             break;
                         default:
-                            throw std::runtime_error("not implemented " + boost::lexical_cast<std::string>(static_cast<int>(action.t)));
+                            throw std::runtime_error("not implemented " + utility::lexical_cast<std::string>(static_cast<int>(action.t)));
                     }
                     current++;
                 }

--- a/include/crow/parser.h
+++ b/include/crow/parser.h
@@ -2,7 +2,6 @@
 
 #include <string>
 #include <unordered_map>
-#include <boost/algorithm/string.hpp>
 #include <algorithm>
 
 #include "crow/http_parser_merged.h"

--- a/include/crow/query_string.h
+++ b/include/crow/query_string.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <unordered_map>
 #include <iostream>
+#include <memory>
 
 namespace crow
 {
@@ -202,7 +203,7 @@ inline char * qs_k2v(const char * key, char * const * qs_kv, int qs_kv_size, int
     return nullptr;
 }
 
-inline std::pair<std::string, std::string>* qs_dict_name2kv(const char * dict_name, char * const * qs_kv, int qs_kv_size, int nth = 0)
+inline std::unique_ptr<std::pair<std::string, std::string>> qs_dict_name2kv(const char * dict_name, char * const * qs_kv, int qs_kv_size, int nth = 0)
 {
     int i;
     size_t name_len, skip_to_eq, skip_to_brace_open, skip_to_brace_close;
@@ -231,7 +232,7 @@ inline std::pair<std::string, std::string>* qs_dict_name2kv(const char * dict_na
             {
                 auto key = std::string(qs_kv[i] + skip_to_brace_open, skip_to_brace_close - skip_to_brace_open);
                 auto value = std::string(qs_kv[i] + skip_to_eq);
-                return new std::pair<std::string, std::string>(key, value);
+                return std::unique_ptr<std::pair<std::string, std::string>>(new std::pair<std::string, std::string>(key, value));
             }
             else
             {
@@ -446,14 +447,10 @@ namespace crow
             int count = 0;
             while (1)
             {
-                auto element = qs_dict_name2kv(name.c_str(), key_value_pairs_.data(), key_value_pairs_.size(), count++);
-
-                if (element)
+                if (auto element = qs_dict_name2kv(name.c_str(), key_value_pairs_.data(), key_value_pairs_.size(), count++))
                     ret.insert(*element);
                 else
                     break;
-
-                delete element;
             }
             return ret;
         }

--- a/include/crow/query_string.h
+++ b/include/crow/query_string.h
@@ -6,7 +6,6 @@
 #include <vector>
 #include <unordered_map>
 #include <iostream>
-#include <boost/optional.hpp>
 
 namespace crow
 {
@@ -194,7 +193,7 @@ inline char * qs_k2v(const char * key, char * const * qs_kv, int qs_kv_size, int
             // return (zero-char value) ? ptr to trailing '\0' : ptr to value
             if(nth == 0)
                 return qs_kv[i] + skip;
-            else 
+            else
                 --nth;
         }
     }
@@ -203,7 +202,7 @@ inline char * qs_k2v(const char * key, char * const * qs_kv, int qs_kv_size, int
     return nullptr;
 }
 
-inline boost::optional<std::pair<std::string, std::string>> qs_dict_name2kv(const char * dict_name, char * const * qs_kv, int qs_kv_size, int nth = 0)
+inline std::pair<std::string, std::string>* qs_dict_name2kv(const char * dict_name, char * const * qs_kv, int qs_kv_size, int nth = 0)
 {
     int i;
     size_t name_len, skip_to_eq, skip_to_brace_open, skip_to_brace_close;
@@ -232,7 +231,7 @@ inline boost::optional<std::pair<std::string, std::string>> qs_dict_name2kv(cons
             {
                 auto key = std::string(qs_kv[i] + skip_to_brace_open, skip_to_brace_close - skip_to_brace_open);
                 auto value = std::string(qs_kv[i] + skip_to_eq);
-                return boost::make_optional(std::make_pair(key, value));
+                return new std::pair<std::string, std::string>(key, value);
             }
             else
             {
@@ -242,7 +241,7 @@ inline boost::optional<std::pair<std::string, std::string>> qs_dict_name2kv(cons
     }
 #endif  // _qsSORTING
 
-    return boost::none;
+    return nullptr;
 }
 
 
@@ -447,10 +446,14 @@ namespace crow
             int count = 0;
             while (1)
             {
-                if (auto element = qs_dict_name2kv(name.c_str(), key_value_pairs_.data(), key_value_pairs_.size(), count++))
+                auto element = qs_dict_name2kv(name.c_str(), key_value_pairs_.data(), key_value_pairs_.size(), count++);
+
+                if (element)
                     ret.insert(*element);
                 else
                     break;
+
+                delete element;
             }
             return ret;
         }

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -5,7 +5,6 @@
 #include <tuple>
 #include <unordered_map>
 #include <memory>
-#include <boost/lexical_cast.hpp>
 #include <vector>
 #include <algorithm>
 #include <type_traits>

--- a/include/crow/socket_adaptors.h
+++ b/include/crow/socket_adaptors.h
@@ -1,27 +1,28 @@
 #pragma once
-#include <boost/asio.hpp>
+#define ASIO_STANDALONE
+#include <asio.hpp>
 #ifdef CROW_ENABLE_SSL
-#include <boost/asio/ssl.hpp>
+#include <asio/ssl.hpp>
 #endif
 #include "crow/settings.h"
 #if BOOST_VERSION >= 107000
-#define GET_IO_SERVICE(s) ((boost::asio::io_context&)(s).get_executor().context())
+#define GET_IO_SERVICE(s) ((asio::io_context&)(s).get_executor().context())
 #else
 #define GET_IO_SERVICE(s) ((s).get_io_service())
 #endif
 namespace crow
 {
-    using tcp = boost::asio::ip::tcp;
+    using tcp = asio::ip::tcp;
 
-    /// A wrapper for the boost::asio::ip::tcp::socket and boost::asio::ssl::stream
+    /// A wrapper for the asio::ip::tcp::socket and asio::ssl::stream
     struct SocketAdaptor
     {
         using context = void;
-        SocketAdaptor(boost::asio::io_service& io_service, context*):
+        SocketAdaptor(asio::io_service& io_service, context*):
           socket_(io_service)
         {}
 
-        boost::asio::io_service& get_io_service()
+        asio::io_service& get_io_service()
         {
             return GET_IO_SERVICE(socket_);
         }
@@ -50,32 +51,32 @@ namespace crow
 
         void close()
         {
-            boost::system::error_code ec;
+            std::error_code ec;
             socket_.close(ec);
         }
 
         void shutdown_readwrite()
         {
-            boost::system::error_code ec;
-            socket_.shutdown(boost::asio::socket_base::shutdown_type::shutdown_both, ec);
+            std::error_code ec;
+            socket_.shutdown(asio::socket_base::shutdown_type::shutdown_both, ec);
         }
 
         void shutdown_write()
         {
-            boost::system::error_code ec;
-            socket_.shutdown(boost::asio::socket_base::shutdown_type::shutdown_send, ec);
+            std::error_code ec;
+            socket_.shutdown(asio::socket_base::shutdown_type::shutdown_send, ec);
         }
 
         void shutdown_read()
         {
-            boost::system::error_code ec;
-            socket_.shutdown(boost::asio::socket_base::shutdown_type::shutdown_receive, ec);
+            std::error_code ec;
+            socket_.shutdown(asio::socket_base::shutdown_type::shutdown_receive, ec);
         }
 
         template<typename F>
         void start(F f)
         {
-            f(boost::system::error_code());
+            f(std::error_code());
         }
 
         tcp::socket socket_;
@@ -84,13 +85,13 @@ namespace crow
 #ifdef CROW_ENABLE_SSL
     struct SSLAdaptor
     {
-        using context = boost::asio::ssl::context;
-        using ssl_socket_t = boost::asio::ssl::stream<tcp::socket>;
-        SSLAdaptor(boost::asio::io_service& io_service, context* ctx):
+        using context = asio::ssl::context;
+        using ssl_socket_t = asio::ssl::stream<tcp::socket>;
+        SSLAdaptor(asio::io_service& io_service, context* ctx):
           ssl_socket_(new ssl_socket_t(io_service, *ctx))
         {}
 
-        boost::asio::ssl::stream<tcp::socket>& socket()
+        asio::ssl::stream<tcp::socket>& socket()
         {
             return *ssl_socket_;
         }
@@ -115,7 +116,7 @@ namespace crow
         {
             if (is_open())
             {
-                boost::system::error_code ec;
+                std::error_code ec;
                 raw_socket().close(ec);
             }
         }
@@ -124,8 +125,8 @@ namespace crow
         {
             if (is_open())
             {
-                boost::system::error_code ec;
-                raw_socket().shutdown(boost::asio::socket_base::shutdown_type::shutdown_both, ec);
+                std::error_code ec;
+                raw_socket().shutdown(asio::socket_base::shutdown_type::shutdown_both, ec);
             }
         }
 
@@ -133,8 +134,8 @@ namespace crow
         {
             if (is_open())
             {
-                boost::system::error_code ec;
-                raw_socket().shutdown(boost::asio::socket_base::shutdown_type::shutdown_send, ec);
+                std::error_code ec;
+                raw_socket().shutdown(asio::socket_base::shutdown_type::shutdown_send, ec);
             }
         }
 
@@ -142,12 +143,12 @@ namespace crow
         {
             if (is_open())
             {
-                boost::system::error_code ec;
-                raw_socket().shutdown(boost::asio::socket_base::shutdown_type::shutdown_receive, ec);
+                std::error_code ec;
+                raw_socket().shutdown(asio::socket_base::shutdown_type::shutdown_receive, ec);
             }
         }
 
-        boost::asio::io_service& get_io_service()
+        asio::io_service& get_io_service()
         {
             return GET_IO_SERVICE(raw_socket());
         }
@@ -155,13 +156,13 @@ namespace crow
         template<typename F>
         void start(F f)
         {
-            ssl_socket_->async_handshake(boost::asio::ssl::stream_base::server,
-                                         [f](const boost::system::error_code& ec) {
+            ssl_socket_->async_handshake(asio::ssl::stream_base::server,
+                                         [f](const std::error_code& ec) {
                                              f(ec);
                                          });
         }
 
-        std::unique_ptr<boost::asio::ssl::stream<tcp::socket>> ssl_socket_;
+        std::unique_ptr<asio::ssl::stream<tcp::socket>> ssl_socket_;
     };
 #endif
 } // namespace crow

--- a/include/crow/socket_adaptors.h
+++ b/include/crow/socket_adaptors.h
@@ -52,32 +52,32 @@ namespace crow
 
         void close()
         {
-            std::error_code ec;
+            asio::error_code ec;
             socket_.close(ec);
         }
 
         void shutdown_readwrite()
         {
-            std::error_code ec;
+            asio::error_code ec;
             socket_.shutdown(asio::socket_base::shutdown_type::shutdown_both, ec);
         }
 
         void shutdown_write()
         {
-            std::error_code ec;
+            asio::error_code ec;
             socket_.shutdown(asio::socket_base::shutdown_type::shutdown_send, ec);
         }
 
         void shutdown_read()
         {
-            std::error_code ec;
+            asio::error_code ec;
             socket_.shutdown(asio::socket_base::shutdown_type::shutdown_receive, ec);
         }
 
         template<typename F>
         void start(F f)
         {
-            f(std::error_code());
+            f(asio::error_code());
         }
 
         tcp::socket socket_;
@@ -117,7 +117,7 @@ namespace crow
         {
             if (is_open())
             {
-                std::error_code ec;
+                asio::error_code ec;
                 raw_socket().close(ec);
             }
         }
@@ -126,7 +126,7 @@ namespace crow
         {
             if (is_open())
             {
-                std::error_code ec;
+                asio::error_code ec;
                 raw_socket().shutdown(asio::socket_base::shutdown_type::shutdown_both, ec);
             }
         }
@@ -135,7 +135,7 @@ namespace crow
         {
             if (is_open())
             {
-                std::error_code ec;
+                asio::error_code ec;
                 raw_socket().shutdown(asio::socket_base::shutdown_type::shutdown_send, ec);
             }
         }
@@ -144,7 +144,7 @@ namespace crow
         {
             if (is_open())
             {
-                std::error_code ec;
+                asio::error_code ec;
                 raw_socket().shutdown(asio::socket_base::shutdown_type::shutdown_receive, ec);
             }
         }
@@ -158,7 +158,7 @@ namespace crow
         void start(F f)
         {
             ssl_socket_->async_handshake(asio::ssl::stream_base::server,
-                                         [f](const std::error_code& ec) {
+                                         [f](const asio::error_code& ec) {
                                              f(ec);
                                          });
         }

--- a/include/crow/socket_adaptors.h
+++ b/include/crow/socket_adaptors.h
@@ -11,10 +11,9 @@
 #endif
 namespace crow
 {
-    using namespace boost;
-    using tcp = asio::ip::tcp;
+    using tcp = boost::asio::ip::tcp;
 
-    /// A wrapper for the asio::ip::tcp::socket and asio::ssl::stream
+    /// A wrapper for the boost::asio::ip::tcp::socket and boost::asio::ssl::stream
     struct SocketAdaptor
     {
         using context = void;

--- a/include/crow/socket_adaptors.h
+++ b/include/crow/socket_adaptors.h
@@ -5,7 +5,8 @@
 #include <asio/ssl.hpp>
 #endif
 #include "crow/settings.h"
-#if BOOST_VERSION >= 107000
+#include <asio/version.hpp>
+#if ASIO_VERSION >= 101300 // 1.13.0
 #define GET_IO_SERVICE(s) ((asio::io_context&)(s).get_executor().context())
 #else
 #define GET_IO_SERVICE(s) ((s).get_io_service())

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -805,7 +805,7 @@ namespace crow
         }
 
         template<typename T, typename U>
-        T lexical_cast(const U& v)
+        inline static T lexical_cast(const U& v)
         {
             std::stringstream stream;
             T res;
@@ -817,7 +817,7 @@ namespace crow
         }
 
         template<typename T>
-        T lexical_cast(const char* v, size_t count)
+        inline static T lexical_cast(const char* v, size_t count)
         {
             std::stringstream stream;
             T res;
@@ -828,7 +828,7 @@ namespace crow
             return res;
         }
 
-        std::string trim(const std::string& v)
+        inline static std::string trim(const std::string& v)
         {
             if (v.empty())
                 return "";

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -827,5 +827,37 @@ namespace crow
 
             return res;
         }
+
+        std::string trim(const std::string& v)
+        {
+            if (v.empty())
+                return "";
+
+            size_t begin = 0, end = v.length();
+
+            size_t i;
+            for (i = 0; i < v.length(); i++)
+            {
+                if (!std::isspace(v[i]))
+                {
+                    begin = i;
+                    break;
+                }
+            }
+
+            if (i == v.length())
+                return "";
+
+            for (i = v.length(); i > 0; i--)
+            {
+                if (!std::isspace(v[i - 1]))
+                {
+                    end = i;
+                    break;
+                }
+            }
+
+            return v.substr(begin, end - begin);
+        }
     } // namespace utility
 } // namespace crow

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -788,20 +788,24 @@ namespace crow
          */
         inline static bool string_equals(const std::string& l, const std::string& r, bool case_sensitive = false)
         {
-            bool equal = true;
-
             if (l.length() != r.length())
                 return false;
 
             for (size_t i = 0; i < l.length(); i++)
             {
                 if (case_sensitive)
-                    equal &= (l[i] == r[i]);
+                {
+                    if (l[i] != r[i])
+                        return false;
+                }
                 else
-                    equal &= (std::toupper(l[i]) == std::toupper(r[i]));
+                {
+                    if (std::toupper(l[i]) != std::toupper(r[i]))
+                        return false;
+                }
             }
 
-            return equal;
+            return true;
         }
 
         template<typename T, typename U>

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -5,6 +5,7 @@
 #include <tuple>
 #include <type_traits>
 #include <cstring>
+#include <cctype>
 #include <functional>
 #include <string>
 #include <unordered_map>
@@ -780,5 +781,27 @@ namespace crow
             }
         }
 
+        /**
+         * @brief Checks two string for equality.
+         * Always returns false if strings differ in size.
+         * Defaults to case-insensitive comparison.
+         */
+        inline static bool string_equals(const std::string& l, const std::string& r, bool case_sensitive = false)
+        {
+            bool equal = true;
+
+            if (l.length() != r.length())
+                return false;
+
+            for (size_t i = 0; i < l.length(); i++)
+            {
+                if (case_sensitive)
+                    equal &= (l[i] == r[i]);
+                else
+                    equal &= (std::toupper(l[i]) == std::toupper(r[i]));
+            }
+
+            return equal;
+        }
     } // namespace utility
 } // namespace crow

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -8,6 +8,7 @@
 #include <cctype>
 #include <functional>
 #include <string>
+#include <sstream>
 #include <unordered_map>
 
 #include "crow/settings.h"
@@ -501,7 +502,6 @@ namespace crow
         {
             static constexpr auto value = get_index_of_element_from_tuple_by_type_impl<T, N + 1, Args...>::value;
         };
-
     } // namespace detail
 
     namespace utility
@@ -802,6 +802,30 @@ namespace crow
             }
 
             return equal;
+        }
+
+        template<typename T, typename U>
+        T lexical_cast(const U& v)
+        {
+            std::stringstream stream;
+            T res;
+
+            stream << v;
+            stream >> res;
+
+            return res;
+        }
+
+        template<typename T>
+        T lexical_cast(const char* v, size_t count)
+        {
+            std::stringstream stream;
+            T res;
+
+            stream.write(v, count);
+            stream >> res;
+
+            return res;
         }
     } // namespace utility
 } // namespace crow

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -832,6 +832,9 @@ namespace crow
             return res;
         }
 
+
+        /// Return a copy of the given string with its
+        /// leading and trailing whitespaces removed.
         inline static std::string trim(const std::string& v)
         {
             if (v.empty())

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -1,6 +1,5 @@
 #pragma once
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/array.hpp>
+#include <array>
 #include "crow/logging.h"
 #include "crow/socket_adaptors.h"
 #include "crow/http_request.h"
@@ -664,7 +663,7 @@ namespace crow
             std::vector<std::string> sending_buffers_;
             std::vector<std::string> write_buffers_;
 
-            boost::array<char, 4096> buffer_;
+            std::array<char, 4096> buffer_;
             bool is_binary_;
             std::string message_;
             std::string fragment_;

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -285,9 +285,9 @@ namespace crow
                         //asio::async_read(adaptor_.socket(), asio::buffer(&mini_header_, 1),
                         adaptor_.socket().async_read_some(
                           asio::buffer(&mini_header_, 2),
-                          [this](const std::error_code& ec, std::size_t
+                          [this](const asio::error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
-                                                              bytes_transferred
+                                                               bytes_transferred
 #endif
                           )
 
@@ -353,9 +353,9 @@ namespace crow
                         remaining_length16_ = 0;
                         asio::async_read(
                           adaptor_.socket(), asio::buffer(&remaining_length16_, 2),
-                          [this](const std::error_code& ec, std::size_t
+                          [this](const asio::error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
-                                                              bytes_transferred
+                                                               bytes_transferred
 #endif
                           ) {
                               is_reading = false;
@@ -389,9 +389,9 @@ namespace crow
                     {
                         asio::async_read(
                           adaptor_.socket(), asio::buffer(&remaining_length_, 8),
-                          [this](const std::error_code& ec, std::size_t
+                          [this](const asio::error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
-                                                              bytes_transferred
+                                                               bytes_transferred
 #endif
                           ) {
                               is_reading = false;
@@ -433,9 +433,9 @@ namespace crow
                         {
                             asio::async_read(
                               adaptor_.socket(), asio::buffer((char*)&mask_, 4),
-                              [this](const std::error_code& ec, std::size_t
+                              [this](const asio::error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
-                                                                  bytes_transferred
+                                                                   bytes_transferred
 #endif
                               ) {
                                   is_reading = false;
@@ -475,7 +475,7 @@ namespace crow
                             to_read = remaining_length_;
                         adaptor_.socket().async_read_some(
                           asio::buffer(buffer_, static_cast<std::size_t>(to_read)),
-                          [this](const std::error_code& ec, std::size_t bytes_transferred) {
+                          [this](const asio::error_code& ec, std::size_t bytes_transferred) {
                               is_reading = false;
 
                               if (!ec)
@@ -626,7 +626,7 @@ namespace crow
                     }
                     asio::async_write(
                       adaptor_.socket(), buffers,
-                      [&](const std::error_code& ec, std::size_t /*bytes_transferred*/) {
+                      [&](const asio::error_code& ec, std::size_t /*bytes_transferred*/) {
                           sending_buffers_.clear();
                           if (!ec && !close_connection_)
                           {

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -5,6 +5,7 @@
 #include "crow/socket_adaptors.h"
 #include "crow/http_request.h"
 #include "crow/TinySHA1.hpp"
+#include "crow/utility.h"
 
 namespace crow
 {
@@ -86,7 +87,7 @@ namespace crow
               error_handler_(std::move(error_handler)),
               accept_handler_(std::move(accept_handler))
             {
-                if (!boost::iequals(req.get_header_value("upgrade"), "websocket"))
+                if (!utility::string_equals(req.get_header_value("upgrade"), "websocket"))
                 {
                     adaptor.close();
                     handler_->remove_websocket(this);

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -283,12 +283,12 @@ namespace crow
                     case WebSocketReadState::MiniHeader:
                     {
                         mini_header_ = 0;
-                        //boost::asio::async_read(adaptor_.socket(), boost::asio::buffer(&mini_header_, 1),
+                        //asio::async_read(adaptor_.socket(), asio::buffer(&mini_header_, 1),
                         adaptor_.socket().async_read_some(
-                          boost::asio::buffer(&mini_header_, 2),
-                          [this](const boost::system::error_code& ec, std::size_t
+                          asio::buffer(&mini_header_, 2),
+                          [this](const std::error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
-                                                                        bytes_transferred
+                                                              bytes_transferred
 #endif
                           )
 
@@ -352,11 +352,11 @@ namespace crow
                     {
                         remaining_length_ = 0;
                         remaining_length16_ = 0;
-                        boost::asio::async_read(
-                          adaptor_.socket(), boost::asio::buffer(&remaining_length16_, 2),
-                          [this](const boost::system::error_code& ec, std::size_t
+                        asio::async_read(
+                          adaptor_.socket(), asio::buffer(&remaining_length16_, 2),
+                          [this](const std::error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
-                                                                        bytes_transferred
+                                                              bytes_transferred
 #endif
                           ) {
                               is_reading = false;
@@ -388,11 +388,11 @@ namespace crow
                     break;
                     case WebSocketReadState::Len64:
                     {
-                        boost::asio::async_read(
-                          adaptor_.socket(), boost::asio::buffer(&remaining_length_, 8),
-                          [this](const boost::system::error_code& ec, std::size_t
+                        asio::async_read(
+                          adaptor_.socket(), asio::buffer(&remaining_length_, 8),
+                          [this](const std::error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
-                                                                        bytes_transferred
+                                                              bytes_transferred
 #endif
                           ) {
                               is_reading = false;
@@ -432,11 +432,11 @@ namespace crow
                         }
                         else if (has_mask_)
                         {
-                            boost::asio::async_read(
-                              adaptor_.socket(), boost::asio::buffer((char*)&mask_, 4),
-                              [this](const boost::system::error_code& ec, std::size_t
+                            asio::async_read(
+                              adaptor_.socket(), asio::buffer((char*)&mask_, 4),
+                              [this](const std::error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
-                                                                            bytes_transferred
+                                                                  bytes_transferred
 #endif
                               ) {
                                   is_reading = false;
@@ -475,8 +475,8 @@ namespace crow
                         if (remaining_length_ < to_read)
                             to_read = remaining_length_;
                         adaptor_.socket().async_read_some(
-                          boost::asio::buffer(buffer_, static_cast<std::size_t>(to_read)),
-                          [this](const boost::system::error_code& ec, std::size_t bytes_transferred) {
+                          asio::buffer(buffer_, static_cast<std::size_t>(to_read)),
+                          [this](const std::error_code& ec, std::size_t bytes_transferred) {
                               is_reading = false;
 
                               if (!ec)
@@ -619,15 +619,15 @@ namespace crow
                 if (sending_buffers_.empty())
                 {
                     sending_buffers_.swap(write_buffers_);
-                    std::vector<boost::asio::const_buffer> buffers;
+                    std::vector<asio::const_buffer> buffers;
                     buffers.reserve(sending_buffers_.size());
                     for (auto& s : sending_buffers_)
                     {
-                        buffers.emplace_back(boost::asio::buffer(s));
+                        buffers.emplace_back(asio::buffer(s));
                     }
-                    boost::asio::async_write(
+                    asio::async_write(
                       adaptor_.socket(), buffers,
-                      [&](const boost::system::error_code& ec, std::size_t /*bytes_transferred*/) {
+                      [&](const std::error_code& ec, std::size_t /*bytes_transferred*/) {
                           sending_buffers_.clear();
                           if (!ec && !close_connection_)
                           {

--- a/scripts/PKGBUILD
+++ b/scripts/PKGBUILD
@@ -6,7 +6,7 @@ pkgdesc="A Fast and Easy to use C++ microframework for the web."
 arch=(any)
 url="https://crowcpp.org"
 license=('custom:BSD-3-Clause')
-depends=('boost>=1.64.0')
+depends=('asio')
 optdepends=('openssl: HTTPS support' 'zlib: HTTP compression support' 'cmake: Choose this if you plan on using CMake for your Crow project')
 conflicts=("$pkgname-git")
 changelog='changelog.md'

--- a/tests/ssl/ssltest.cpp
+++ b/tests/ssl/ssltest.cpp
@@ -41,15 +41,15 @@ TEST_CASE("SSL")
 
     std::string sendmsg = "GET /\r\n\r\n";
 
-    boost::asio::ssl::context ctx(boost::asio::ssl::context::sslv23);
+    asio::ssl::context ctx(asio::ssl::context::sslv23);
 
-    boost::asio::io_service is;
+    asio::io_service is;
     {
-        boost::asio::ssl::stream<boost::asio::ip::tcp::socket> c(is, ctx);
-        c.lowest_layer().connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45460));
+        asio::ssl::stream<asio::ip::tcp::socket> c(is, ctx);
+        c.lowest_layer().connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45460));
 
-        c.handshake(boost::asio::ssl::stream_base::client);
-        c.write_some(boost::asio::buffer(sendmsg));
+        c.handshake(asio::ssl::stream_base::client);
+        c.write_some(asio::buffer(sendmsg));
 
         size_t x = 0;
         size_t y = 0;
@@ -57,7 +57,7 @@ TEST_CASE("SSL")
 
         while (x < 121)
         {
-            y = c.read_some(boost::asio::buffer(buf, 2048));
+            y = c.read_some(asio::buffer(buf, 2048));
             x += y;
             buf[y] = '\0';
         }
@@ -74,24 +74,24 @@ TEST_CASE("SSL")
             CHECK(std::string("Hello world, I'm keycrt.").substr((z * -1)) == to_test);
         }
 
-        boost::system::error_code ec;
-        c.lowest_layer().shutdown(boost::asio::socket_base::shutdown_type::shutdown_both, ec);
+        std::error_code ec;
+        c.lowest_layer().shutdown(asio::socket_base::shutdown_type::shutdown_both, ec);
     }
 
     /*
-    boost::asio::io_service is2;
+    asio::io_service is2;
     {
         std::cout << "started second one" << std::endl;
 
-      boost::asio::ssl::stream<boost::asio::ip::tcp::socket> c(is2, ctx);
-      c.lowest_layer().connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45461));
+      asio::ssl::stream<asio::ip::tcp::socket> c(is2, ctx);
+      c.lowest_layer().connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45461));
 
-      c.handshake(boost::asio::ssl::stream_base::client);
+      c.handshake(asio::ssl::stream_base::client);
 
-      c.write_some(boost::asio::buffer(sendmsg));
+      c.write_some(asio::buffer(sendmsg));
 
-      size_t sz = c.read_some(boost::asio::buffer(buf2, 2048));
+      size_t sz = c.read_some(asio::buffer(buf2, 2048));
       CHECK("Hello world, I'm pem." == std::string(buf2).substr((sz - 21)));
     }
 */

--- a/tests/ssl/ssltest.cpp
+++ b/tests/ssl/ssltest.cpp
@@ -74,7 +74,7 @@ TEST_CASE("SSL")
             CHECK(std::string("Hello world, I'm keycrt.").substr((z * -1)) == to_test);
         }
 
-        std::error_code ec;
+        asio::error_code ec;
         c.lowest_layer().shutdown(asio::socket_base::shutdown_type::shutdown_both, ec);
     }
 

--- a/tests/ssl/ssltest.cpp
+++ b/tests/ssl/ssltest.cpp
@@ -8,8 +8,6 @@
 
 #define LOCALHOST_ADDRESS "127.0.0.1"
 
-using namespace boost;
-
 // TODO(EDev): SSL test with .pem file
 TEST_CASE("SSL")
 {
@@ -43,15 +41,15 @@ TEST_CASE("SSL")
 
     std::string sendmsg = "GET /\r\n\r\n";
 
-    asio::ssl::context ctx(asio::ssl::context::sslv23);
+    boost::asio::ssl::context ctx(boost::asio::ssl::context::sslv23);
 
-    asio::io_service is;
+    boost::asio::io_service is;
     {
-        asio::ssl::stream<asio::ip::tcp::socket> c(is, ctx);
-        c.lowest_layer().connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45460));
+        boost::asio::ssl::stream<boost::asio::ip::tcp::socket> c(is, ctx);
+        c.lowest_layer().connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45460));
 
-        c.handshake(asio::ssl::stream_base::client);
-        c.write_some(asio::buffer(sendmsg));
+        c.handshake(boost::asio::ssl::stream_base::client);
+        c.write_some(boost::asio::buffer(sendmsg));
 
         size_t x = 0;
         size_t y = 0;
@@ -59,7 +57,7 @@ TEST_CASE("SSL")
 
         while (x < 121)
         {
-            y = c.read_some(asio::buffer(buf, 2048));
+            y = c.read_some(boost::asio::buffer(buf, 2048));
             x += y;
             buf[y] = '\0';
         }
@@ -81,19 +79,19 @@ TEST_CASE("SSL")
     }
 
     /*
-    asio::io_service is2;
+    boost::asio::io_service is2;
     {
         std::cout << "started second one" << std::endl;
 
-      asio::ssl::stream<asio::ip::tcp::socket> c(is2, ctx);
-      c.lowest_layer().connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45461));
+      boost::asio::ssl::stream<boost::asio::ip::tcp::socket> c(is2, ctx);
+      c.lowest_layer().connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45461));
 
-      c.handshake(asio::ssl::stream_base::client);
+      c.handshake(boost::asio::ssl::stream_base::client);
 
-      c.write_some(asio::buffer(sendmsg));
+      c.write_some(boost::asio::buffer(sendmsg));
 
-      size_t sz = c.read_some(asio::buffer(buf2, 2048));
+      size_t sz = c.read_some(boost::asio::buffer(buf2, 2048));
       CHECK("Hello world, I'm pem." == std::string(buf2).substr((sz - 21)));
     }
 */

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -759,7 +759,7 @@ TEST_CASE("json_read_real")
     for (auto x : v)
     {
         CROW_LOG_DEBUG << x;
-        CHECK(json::load(x).d() == boost::lexical_cast<double>(x));
+        CHECK(json::load(x).d() == utility::lexical_cast<double>(x));
     }
 
     auto ret = json::load(
@@ -1936,10 +1936,10 @@ TEST_CASE("simple_url_params")
         c.receive(asio::buffer(buf, 2048));
         c.close();
 
-        CHECK(boost::lexical_cast<int>(last_url_params.get("int")) == 100);
-        CHECK(boost::lexical_cast<double>(last_url_params.get("double")) ==
+        CHECK(utility::lexical_cast<int>(last_url_params.get("int")) == 100);
+        CHECK(utility::lexical_cast<double>(last_url_params.get("double")) ==
               123.45);
-        CHECK(boost::lexical_cast<bool>(last_url_params.get("boolean")));
+        CHECK(utility::lexical_cast<bool>(last_url_params.get("boolean")));
     }
     // check single array value
     sendmsg = "GET /params?tmnt[]=leonardo\r\n\r\n";

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1702,9 +1702,15 @@ TEST_CASE("middleware_cookieparser_format")
     }
     // expires
     {
-        auto tp = boost::posix_time::time_from_string("2000-11-01 23:59:59.000");
+        std::time_t tp;
+        std::time(&tp);
+        std::tm* tm = std::gmtime(&tp);
+        std::istringstream ss("2000-11-01 23:59:59");
+        ss >> std::get_time(tm, "%Y-%m-%d %H:%M:%S");
+        std::mktime(tm);
+
         auto c = Cookie("key", "value")
-                   .expires(boost::posix_time::to_tm(tp));
+                   .expires(*tm);
         auto s = c.dump();
         CHECK(valid(s, 2));
         CHECK(s.find("Expires=Wed, 01 Nov 2000 23:59:59 GMT") != std::string::npos);

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -3112,3 +3112,15 @@ TEST_CASE("task_timer")
     io_service.stop();
     io_thread.join();
 } // task_timer
+
+
+TEST_CASE("trim")
+{
+    CHECK(utility::trim("") == "");
+    CHECK(utility::trim("0") == "0");
+    CHECK(utility::trim(" a") == "a");
+    CHECK(utility::trim("b ") == "b");
+    CHECK(utility::trim(" c ") == "c");
+    CHECK(utility::trim(" a b ") == "a b");
+    CHECK(utility::trim("   ") == "");
+}

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -467,17 +467,17 @@ TEST_CASE("server_handling_error_request")
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
     app.wait_for_server_start();
     std::string sendmsg = "POX";
-    boost::asio::io_service is;
+    asio::io_service is;
     {
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(boost::asio::buffer(sendmsg));
+        c.send(asio::buffer(sendmsg));
 
         try
         {
-            c.receive(boost::asio::buffer(buf, 2048));
+            c.receive(asio::buffer(buf, 2048));
             FAIL_CHECK();
         }
         catch (std::exception& e)
@@ -499,17 +499,17 @@ TEST_CASE("server_handling_error_request_http_version")
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
     app.wait_for_server_start();
     std::string sendmsg = "POST /\r\nContent-Length:3\r\nX-HeaderTest: 123\r\n\r\nA=B\r\n";
-    boost::asio::io_service is;
+    asio::io_service is;
     {
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(boost::asio::buffer(sendmsg));
+        c.send(asio::buffer(sendmsg));
 
         try
         {
-            c.receive(boost::asio::buffer(buf, 2048));
+            c.receive(asio::buffer(buf, 2048));
             FAIL_CHECK();
         }
         catch (std::exception& e)
@@ -541,30 +541,30 @@ TEST_CASE("multi_server")
     std::string sendmsg =
       "POST / HTTP/1.0\r\nContent-Length:3\r\nX-HeaderTest: 123\r\n\r\nA=B\r\n";
     {
-        boost::asio::io_service is;
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        asio::io_service is;
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(boost::asio::buffer(sendmsg));
+        c.send(asio::buffer(sendmsg));
 
-        size_t recved = c.receive(boost::asio::buffer(buf, 2048));
+        size_t recved = c.receive(asio::buffer(buf, 2048));
         CHECK('A' == buf[recved - 1]);
     }
 
     {
-        boost::asio::io_service is;
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
+        asio::io_service is;
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
 
         for (auto ch : sendmsg)
         {
             char buf[1] = {ch};
-            c.send(boost::asio::buffer(buf));
+            c.send(asio::buffer(buf));
         }
 
-        size_t recved = c.receive(boost::asio::buffer(buf, 2048));
+        size_t recved = c.receive(asio::buffer(buf, 2048));
         CHECK('B' == buf[recved - 1]);
     }
 
@@ -591,12 +591,12 @@ TEST_CASE("undefined_status_code")
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45471).run_async();
     app.wait_for_server_start();
 
-    boost::asio::io_service is;
+    asio::io_service is;
     auto sendRequestAndGetStatusCode = [&](const std::string& route) -> unsigned {
-        boost::asio::ip::tcp::socket socket(is);
-        socket.connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), app.port()));
+        asio::ip::tcp::socket socket(is);
+        socket.connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), app.port()));
 
-        boost::asio::streambuf request;
+        asio::streambuf request;
         std::ostream request_stream(&request);
         request_stream << "GET " << route << " HTTP/1.0\r\n";
         request_stream << "Host: " << LOCALHOST_ADDRESS << "\r\n";
@@ -604,10 +604,10 @@ TEST_CASE("undefined_status_code")
         request_stream << "Connection: close\r\n\r\n";
 
         // Send the request.
-        boost::asio::write(socket, request);
+        asio::write(socket, request);
 
-        boost::asio::streambuf response;
-        boost::asio::read_until(socket, response, "\r\n");
+        asio::streambuf response;
+        asio::read_until(socket, response, "\r\n");
 
         std::istream response_stream(&response);
         std::string http_version;
@@ -1407,15 +1407,15 @@ TEST_CASE("middleware_context")
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
     app.wait_for_server_start();
     std::string sendmsg = "GET /\r\n\r\n";
-    boost::asio::io_service is;
+    asio::io_service is;
     {
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(boost::asio::buffer(sendmsg));
+        c.send(asio::buffer(sendmsg));
 
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
     }
     {
@@ -1432,13 +1432,13 @@ TEST_CASE("middleware_context")
     }
     std::string sendmsg2 = "GET /break\r\n\r\n";
     {
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(boost::asio::buffer(sendmsg2));
+        c.send(asio::buffer(sendmsg2));
 
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
     }
     {
@@ -1487,25 +1487,25 @@ TEST_CASE("local_middleware")
 
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
     app.wait_for_server_start();
-    boost::asio::io_service is;
+    asio::io_service is;
 
     {
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(boost::asio::buffer("GET /\r\n\r\n"));
-        c.receive(boost::asio::buffer(buf, 2048));
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(asio::buffer("GET /\r\n\r\n"));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
 
         CHECK(std::string(buf).find("200") != std::string::npos);
     }
 
     {
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(boost::asio::buffer("GET /secret\r\n\r\n"));
-        c.receive(boost::asio::buffer(buf, 2048));
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(asio::buffer("GET /secret\r\n\r\n"));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
 
         CHECK(std::string(buf).find("403") != std::string::npos);
@@ -1569,15 +1569,15 @@ TEST_CASE("middleware_blueprint")
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
     app.wait_for_server_start();
 
-    boost::asio::io_service is;
+    asio::io_service is;
     {
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(boost::asio::buffer("GET /a/b/\r\n\r\n"));
+        c.send(asio::buffer("GET /a/b/\r\n\r\n"));
 
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
     }
     {
@@ -1592,13 +1592,13 @@ TEST_CASE("middleware_blueprint")
         CHECK("1 after" == out[6]);
     }
     {
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(boost::asio::buffer("GET /a/c/break\r\n\r\n"));
+        c.send(asio::buffer("GET /a/c/break\r\n\r\n"));
 
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
     }
     {
@@ -1643,15 +1643,15 @@ TEST_CASE("middleware_cookieparser_parse")
     std::string sendmsg =
       "GET /\r\nCookie: key1=value1; key2=\"val=ue2\"; key3=\"val\"ue3\"; "
       "key4=\"val\"ue4\"\r\n\r\n";
-    boost::asio::io_service is;
+    asio::io_service is;
     {
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(boost::asio::buffer(sendmsg));
+        c.send(asio::buffer(sendmsg));
 
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
     }
     {
@@ -1747,42 +1747,42 @@ TEST_CASE("middleware_cors")
                    });
 
     app.wait_for_server_start();
-    boost::asio::io_service is;
+    asio::io_service is;
 
     {
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(boost::asio::buffer("GET /\r\n\r\n"));
+        c.send(asio::buffer("GET /\r\n\r\n"));
 
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
 
         CHECK(std::string(buf).find("Access-Control-Allow-Origin: *") != std::string::npos);
     }
 
     {
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(boost::asio::buffer("GET /origin\r\n\r\n"));
+        c.send(asio::buffer("GET /origin\r\n\r\n"));
 
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
 
         CHECK(std::string(buf).find("Access-Control-Allow-Origin: test.test") != std::string::npos);
     }
 
     {
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(boost::asio::buffer("GET /nocors/path\r\n\r\n"));
+        c.send(asio::buffer("GET /nocors/path\r\n\r\n"));
 
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
 
         CHECK(std::string(buf).find("Access-Control-Allow-Origin:") == std::string::npos);
@@ -1805,21 +1805,21 @@ TEST_CASE("bug_quick_repeated_request")
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
     app.wait_for_server_start();
     std::string sendmsg = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    boost::asio::io_service is;
+    asio::io_service is;
     {
         std::vector<std::future<void>> v;
         for (int i = 0; i < 5; i++)
         {
             v.push_back(async(launch::async, [&] {
-                boost::asio::ip::tcp::socket c(is);
-                c.connect(boost::asio::ip::tcp::endpoint(
-                  boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+                asio::ip::tcp::socket c(is);
+                c.connect(asio::ip::tcp::endpoint(
+                  asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
                 for (int j = 0; j < 5; j++)
                 {
-                    c.send(boost::asio::buffer(sendmsg));
+                    c.send(asio::buffer(sendmsg));
 
-                    size_t received = c.receive(boost::asio::buffer(buf, 2048));
+                    size_t received = c.receive(asio::buffer(buf, 2048));
                     CHECK("hello" == std::string(buf + received - 5, buf + received));
                 }
                 c.close();
@@ -1847,17 +1847,17 @@ TEST_CASE("simple_url_params")
 
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
     app.wait_for_server_start();
-    boost::asio::io_service is;
+    asio::io_service is;
     std::string sendmsg;
 
     // check empty params
     sendmsg = "GET /params\r\n\r\n";
     {
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(boost::asio::buffer(sendmsg));
-        c.receive(boost::asio::buffer(buf, 2048));
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(asio::buffer(sendmsg));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
 
         stringstream ss;
@@ -1868,11 +1868,11 @@ TEST_CASE("simple_url_params")
     // check single presence
     sendmsg = "GET /params?foobar\r\n\r\n";
     {
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(boost::asio::buffer(sendmsg));
-        c.receive(boost::asio::buffer(buf, 2048));
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(asio::buffer(sendmsg));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
 
         CHECK(last_url_params.get("missing") == nullptr);
@@ -1882,11 +1882,11 @@ TEST_CASE("simple_url_params")
     // check multiple presence
     sendmsg = "GET /params?foo&bar&baz\r\n\r\n";
     {
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(boost::asio::buffer(sendmsg));
-        c.receive(boost::asio::buffer(buf, 2048));
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(asio::buffer(sendmsg));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
 
         CHECK(last_url_params.get("missing") == nullptr);
@@ -1897,11 +1897,11 @@ TEST_CASE("simple_url_params")
     // check single value
     sendmsg = "GET /params?hello=world\r\n\r\n";
     {
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(boost::asio::buffer(sendmsg));
-        c.receive(boost::asio::buffer(buf, 2048));
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(asio::buffer(sendmsg));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
 
         CHECK(string(last_url_params.get("hello")) == "world");
@@ -1909,11 +1909,11 @@ TEST_CASE("simple_url_params")
     // check multiple value
     sendmsg = "GET /params?hello=world&left=right&up=down\r\n\r\n";
     {
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(boost::asio::buffer(sendmsg));
-        c.receive(boost::asio::buffer(buf, 2048));
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(asio::buffer(sendmsg));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
 
         query_string mutable_params(last_url_params);
@@ -1929,11 +1929,11 @@ TEST_CASE("simple_url_params")
     // check multiple value, multiple types
     sendmsg = "GET /params?int=100&double=123.45&boolean=1\r\n\r\n";
     {
-        boost::asio::ip::tcp::socket c(is);
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(boost::asio::buffer(sendmsg));
-        c.receive(boost::asio::buffer(buf, 2048));
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(asio::buffer(sendmsg));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
 
         CHECK(boost::lexical_cast<int>(last_url_params.get("int")) == 100);
@@ -1944,12 +1944,12 @@ TEST_CASE("simple_url_params")
     // check single array value
     sendmsg = "GET /params?tmnt[]=leonardo\r\n\r\n";
     {
-        boost::asio::ip::tcp::socket c(is);
+        asio::ip::tcp::socket c(is);
 
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(boost::asio::buffer(sendmsg));
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(asio::buffer(sendmsg));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
 
         CHECK(last_url_params.get("tmnt") == nullptr);
@@ -1959,12 +1959,12 @@ TEST_CASE("simple_url_params")
     // check multiple array value
     sendmsg = "GET /params?tmnt[]=leonardo&tmnt[]=donatello&tmnt[]=raphael\r\n\r\n";
     {
-        boost::asio::ip::tcp::socket c(is);
+        asio::ip::tcp::socket c(is);
 
-        c.connect(boost::asio::ip::tcp::endpoint(
-          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(boost::asio::buffer(sendmsg));
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(asio::buffer(sendmsg));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
 
         CHECK(last_url_params.get_list("tmnt").size() == 3);
@@ -1977,11 +1977,11 @@ TEST_CASE("simple_url_params")
     // check dictionary value
     sendmsg = "GET /params?kees[one]=vee1&kees[two]=vee2&kees[three]=vee3\r\n\r\n";
     {
-        boost::asio::ip::tcp::socket c(is);
+        asio::ip::tcp::socket c(is);
 
-        c.connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(boost::asio::buffer(sendmsg));
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(asio::buffer(sendmsg));
+        c.receive(asio::buffer(buf, 2048));
         c.close();
 
         CHECK(last_url_params.get_dict("kees").size() == 3);
@@ -2243,19 +2243,19 @@ TEST_CASE("stream_response")
     std::thread runTest([&app, &key_response, key_response_size, keyword_]() {
         auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
         app.wait_for_server_start();
-        boost::asio::io_service is;
+        asio::io_service is;
         std::string sendmsg;
 
         //Total bytes received
         unsigned int received = 0;
         sendmsg = "GET /test HTTP/1.0\r\n\r\n";
         {
-            boost::asio::streambuf b;
+            asio::streambuf b;
 
-            boost::asio::ip::tcp::socket c(is);
-            c.connect(boost::asio::ip::tcp::endpoint(
-              boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-            c.send(boost::asio::buffer(sendmsg));
+            asio::ip::tcp::socket c(is);
+            c.connect(asio::ip::tcp::endpoint(
+              asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+            c.send(asio::buffer(sendmsg));
 
             // consuming the headers, since we don't need those for the test
             static char buf[2048];
@@ -2275,7 +2275,7 @@ TEST_CASE("stream_response")
 
             while (received < key_response_size)
             {
-                boost::asio::streambuf::mutable_buffers_type bufs = b.prepare(16384);
+                asio::streambuf::mutable_buffers_type bufs = b.prepare(16384);
 
                 size_t n(0);
                 n = c.receive(bufs);
@@ -2323,11 +2323,11 @@ TEST_CASE("websocket")
 
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
     app.wait_for_server_start();
-    boost::asio::io_service is;
+    asio::io_service is;
 
-    boost::asio::ip::tcp::socket c(is);
-    c.connect(boost::asio::ip::tcp::endpoint(
-      boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+    asio::ip::tcp::socket c(is);
+    c.connect(asio::ip::tcp::endpoint(
+      asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
 
     char buf[2048];
@@ -2335,9 +2335,9 @@ TEST_CASE("websocket")
     //----------Handshake----------
     {
         std::fill_n(buf, 2048, 0);
-        c.send(boost::asio::buffer(http_message));
+        c.send(asio::buffer(http_message));
 
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.receive(asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         CHECK(connected);
     }
@@ -2346,8 +2346,8 @@ TEST_CASE("websocket")
         std::fill_n(buf, 2048, 0);
         char ping_message[2]("\x89");
 
-        c.send(boost::asio::buffer(ping_message, 2));
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.send(asio::buffer(ping_message, 2));
+        c.receive(asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         CHECK((int)(unsigned char)buf[0] == 0x8A);
     }
@@ -2357,8 +2357,8 @@ TEST_CASE("websocket")
         char not_ping_message[2 + 6 + 1]("\x81\x06"
                                          "PINGME");
 
-        c.send(boost::asio::buffer(not_ping_message, 8));
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.send(asio::buffer(not_ping_message, 8));
+        c.receive(asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         CHECK((int)(unsigned char)buf[0] == 0x89);
     }
@@ -2368,8 +2368,8 @@ TEST_CASE("websocket")
         char text_message[2 + 5 + 1]("\x81\x05"
                                      "Hello");
 
-        c.send(boost::asio::buffer(text_message, 7));
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.send(asio::buffer(text_message, 7));
+        c.receive(asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         std::string checkstring(std::string(buf).substr(0, 12));
         CHECK(checkstring == "\x81\x0AHello back");
@@ -2380,8 +2380,8 @@ TEST_CASE("websocket")
         char bin_message[2 + 9 + 1]("\x82\x09"
                                     "Hello bin");
 
-        c.send(boost::asio::buffer(bin_message, 11));
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.send(asio::buffer(bin_message, 11));
+        c.receive(asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         std::string checkstring2(std::string(buf).substr(0, 16));
         CHECK(checkstring2 == "\x82\x0EHello back bin");
@@ -2393,8 +2393,8 @@ TEST_CASE("websocket")
                                                 "\x67\xc6\x69\x73"
                                                 "\x2f\xa3\x05\x1f\x08");
 
-        c.send(boost::asio::buffer(text_masked_message, 11));
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.send(asio::buffer(text_masked_message, 11));
+        c.receive(asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         std::string checkstring3(std::string(buf).substr(0, 12));
         CHECK(checkstring3 == "\x81\x0AHello back");
@@ -2406,8 +2406,8 @@ TEST_CASE("websocket")
                                                "\x67\xc6\x69\x73"
                                                "\x2f\xa3\x05\x1f\x08\xe6\x0b\x1a\x09");
 
-        c.send(boost::asio::buffer(bin_masked_message, 15));
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.send(asio::buffer(bin_masked_message, 15));
+        c.receive(asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         std::string checkstring4(std::string(buf).substr(0, 16));
         CHECK(checkstring4 == "\x82\x0EHello back bin");
@@ -2419,8 +2419,8 @@ TEST_CASE("websocket")
                                              "\x00\x05"
                                              "Hello");
 
-        c.send(boost::asio::buffer(b16_text_message, 9));
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.send(asio::buffer(b16_text_message, 9));
+        c.receive(asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         std::string checkstring(std::string(buf).substr(0, 12));
         CHECK(checkstring == "\x81\x0AHello back");
@@ -2432,8 +2432,8 @@ TEST_CASE("websocket")
                                             "\x00\x00\x00\x00\x00\x00\x00\x05"
                                             "Hello");
 
-        c.send(boost::asio::buffer(b64text_message, 15));
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.send(asio::buffer(b64text_message, 15));
+        c.receive(asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         std::string checkstring(std::string(buf).substr(0, 12));
         CHECK(checkstring == "\x81\x0AHello back");
@@ -2443,8 +2443,8 @@ TEST_CASE("websocket")
         std::fill_n(buf, 2048, 0);
         char close_message[10]("\x88"); //I do not know why, but the websocket code does not read this unless it's longer than 4 or so bytes
 
-        c.send(boost::asio::buffer(close_message, 10));
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.send(asio::buffer(close_message, 10));
+        c.receive(asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         CHECK((int)(unsigned char)buf[0] == 0x88);
     }
@@ -2482,11 +2482,11 @@ TEST_CASE("websocket_max_payload")
 
     auto _ = app.websocket_max_payload(3).bindaddr(LOCALHOST_ADDRESS).port(45461).run_async();
     app.wait_for_server_start();
-    boost::asio::io_service is;
+    asio::io_service is;
 
-    boost::asio::ip::tcp::socket c(is);
-    c.connect(boost::asio::ip::tcp::endpoint(
-      boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45461));
+    asio::ip::tcp::socket c(is);
+    c.connect(asio::ip::tcp::endpoint(
+      asio::ip::address::from_string(LOCALHOST_ADDRESS), 45461));
 
 
     char buf[2048];
@@ -2494,9 +2494,9 @@ TEST_CASE("websocket_max_payload")
     //----------Handshake----------
     {
         std::fill_n(buf, 2048, 0);
-        c.send(boost::asio::buffer(http_message));
+        c.send(asio::buffer(http_message));
 
-        c.receive(boost::asio::buffer(buf, 2048));
+        c.receive(asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         CHECK(connected);
     }
@@ -2506,10 +2506,10 @@ TEST_CASE("websocket_max_payload")
         char text_message[2 + 5 + 1]("\x81\x05"
                                      "Hello");
 
-        c.send(boost::asio::buffer(text_message, 7));
+        c.send(asio::buffer(text_message, 7));
         try
         {
-            c.receive(boost::asio::buffer(buf, 2048));
+            c.receive(asio::buffer(buf, 2048));
             FAIL_CHECK();
         }
         catch (std::exception& e)
@@ -2518,8 +2518,8 @@ TEST_CASE("websocket_max_payload")
         }
     }
 
-    boost::system::error_code ec;
-    c.lowest_layer().shutdown(boost::asio::socket_base::shutdown_type::shutdown_both, ec);
+    std::error_code ec;
+    c.lowest_layer().shutdown(asio::socket_base::shutdown_type::shutdown_both, ec);
 
     app.stop();
 } // websocket_max_payload
@@ -2612,19 +2612,19 @@ TEST_CASE("zlib_compression")
         return inflated_string;
     };
 
-    boost::asio::io_service is;
+    asio::io_service is;
     {
         // Compression
         {
-            boost::asio::ip::tcp::socket socket[2] = {boost::asio::ip::tcp::socket(is), boost::asio::ip::tcp::socket(is)};
-            socket[0].connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-            socket[1].connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
+            asio::ip::tcp::socket socket[2] = {asio::ip::tcp::socket(is), asio::ip::tcp::socket(is)};
+            socket[0].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+            socket[1].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
 
-            socket[0].send(boost::asio::buffer(test_compress_msg));
-            socket[1].send(boost::asio::buffer(test_compress_msg));
+            socket[0].send(asio::buffer(test_compress_msg));
+            socket[1].send(asio::buffer(test_compress_msg));
 
-            socket[0].receive(boost::asio::buffer(buf_deflate, 2048));
-            socket[1].receive(boost::asio::buffer(buf_gzip, 2048));
+            socket[0].receive(asio::buffer(buf_deflate, 2048));
+            socket[1].receive(asio::buffer(buf_gzip, 2048));
 
             std::string response_deflate;
             std::string response_gzip;
@@ -2685,15 +2685,15 @@ TEST_CASE("zlib_compression")
         }
         // No Header (thus no compression)
         {
-            boost::asio::ip::tcp::socket socket[2] = {boost::asio::ip::tcp::socket(is), boost::asio::ip::tcp::socket(is)};
-            socket[0].connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-            socket[1].connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
+            asio::ip::tcp::socket socket[2] = {asio::ip::tcp::socket(is), asio::ip::tcp::socket(is)};
+            socket[0].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+            socket[1].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
 
-            socket[0].send(boost::asio::buffer(test_compress_no_header_msg));
-            socket[1].send(boost::asio::buffer(test_compress_no_header_msg));
+            socket[0].send(asio::buffer(test_compress_no_header_msg));
+            socket[1].send(asio::buffer(test_compress_no_header_msg));
 
-            socket[0].receive(boost::asio::buffer(buf_deflate, 2048));
-            socket[1].receive(boost::asio::buffer(buf_gzip, 2048));
+            socket[0].receive(asio::buffer(buf_deflate, 2048));
+            socket[1].receive(asio::buffer(buf_gzip, 2048));
 
             std::string response_deflate(buf_deflate);
             std::string response_gzip(buf_gzip);
@@ -2707,15 +2707,15 @@ TEST_CASE("zlib_compression")
         }
         // No compression
         {
-            boost::asio::ip::tcp::socket socket[2] = {boost::asio::ip::tcp::socket(is), boost::asio::ip::tcp::socket(is)};
-            socket[0].connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-            socket[1].connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
+            asio::ip::tcp::socket socket[2] = {asio::ip::tcp::socket(is), asio::ip::tcp::socket(is)};
+            socket[0].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+            socket[1].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
 
-            socket[0].send(boost::asio::buffer(test_none_msg));
-            socket[1].send(boost::asio::buffer(test_none_msg));
+            socket[0].send(asio::buffer(test_none_msg));
+            socket[1].send(asio::buffer(test_none_msg));
 
-            socket[0].receive(boost::asio::buffer(buf_deflate, 2048));
-            socket[1].receive(boost::asio::buffer(buf_gzip, 2048));
+            socket[0].receive(asio::buffer(buf_deflate, 2048));
+            socket[1].receive(asio::buffer(buf_gzip, 2048));
 
             std::string response_deflate(buf_deflate);
             std::string response_gzip(buf_gzip);
@@ -3013,18 +3013,18 @@ TEST_CASE("timeout")
         auto _ = app.bindaddr(LOCALHOST_ADDRESS).timeout(timeout).port(45451).run_async();
 
         app.wait_for_server_start();
-        boost::asio::io_service is;
+        asio::io_service is;
         std::string sendmsg = "GET /\r\n\r\n";
         future_status status;
 
         {
-            boost::asio::ip::tcp::socket c(is);
-            c.connect(boost::asio::ip::tcp::endpoint(
-              boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+            asio::ip::tcp::socket c(is);
+            c.connect(asio::ip::tcp::endpoint(
+              asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
             auto receive_future = async(launch::async, [&]() {
-                boost::system::error_code ec;
-                c.receive(boost::asio::buffer(buf, 2048), 0, ec);
+                std::error_code ec;
+                c.receive(asio::buffer(buf, 2048), 0, ec);
                 return ec;
             });
             status = receive_future.wait_for(std::chrono::seconds(timeout - 1));
@@ -3032,25 +3032,25 @@ TEST_CASE("timeout")
 
             status = receive_future.wait_for(chrono::seconds(3));
             CHECK(status == future_status::ready);
-            CHECK(receive_future.get() == boost::asio::error::eof);
+            CHECK(receive_future.get() == asio::error::eof);
 
             c.close();
         }
         {
-            boost::asio::ip::tcp::socket c(is);
-            c.connect(boost::asio::ip::tcp::endpoint(
-              boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+            asio::ip::tcp::socket c(is);
+            c.connect(asio::ip::tcp::endpoint(
+              asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
             size_t received;
             auto receive_future = async(launch::async, [&]() {
-                boost::system::error_code ec;
-                received = c.receive(boost::asio::buffer(buf, 2048), 0, ec);
+                std::error_code ec;
+                received = c.receive(asio::buffer(buf, 2048), 0, ec);
                 return ec;
             });
             status = receive_future.wait_for(std::chrono::seconds(timeout - 1));
             CHECK(status == future_status::timeout);
 
-            c.send(boost::asio::buffer(sendmsg));
+            c.send(asio::buffer(sendmsg));
 
             status = receive_future.wait_for(chrono::seconds(3));
             CHECK(status == future_status::ready);
@@ -3069,9 +3069,9 @@ TEST_CASE("timeout")
 
 TEST_CASE("task_timer")
 {
-    using work_guard_type = boost::asio::executor_work_guard<boost::asio::io_service::executor_type>;
+    using work_guard_type = asio::executor_work_guard<asio::io_service::executor_type>;
 
-    boost::asio::io_service io_service;
+    asio::io_service io_service;
     work_guard_type work_guard(io_service.get_executor());
     thread io_thread([&io_service]() {
         io_service.run();

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -3124,3 +3124,27 @@ TEST_CASE("trim")
     CHECK(utility::trim(" a b ") == "a b");
     CHECK(utility::trim("   ") == "");
 }
+
+TEST_CASE("string_equals")
+{
+    CHECK(utility::string_equals("a", "aa") == false);
+    CHECK(utility::string_equals("a", "b") == false);
+    CHECK(utility::string_equals("", "") == true);
+    CHECK(utility::string_equals("abc", "abc") == true);
+    CHECK(utility::string_equals("ABC", "abc") == true);
+
+    CHECK(utility::string_equals("a", "aa", true) == false);
+    CHECK(utility::string_equals("a", "b", true) == false);
+    CHECK(utility::string_equals("", "", true) == true);
+    CHECK(utility::string_equals("abc", "abc", true) == true);
+    CHECK(utility::string_equals("ABC", "abc", true) == false);
+}
+
+TEST_CASE("lexical_cast")
+{
+    CHECK(utility::lexical_cast<int>(4) == 4);
+    CHECK(utility::lexical_cast<double>(4) == 4.0);
+    CHECK(utility::lexical_cast<int>("5") == 5);
+    CHECK(utility::lexical_cast<string>(4) == "4");
+    CHECK(utility::lexical_cast<float>("10", 2) == 10.0f);
+}

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -467,17 +467,17 @@ TEST_CASE("server_handling_error_request")
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
     app.wait_for_server_start();
     std::string sendmsg = "POX";
-    asio::io_service is;
+    boost::asio::io_service is;
     {
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(asio::buffer(sendmsg));
+        c.send(boost::asio::buffer(sendmsg));
 
         try
         {
-            c.receive(asio::buffer(buf, 2048));
+            c.receive(boost::asio::buffer(buf, 2048));
             FAIL_CHECK();
         }
         catch (std::exception& e)
@@ -499,17 +499,17 @@ TEST_CASE("server_handling_error_request_http_version")
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
     app.wait_for_server_start();
     std::string sendmsg = "POST /\r\nContent-Length:3\r\nX-HeaderTest: 123\r\n\r\nA=B\r\n";
-    asio::io_service is;
+    boost::asio::io_service is;
     {
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(asio::buffer(sendmsg));
+        c.send(boost::asio::buffer(sendmsg));
 
         try
         {
-            c.receive(asio::buffer(buf, 2048));
+            c.receive(boost::asio::buffer(buf, 2048));
             FAIL_CHECK();
         }
         catch (std::exception& e)
@@ -541,30 +541,30 @@ TEST_CASE("multi_server")
     std::string sendmsg =
       "POST / HTTP/1.0\r\nContent-Length:3\r\nX-HeaderTest: 123\r\n\r\nA=B\r\n";
     {
-        asio::io_service is;
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        boost::asio::io_service is;
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(asio::buffer(sendmsg));
+        c.send(boost::asio::buffer(sendmsg));
 
-        size_t recved = c.receive(asio::buffer(buf, 2048));
+        size_t recved = c.receive(boost::asio::buffer(buf, 2048));
         CHECK('A' == buf[recved - 1]);
     }
 
     {
-        asio::io_service is;
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
+        boost::asio::io_service is;
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
 
         for (auto ch : sendmsg)
         {
             char buf[1] = {ch};
-            c.send(asio::buffer(buf));
+            c.send(boost::asio::buffer(buf));
         }
 
-        size_t recved = c.receive(asio::buffer(buf, 2048));
+        size_t recved = c.receive(boost::asio::buffer(buf, 2048));
         CHECK('B' == buf[recved - 1]);
     }
 
@@ -591,10 +591,10 @@ TEST_CASE("undefined_status_code")
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45471).run_async();
     app.wait_for_server_start();
 
-    asio::io_service is;
+    boost::asio::io_service is;
     auto sendRequestAndGetStatusCode = [&](const std::string& route) -> unsigned {
-        asio::ip::tcp::socket socket(is);
-        socket.connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), app.port()));
+        boost::asio::ip::tcp::socket socket(is);
+        socket.connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), app.port()));
 
         boost::asio::streambuf request;
         std::ostream request_stream(&request);
@@ -1407,15 +1407,15 @@ TEST_CASE("middleware_context")
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
     app.wait_for_server_start();
     std::string sendmsg = "GET /\r\n\r\n";
-    asio::io_service is;
+    boost::asio::io_service is;
     {
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(asio::buffer(sendmsg));
+        c.send(boost::asio::buffer(sendmsg));
 
-        c.receive(asio::buffer(buf, 2048));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
     }
     {
@@ -1432,13 +1432,13 @@ TEST_CASE("middleware_context")
     }
     std::string sendmsg2 = "GET /break\r\n\r\n";
     {
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(asio::buffer(sendmsg2));
+        c.send(boost::asio::buffer(sendmsg2));
 
-        c.receive(asio::buffer(buf, 2048));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
     }
     {
@@ -1487,25 +1487,25 @@ TEST_CASE("local_middleware")
 
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
     app.wait_for_server_start();
-    asio::io_service is;
+    boost::asio::io_service is;
 
     {
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(asio::buffer("GET /\r\n\r\n"));
-        c.receive(asio::buffer(buf, 2048));
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(boost::asio::buffer("GET /\r\n\r\n"));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
 
         CHECK(std::string(buf).find("200") != std::string::npos);
     }
 
     {
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(asio::buffer("GET /secret\r\n\r\n"));
-        c.receive(asio::buffer(buf, 2048));
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(boost::asio::buffer("GET /secret\r\n\r\n"));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
 
         CHECK(std::string(buf).find("403") != std::string::npos);
@@ -1569,15 +1569,15 @@ TEST_CASE("middleware_blueprint")
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
     app.wait_for_server_start();
 
-    asio::io_service is;
+    boost::asio::io_service is;
     {
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(asio::buffer("GET /a/b/\r\n\r\n"));
+        c.send(boost::asio::buffer("GET /a/b/\r\n\r\n"));
 
-        c.receive(asio::buffer(buf, 2048));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
     }
     {
@@ -1592,13 +1592,13 @@ TEST_CASE("middleware_blueprint")
         CHECK("1 after" == out[6]);
     }
     {
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(asio::buffer("GET /a/c/break\r\n\r\n"));
+        c.send(boost::asio::buffer("GET /a/c/break\r\n\r\n"));
 
-        c.receive(asio::buffer(buf, 2048));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
     }
     {
@@ -1643,15 +1643,15 @@ TEST_CASE("middleware_cookieparser_parse")
     std::string sendmsg =
       "GET /\r\nCookie: key1=value1; key2=\"val=ue2\"; key3=\"val\"ue3\"; "
       "key4=\"val\"ue4\"\r\n\r\n";
-    asio::io_service is;
+    boost::asio::io_service is;
     {
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(asio::buffer(sendmsg));
+        c.send(boost::asio::buffer(sendmsg));
 
-        c.receive(asio::buffer(buf, 2048));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
     }
     {
@@ -1747,42 +1747,42 @@ TEST_CASE("middleware_cors")
                    });
 
     app.wait_for_server_start();
-    asio::io_service is;
+    boost::asio::io_service is;
 
     {
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(asio::buffer("GET /\r\n\r\n"));
+        c.send(boost::asio::buffer("GET /\r\n\r\n"));
 
-        c.receive(asio::buffer(buf, 2048));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
 
         CHECK(std::string(buf).find("Access-Control-Allow-Origin: *") != std::string::npos);
     }
 
     {
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(asio::buffer("GET /origin\r\n\r\n"));
+        c.send(boost::asio::buffer("GET /origin\r\n\r\n"));
 
-        c.receive(asio::buffer(buf, 2048));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
 
         CHECK(std::string(buf).find("Access-Control-Allow-Origin: test.test") != std::string::npos);
     }
 
     {
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
-        c.send(asio::buffer("GET /nocors/path\r\n\r\n"));
+        c.send(boost::asio::buffer("GET /nocors/path\r\n\r\n"));
 
-        c.receive(asio::buffer(buf, 2048));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
 
         CHECK(std::string(buf).find("Access-Control-Allow-Origin:") == std::string::npos);
@@ -1805,21 +1805,21 @@ TEST_CASE("bug_quick_repeated_request")
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
     app.wait_for_server_start();
     std::string sendmsg = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    asio::io_service is;
+    boost::asio::io_service is;
     {
         std::vector<std::future<void>> v;
         for (int i = 0; i < 5; i++)
         {
             v.push_back(async(launch::async, [&] {
-                asio::ip::tcp::socket c(is);
-                c.connect(asio::ip::tcp::endpoint(
-                  asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+                boost::asio::ip::tcp::socket c(is);
+                c.connect(boost::asio::ip::tcp::endpoint(
+                  boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
                 for (int j = 0; j < 5; j++)
                 {
-                    c.send(asio::buffer(sendmsg));
+                    c.send(boost::asio::buffer(sendmsg));
 
-                    size_t received = c.receive(asio::buffer(buf, 2048));
+                    size_t received = c.receive(boost::asio::buffer(buf, 2048));
                     CHECK("hello" == std::string(buf + received - 5, buf + received));
                 }
                 c.close();
@@ -1847,17 +1847,17 @@ TEST_CASE("simple_url_params")
 
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
     app.wait_for_server_start();
-    asio::io_service is;
+    boost::asio::io_service is;
     std::string sendmsg;
 
     // check empty params
     sendmsg = "GET /params\r\n\r\n";
     {
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(asio::buffer(sendmsg));
-        c.receive(asio::buffer(buf, 2048));
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(boost::asio::buffer(sendmsg));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
 
         stringstream ss;
@@ -1868,11 +1868,11 @@ TEST_CASE("simple_url_params")
     // check single presence
     sendmsg = "GET /params?foobar\r\n\r\n";
     {
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(asio::buffer(sendmsg));
-        c.receive(asio::buffer(buf, 2048));
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(boost::asio::buffer(sendmsg));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
 
         CHECK(last_url_params.get("missing") == nullptr);
@@ -1882,11 +1882,11 @@ TEST_CASE("simple_url_params")
     // check multiple presence
     sendmsg = "GET /params?foo&bar&baz\r\n\r\n";
     {
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(asio::buffer(sendmsg));
-        c.receive(asio::buffer(buf, 2048));
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(boost::asio::buffer(sendmsg));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
 
         CHECK(last_url_params.get("missing") == nullptr);
@@ -1897,11 +1897,11 @@ TEST_CASE("simple_url_params")
     // check single value
     sendmsg = "GET /params?hello=world\r\n\r\n";
     {
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(asio::buffer(sendmsg));
-        c.receive(asio::buffer(buf, 2048));
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(boost::asio::buffer(sendmsg));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
 
         CHECK(string(last_url_params.get("hello")) == "world");
@@ -1909,11 +1909,11 @@ TEST_CASE("simple_url_params")
     // check multiple value
     sendmsg = "GET /params?hello=world&left=right&up=down\r\n\r\n";
     {
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(asio::buffer(sendmsg));
-        c.receive(asio::buffer(buf, 2048));
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(boost::asio::buffer(sendmsg));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
 
         query_string mutable_params(last_url_params);
@@ -1929,11 +1929,11 @@ TEST_CASE("simple_url_params")
     // check multiple value, multiple types
     sendmsg = "GET /params?int=100&double=123.45&boolean=1\r\n\r\n";
     {
-        asio::ip::tcp::socket c(is);
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(asio::buffer(sendmsg));
-        c.receive(asio::buffer(buf, 2048));
+        boost::asio::ip::tcp::socket c(is);
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(boost::asio::buffer(sendmsg));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
 
         CHECK(boost::lexical_cast<int>(last_url_params.get("int")) == 100);
@@ -1944,12 +1944,12 @@ TEST_CASE("simple_url_params")
     // check single array value
     sendmsg = "GET /params?tmnt[]=leonardo\r\n\r\n";
     {
-        asio::ip::tcp::socket c(is);
+        boost::asio::ip::tcp::socket c(is);
 
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(asio::buffer(sendmsg));
-        c.receive(asio::buffer(buf, 2048));
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(boost::asio::buffer(sendmsg));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
 
         CHECK(last_url_params.get("tmnt") == nullptr);
@@ -1959,12 +1959,12 @@ TEST_CASE("simple_url_params")
     // check multiple array value
     sendmsg = "GET /params?tmnt[]=leonardo&tmnt[]=donatello&tmnt[]=raphael\r\n\r\n";
     {
-        asio::ip::tcp::socket c(is);
+        boost::asio::ip::tcp::socket c(is);
 
-        c.connect(asio::ip::tcp::endpoint(
-          asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(asio::buffer(sendmsg));
-        c.receive(asio::buffer(buf, 2048));
+        c.connect(boost::asio::ip::tcp::endpoint(
+          boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(boost::asio::buffer(sendmsg));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
 
         CHECK(last_url_params.get_list("tmnt").size() == 3);
@@ -1977,11 +1977,11 @@ TEST_CASE("simple_url_params")
     // check dictionary value
     sendmsg = "GET /params?kees[one]=vee1&kees[two]=vee2&kees[three]=vee3\r\n\r\n";
     {
-        asio::ip::tcp::socket c(is);
+        boost::asio::ip::tcp::socket c(is);
 
-        c.connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-        c.send(asio::buffer(sendmsg));
-        c.receive(asio::buffer(buf, 2048));
+        c.connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+        c.send(boost::asio::buffer(sendmsg));
+        c.receive(boost::asio::buffer(buf, 2048));
         c.close();
 
         CHECK(last_url_params.get_dict("kees").size() == 3);
@@ -2243,19 +2243,19 @@ TEST_CASE("stream_response")
     std::thread runTest([&app, &key_response, key_response_size, keyword_]() {
         auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
         app.wait_for_server_start();
-        asio::io_service is;
+        boost::asio::io_service is;
         std::string sendmsg;
 
         //Total bytes received
         unsigned int received = 0;
         sendmsg = "GET /test HTTP/1.0\r\n\r\n";
         {
-            asio::streambuf b;
+            boost::asio::streambuf b;
 
-            asio::ip::tcp::socket c(is);
-            c.connect(asio::ip::tcp::endpoint(
-              asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-            c.send(asio::buffer(sendmsg));
+            boost::asio::ip::tcp::socket c(is);
+            c.connect(boost::asio::ip::tcp::endpoint(
+              boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+            c.send(boost::asio::buffer(sendmsg));
 
             // consuming the headers, since we don't need those for the test
             static char buf[2048];
@@ -2275,7 +2275,7 @@ TEST_CASE("stream_response")
 
             while (received < key_response_size)
             {
-                asio::streambuf::mutable_buffers_type bufs = b.prepare(16384);
+                boost::asio::streambuf::mutable_buffers_type bufs = b.prepare(16384);
 
                 size_t n(0);
                 n = c.receive(bufs);
@@ -2323,11 +2323,11 @@ TEST_CASE("websocket")
 
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
     app.wait_for_server_start();
-    asio::io_service is;
+    boost::asio::io_service is;
 
-    asio::ip::tcp::socket c(is);
-    c.connect(asio::ip::tcp::endpoint(
-      asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+    boost::asio::ip::tcp::socket c(is);
+    c.connect(boost::asio::ip::tcp::endpoint(
+      boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
 
     char buf[2048];
@@ -2335,9 +2335,9 @@ TEST_CASE("websocket")
     //----------Handshake----------
     {
         std::fill_n(buf, 2048, 0);
-        c.send(asio::buffer(http_message));
+        c.send(boost::asio::buffer(http_message));
 
-        c.receive(asio::buffer(buf, 2048));
+        c.receive(boost::asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         CHECK(connected);
     }
@@ -2346,8 +2346,8 @@ TEST_CASE("websocket")
         std::fill_n(buf, 2048, 0);
         char ping_message[2]("\x89");
 
-        c.send(asio::buffer(ping_message, 2));
-        c.receive(asio::buffer(buf, 2048));
+        c.send(boost::asio::buffer(ping_message, 2));
+        c.receive(boost::asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         CHECK((int)(unsigned char)buf[0] == 0x8A);
     }
@@ -2357,8 +2357,8 @@ TEST_CASE("websocket")
         char not_ping_message[2 + 6 + 1]("\x81\x06"
                                          "PINGME");
 
-        c.send(asio::buffer(not_ping_message, 8));
-        c.receive(asio::buffer(buf, 2048));
+        c.send(boost::asio::buffer(not_ping_message, 8));
+        c.receive(boost::asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         CHECK((int)(unsigned char)buf[0] == 0x89);
     }
@@ -2368,8 +2368,8 @@ TEST_CASE("websocket")
         char text_message[2 + 5 + 1]("\x81\x05"
                                      "Hello");
 
-        c.send(asio::buffer(text_message, 7));
-        c.receive(asio::buffer(buf, 2048));
+        c.send(boost::asio::buffer(text_message, 7));
+        c.receive(boost::asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         std::string checkstring(std::string(buf).substr(0, 12));
         CHECK(checkstring == "\x81\x0AHello back");
@@ -2380,8 +2380,8 @@ TEST_CASE("websocket")
         char bin_message[2 + 9 + 1]("\x82\x09"
                                     "Hello bin");
 
-        c.send(asio::buffer(bin_message, 11));
-        c.receive(asio::buffer(buf, 2048));
+        c.send(boost::asio::buffer(bin_message, 11));
+        c.receive(boost::asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         std::string checkstring2(std::string(buf).substr(0, 16));
         CHECK(checkstring2 == "\x82\x0EHello back bin");
@@ -2393,8 +2393,8 @@ TEST_CASE("websocket")
                                                 "\x67\xc6\x69\x73"
                                                 "\x2f\xa3\x05\x1f\x08");
 
-        c.send(asio::buffer(text_masked_message, 11));
-        c.receive(asio::buffer(buf, 2048));
+        c.send(boost::asio::buffer(text_masked_message, 11));
+        c.receive(boost::asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         std::string checkstring3(std::string(buf).substr(0, 12));
         CHECK(checkstring3 == "\x81\x0AHello back");
@@ -2406,8 +2406,8 @@ TEST_CASE("websocket")
                                                "\x67\xc6\x69\x73"
                                                "\x2f\xa3\x05\x1f\x08\xe6\x0b\x1a\x09");
 
-        c.send(asio::buffer(bin_masked_message, 15));
-        c.receive(asio::buffer(buf, 2048));
+        c.send(boost::asio::buffer(bin_masked_message, 15));
+        c.receive(boost::asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         std::string checkstring4(std::string(buf).substr(0, 16));
         CHECK(checkstring4 == "\x82\x0EHello back bin");
@@ -2419,8 +2419,8 @@ TEST_CASE("websocket")
                                              "\x00\x05"
                                              "Hello");
 
-        c.send(asio::buffer(b16_text_message, 9));
-        c.receive(asio::buffer(buf, 2048));
+        c.send(boost::asio::buffer(b16_text_message, 9));
+        c.receive(boost::asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         std::string checkstring(std::string(buf).substr(0, 12));
         CHECK(checkstring == "\x81\x0AHello back");
@@ -2432,8 +2432,8 @@ TEST_CASE("websocket")
                                             "\x00\x00\x00\x00\x00\x00\x00\x05"
                                             "Hello");
 
-        c.send(asio::buffer(b64text_message, 15));
-        c.receive(asio::buffer(buf, 2048));
+        c.send(boost::asio::buffer(b64text_message, 15));
+        c.receive(boost::asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         std::string checkstring(std::string(buf).substr(0, 12));
         CHECK(checkstring == "\x81\x0AHello back");
@@ -2443,8 +2443,8 @@ TEST_CASE("websocket")
         std::fill_n(buf, 2048, 0);
         char close_message[10]("\x88"); //I do not know why, but the websocket code does not read this unless it's longer than 4 or so bytes
 
-        c.send(asio::buffer(close_message, 10));
-        c.receive(asio::buffer(buf, 2048));
+        c.send(boost::asio::buffer(close_message, 10));
+        c.receive(boost::asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         CHECK((int)(unsigned char)buf[0] == 0x88);
     }
@@ -2482,11 +2482,11 @@ TEST_CASE("websocket_max_payload")
 
     auto _ = app.websocket_max_payload(3).bindaddr(LOCALHOST_ADDRESS).port(45461).run_async();
     app.wait_for_server_start();
-    asio::io_service is;
+    boost::asio::io_service is;
 
-    asio::ip::tcp::socket c(is);
-    c.connect(asio::ip::tcp::endpoint(
-      asio::ip::address::from_string(LOCALHOST_ADDRESS), 45461));
+    boost::asio::ip::tcp::socket c(is);
+    c.connect(boost::asio::ip::tcp::endpoint(
+      boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45461));
 
 
     char buf[2048];
@@ -2494,9 +2494,9 @@ TEST_CASE("websocket_max_payload")
     //----------Handshake----------
     {
         std::fill_n(buf, 2048, 0);
-        c.send(asio::buffer(http_message));
+        c.send(boost::asio::buffer(http_message));
 
-        c.receive(asio::buffer(buf, 2048));
+        c.receive(boost::asio::buffer(buf, 2048));
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         CHECK(connected);
     }
@@ -2506,10 +2506,10 @@ TEST_CASE("websocket_max_payload")
         char text_message[2 + 5 + 1]("\x81\x05"
                                      "Hello");
 
-        c.send(asio::buffer(text_message, 7));
+        c.send(boost::asio::buffer(text_message, 7));
         try
         {
-            c.receive(asio::buffer(buf, 2048));
+            c.receive(boost::asio::buffer(buf, 2048));
             FAIL_CHECK();
         }
         catch (std::exception& e)
@@ -2612,19 +2612,19 @@ TEST_CASE("zlib_compression")
         return inflated_string;
     };
 
-    asio::io_service is;
+    boost::asio::io_service is;
     {
         // Compression
         {
-            asio::ip::tcp::socket socket[2] = {asio::ip::tcp::socket(is), asio::ip::tcp::socket(is)};
-            socket[0].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-            socket[1].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
+            boost::asio::ip::tcp::socket socket[2] = {boost::asio::ip::tcp::socket(is), boost::asio::ip::tcp::socket(is)};
+            socket[0].connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+            socket[1].connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
 
-            socket[0].send(asio::buffer(test_compress_msg));
-            socket[1].send(asio::buffer(test_compress_msg));
+            socket[0].send(boost::asio::buffer(test_compress_msg));
+            socket[1].send(boost::asio::buffer(test_compress_msg));
 
-            socket[0].receive(asio::buffer(buf_deflate, 2048));
-            socket[1].receive(asio::buffer(buf_gzip, 2048));
+            socket[0].receive(boost::asio::buffer(buf_deflate, 2048));
+            socket[1].receive(boost::asio::buffer(buf_gzip, 2048));
 
             std::string response_deflate;
             std::string response_gzip;
@@ -2685,15 +2685,15 @@ TEST_CASE("zlib_compression")
         }
         // No Header (thus no compression)
         {
-            asio::ip::tcp::socket socket[2] = {asio::ip::tcp::socket(is), asio::ip::tcp::socket(is)};
-            socket[0].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-            socket[1].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
+            boost::asio::ip::tcp::socket socket[2] = {boost::asio::ip::tcp::socket(is), boost::asio::ip::tcp::socket(is)};
+            socket[0].connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+            socket[1].connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
 
-            socket[0].send(asio::buffer(test_compress_no_header_msg));
-            socket[1].send(asio::buffer(test_compress_no_header_msg));
+            socket[0].send(boost::asio::buffer(test_compress_no_header_msg));
+            socket[1].send(boost::asio::buffer(test_compress_no_header_msg));
 
-            socket[0].receive(asio::buffer(buf_deflate, 2048));
-            socket[1].receive(asio::buffer(buf_gzip, 2048));
+            socket[0].receive(boost::asio::buffer(buf_deflate, 2048));
+            socket[1].receive(boost::asio::buffer(buf_gzip, 2048));
 
             std::string response_deflate(buf_deflate);
             std::string response_gzip(buf_gzip);
@@ -2707,15 +2707,15 @@ TEST_CASE("zlib_compression")
         }
         // No compression
         {
-            asio::ip::tcp::socket socket[2] = {asio::ip::tcp::socket(is), asio::ip::tcp::socket(is)};
-            socket[0].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
-            socket[1].connect(asio::ip::tcp::endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
+            boost::asio::ip::tcp::socket socket[2] = {boost::asio::ip::tcp::socket(is), boost::asio::ip::tcp::socket(is)};
+            socket[0].connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+            socket[1].connect(boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45452));
 
-            socket[0].send(asio::buffer(test_none_msg));
-            socket[1].send(asio::buffer(test_none_msg));
+            socket[0].send(boost::asio::buffer(test_none_msg));
+            socket[1].send(boost::asio::buffer(test_none_msg));
 
-            socket[0].receive(asio::buffer(buf_deflate, 2048));
-            socket[1].receive(asio::buffer(buf_gzip, 2048));
+            socket[0].receive(boost::asio::buffer(buf_deflate, 2048));
+            socket[1].receive(boost::asio::buffer(buf_gzip, 2048));
 
             std::string response_deflate(buf_deflate);
             std::string response_gzip(buf_gzip);
@@ -3013,18 +3013,18 @@ TEST_CASE("timeout")
         auto _ = app.bindaddr(LOCALHOST_ADDRESS).timeout(timeout).port(45451).run_async();
 
         app.wait_for_server_start();
-        asio::io_service is;
+        boost::asio::io_service is;
         std::string sendmsg = "GET /\r\n\r\n";
         future_status status;
 
         {
-            asio::ip::tcp::socket c(is);
-            c.connect(asio::ip::tcp::endpoint(
-              asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+            boost::asio::ip::tcp::socket c(is);
+            c.connect(boost::asio::ip::tcp::endpoint(
+              boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
             auto receive_future = async(launch::async, [&]() {
                 boost::system::error_code ec;
-                c.receive(asio::buffer(buf, 2048), 0, ec);
+                c.receive(boost::asio::buffer(buf, 2048), 0, ec);
                 return ec;
             });
             status = receive_future.wait_for(std::chrono::seconds(timeout - 1));
@@ -3032,25 +3032,25 @@ TEST_CASE("timeout")
 
             status = receive_future.wait_for(chrono::seconds(3));
             CHECK(status == future_status::ready);
-            CHECK(receive_future.get() == asio::error::eof);
+            CHECK(receive_future.get() == boost::asio::error::eof);
 
             c.close();
         }
         {
-            asio::ip::tcp::socket c(is);
-            c.connect(asio::ip::tcp::endpoint(
-              asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
+            boost::asio::ip::tcp::socket c(is);
+            c.connect(boost::asio::ip::tcp::endpoint(
+              boost::asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
             size_t received;
             auto receive_future = async(launch::async, [&]() {
                 boost::system::error_code ec;
-                received = c.receive(asio::buffer(buf, 2048), 0, ec);
+                received = c.receive(boost::asio::buffer(buf, 2048), 0, ec);
                 return ec;
             });
             status = receive_future.wait_for(std::chrono::seconds(timeout - 1));
             CHECK(status == future_status::timeout);
 
-            c.send(asio::buffer(sendmsg));
+            c.send(boost::asio::buffer(sendmsg));
 
             status = receive_future.wait_for(chrono::seconds(3));
             CHECK(status == future_status::ready);

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2524,7 +2524,7 @@ TEST_CASE("websocket_max_payload")
         }
     }
 
-    std::error_code ec;
+    asio::error_code ec;
     c.lowest_layer().shutdown(asio::socket_base::shutdown_type::shutdown_both, ec);
 
     app.stop();
@@ -3029,7 +3029,7 @@ TEST_CASE("timeout")
               asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
             auto receive_future = async(launch::async, [&]() {
-                std::error_code ec;
+                asio::error_code ec;
                 c.receive(asio::buffer(buf, 2048), 0, ec);
                 return ec;
             });
@@ -3049,7 +3049,7 @@ TEST_CASE("timeout")
 
             size_t received;
             auto receive_future = async(launch::async, [&]() {
-                std::error_code ec;
+                asio::error_code ec;
                 received = c.receive(asio::buffer(buf, 2048), 0, ec);
                 return ec;
             });

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,68 +3,13 @@
     "version-string": "master",
     "dependencies": [
         {
-            "name": "boost-array",
-            "version>=": "1.70.0"
-        },
-        {
-            "name": "boost-algorithm",
-            "version>=": "1.70.0"
-        },
-        {
-            "name": "boost-asio",
-            "version>=": "1.70.0"
-        },
-        {
-            "name": "boost-date-time",
-            "version>=": "1.70.0"
-        },
-        {
-            "name": "boost-functional",
-            "version>=": "1.70.0"
-        },
-        {
-            "name": "boost-lexical-cast",
-            "version>=": "1.70.0"
-        },
-        {
-            "name": "boost-optional",
-            "version>=": "1.70.0"
+            "name": "asio"
         },
         {
             "name": "openssl"
         },
         {
             "name": "zlib"
-        }
-    ],
-    "overrides": [
-        {
-            "name": "boost-array",
-            "version": "1.70.0"
-        },
-        {
-            "name": "boost-algorithm",
-            "version": "1.70.0"
-        },
-        {
-            "name": "boost-asio",
-            "version-semver": "1.70.0-2"
-        },
-        {
-            "name": "boost-date-time",
-            "version": "1.70.0"
-        },
-        {
-            "name": "boost-functional",
-            "version": "1.70.0"
-        },
-        {
-            "name": "boost-lexical-cast",
-            "version": "1.70.0"
-        },
-        {
-            "name": "boost-optional",
-            "version": "1.70.0"
         }
     ],
     "builtin-baseline": "44d94c2edbd44f0c01d66c2ad95eb6982a9a61bc"


### PR DESCRIPTION
This Pr removes `Boost` as a dependency and will instead rely on the standalone `asio` library.
CI now installs `libasio-dev` instead of `libboost-all-dev` and the documentation resembles that change. (Although the MacOS section could use a double-check, I have no such device on hand)

### Proper testing necessary
Unittests are all passing but I think some real-life testing does no harm.

### Removed Boost functions and types and their replacements:
- `boost::lexical_cast` becomes `crow::utility::lexical_cast`. Its implementation relies on `std::stringstream` for converting between types.
- `boost::hash_combine` is replaced by a private function. Its implementation idea stems from around the internet and can be found in multiple sources.
- `boost::iequals` is replaced by `crow::utility::string_equals` taking two mandatory `std::string` arguments and one optional `bool` controlling the case-sensitivity.
- `boost::system::error_code` is replaced by `asio::error_code` which is an alias for `std::error_code`.
- Every `boost::asio::` function is replaced with their standalone `asio::` counterpart.
- `boost::array` is replaced with `std::array`.
- `boost::posix_time` is replaced with a `std::chrono` equivalent.
- `boost::*_comparable` is dropped and the respective operators are implemented manually.
- `boost::lexicographical_compare` is replaced with `std::lexicographical_compare`.
- `boost::optional` is replaced with `std::unique_ptr`.
- `boost::trim` is replaced with `crow::utility::trim`.

### Introduced functions (\*explicitly\* tested?):
- `private void crow::ci_hash::hash_combine`. (❌)
- `private bool crow::json::detail::r_string::equals`. (❌)
- Copy-constructor for `crow::CookieParser::Cookie`. (❌)
- `bool crow::utility::string_equals` (✅)
- `T crow::utility::lexical_cast` (✅)
- `std::string crow::utility::trim` (✅)