### PR TITLE
only allow regular files in set_static_file_info, return 404 in all o…

### DIFF
--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -233,7 +233,7 @@ namespace crow
 #ifdef CROW_ENABLE_COMPRESSION
             compressed = false;
 #endif
-            if (file_info.statResult == 0)
+            if (file_info.statResult == 0 && S_ISREG(file_info.statbuf.st_mode))
             {
                 std::size_t last_dot = path.find_last_of(".");
                 std::string extension = path.substr(last_dot + 1);
@@ -257,7 +257,6 @@ namespace crow
             {
                 code = 404;
                 file_info.path.clear();
-                this->end();
             }
         }
 

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -4,7 +4,15 @@
 #include <ios>
 #include <fstream>
 #include <sstream>
+#if defined(_MSC_VER)
+#define _CRT_INTERNAL_NONSTDC_NAMES 1
 #include <sys/stat.h>
+#if !defined(S_ISREG) && defined(S_IFMT) && defined(S_IFREG)
+#define S_ISREG(m) (((m)&S_IFMT) == S_IFREG)
+#endif
+#else
+#include <sys/stat.h>
+#endif
 
 #include "crow/http_request.h"
 #include "crow/ci_map.h"

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -4,6 +4,8 @@
 #include <ios>
 #include <fstream>
 #include <sstream>
+// S_ISREG is not defined for windows
+// This defines it like suggested in https://stackoverflow.com/a/62371749
 #if defined(_MSC_VER)
 #define _CRT_INTERNAL_NONSTDC_NAMES 1
 #endif

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -6,12 +6,10 @@
 #include <sstream>
 #if defined(_MSC_VER)
 #define _CRT_INTERNAL_NONSTDC_NAMES 1
+#endif
 #include <sys/stat.h>
 #if !defined(S_ISREG) && defined(S_IFMT) && defined(S_IFREG)
 #define S_ISREG(m) (((m)&S_IFMT) == S_IFREG)
-#endif
-#else
-#include <sys/stat.h>
 #endif
 
 #include "crow/http_request.h"


### PR DESCRIPTION
This is a fix for https://github.com/CrowCpp/Crow/issues/469
1) if the `path` given to `set_static_file_info` or `set_static_file_info_unsafe` is not a regular file return `404`.
2) `this->end()` in the error case in `set_static_file_info_unsafe` locks crow, when the route-handler uses `return response`, because the completion-handler is called twice. Removing it, makes it work in all cases.