### PR TITLE
Fix failing unittests in master and 1.0

### DIFF
--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2921,12 +2921,18 @@ TEST_CASE("blueprint")
 TEST_CASE("base64")
 {
     unsigned char sample_bin[] = {0x14, 0xfb, 0x9c, 0x03, 0xd9, 0x7e};
+    std::string sample_bin_str(reinterpret_cast<char const*>(sample_bin),
+                               sizeof(sample_bin) / sizeof(sample_bin[0]));
     std::string sample_bin_enc = "FPucA9l+";
     std::string sample_bin_enc_url = "FPucA9l-";
     unsigned char sample_bin1[] = {0x14, 0xfb, 0x9c, 0x03, 0xd9};
+    std::string sample_bin1_str(reinterpret_cast<char const*>(sample_bin1),
+                                sizeof(sample_bin1) / sizeof(sample_bin1[0]));
     std::string sample_bin1_enc = "FPucA9k=";
     std::string sample_bin1_enc_np = "FPucA9k";
     unsigned char sample_bin2[] = {0x14, 0xfb, 0x9c, 0x03};
+    std::string sample_bin2_str(reinterpret_cast<char const*>(sample_bin2),
+                                sizeof(sample_bin2) / sizeof(sample_bin2[0]));
     std::string sample_bin2_enc = "FPucAw==";
     std::string sample_bin2_enc_np = "FPucAw";
     std::string sample_text = "Crow Allows users to handle requests that may not come from the network. This is done by calling the handle(req, res) method and providing a request and response objects. Which causes crow to identify and run the appropriate handler, returning the resulting response.";
@@ -2934,20 +2940,19 @@ TEST_CASE("base64")
 
 
     CHECK(crow::utility::base64encode(sample_text, sample_text.length()) == sample_base64);
-    CHECK(crow::utility::base64encode((unsigned char*)sample_bin, 6) == sample_bin_enc);
-    CHECK(crow::utility::base64encode_urlsafe((unsigned char*)sample_bin, 6) == sample_bin_enc_url);
-    CHECK(crow::utility::base64encode((unsigned char*)sample_bin1, 5) == sample_bin1_enc);
-    CHECK(crow::utility::base64encode((unsigned char*)sample_bin2, 4) == sample_bin2_enc);
-
+    CHECK(crow::utility::base64encode(sample_bin, 6) == sample_bin_enc);
+    CHECK(crow::utility::base64encode_urlsafe(sample_bin, 6) == sample_bin_enc_url);
+    CHECK(crow::utility::base64encode(sample_bin1, 5) == sample_bin1_enc);
+    CHECK(crow::utility::base64encode(sample_bin2, 4) == sample_bin2_enc);
 
     CHECK(crow::utility::base64decode(sample_base64) == sample_text);
     CHECK(crow::utility::base64decode(sample_base64, sample_base64.length()) == sample_text);
-    CHECK(crow::utility::base64decode(sample_bin_enc, 8) == std::string(reinterpret_cast<char const*>(sample_bin)));
-    CHECK(crow::utility::base64decode(sample_bin_enc_url, 8) == std::string(reinterpret_cast<char const*>(sample_bin)));
-    CHECK(crow::utility::base64decode(sample_bin1_enc, 8) == std::string(reinterpret_cast<char const*>(sample_bin1)).substr(0, 5));
-    CHECK(crow::utility::base64decode(sample_bin1_enc_np, 7) == std::string(reinterpret_cast<char const*>(sample_bin1)).substr(0, 5));
-    CHECK(crow::utility::base64decode(sample_bin2_enc, 8) == std::string(reinterpret_cast<char const*>(sample_bin2)).substr(0, 4));
-    CHECK(crow::utility::base64decode(sample_bin2_enc_np, 6) == std::string(reinterpret_cast<char const*>(sample_bin2)).substr(0, 4));
+    CHECK(crow::utility::base64decode(sample_bin_enc, 8) == sample_bin_str);
+    CHECK(crow::utility::base64decode(sample_bin_enc_url, 8) == sample_bin_str);
+    CHECK(crow::utility::base64decode(sample_bin1_enc, 8) == sample_bin1_str);
+    CHECK(crow::utility::base64decode(sample_bin1_enc_np, 7) == sample_bin1_str);
+    CHECK(crow::utility::base64decode(sample_bin2_enc, 8) == sample_bin2_str);
+    CHECK(crow::utility::base64decode(sample_bin2_enc_np, 6) == sample_bin2_str);
 } // base64
 
 TEST_CASE("sanitize_filename")

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2240,7 +2240,7 @@ TEST_CASE("stream_response")
     app.validate();
 
     // running the test on a separate thread to allow the client to sleep
-    std::thread runTest([&app, &key_response, key_response_size]() {
+    std::thread runTest([&app, &key_response, key_response_size, keyword_]() {
         auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
         app.wait_for_server_start();
         asio::io_service is;
@@ -2257,15 +2257,21 @@ TEST_CASE("stream_response")
               asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
             c.send(asio::buffer(sendmsg));
 
-            //consuming the headers, since we don't need those for the test
+            // consuming the headers, since we don't need those for the test
             static char buf[2048];
             size_t received_headers_bytes = 0;
 
-            // magic number is 102 (it's the size of the headers, which is how much this line below needs to read)
-            const size_t headers_bytes = 102;
-            while (received_headers_bytes < headers_bytes)
-                received_headers_bytes += c.receive(asio::buffer(buf, 102));
-            received += received_headers_bytes - headers_bytes; //add any extra that might have been received to the proper received count
+            // Magic number is 102. It's the size of the headers, which is at
+            // least how much we need to read. Since the header size may change
+            // and break the test, we read twice as much as the header and
+            // search in the received data for the first occurrence of keyword_.
+            const size_t headers_bytes_and_some = 102 * 2;
+            while (received_headers_bytes < headers_bytes_and_some)
+                received_headers_bytes += c.receive(asio::buffer(buf + received_headers_bytes,
+                                                                 sizeof(buf) / sizeof(buf[0]) - received_headers_bytes));
+
+            const std::string::size_type header_end_pos = std::string(buf, received_headers_bytes).find(keyword_);
+            received += received_headers_bytes - header_end_pos; // add any extra that might have been received to the proper received count
 
             while (received < key_response_size)
             {


### PR DESCRIPTION
Created pull request on master instead of the 1.0-branch, as requested (ref. pull request #460).

Running the unit tests on the master branch uncovered a race condition in a short test, where the server is started, waited for and then almost immediately stopped again. The race condition resulted in a deadlock. A proposed fix for this issue is in commit 3782044.