### PR TITLE
overload template_t::render to accept context as an r-value

### DIFF
--- a/include/crow/mustache.h
+++ b/include/crow/mustache.h
@@ -379,6 +379,12 @@ namespace crow
                 return rendered_template(ret);
             }
 
+            /// Apply the values from the context provided and output a returnable template from this mustache template
+            rendered_template render(context&& ctx) const
+            {
+                return render(ctx);
+            }
+
             /// Output a returnable template from this mustache template
             std::string render_string() const
             {


### PR DESCRIPTION
This allows us to do:

```cpp
return crow::mustache::load("index.mustache").render({ { "key", "value" } });
```

Rather than:

```cpp
crow::mustache::context ctx{ {"key", "value"} };
return crow::mustache::load("index.mustache").render(ctx);
```