### PR TITLE
Add error message to Websocket `onerror` handler

### DIFF
--- a/docs/guides/websockets.md
+++ b/docs/guides/websockets.md
@@ -8,7 +8,7 @@ A websocket route differs from a normal route quite a bit. It uses A slightly al
 - `#!cpp onaccept([&](const crow::request& req, void** userdata){handler code goes here})`
 - `#!cpp onopen([&](crow::websocket::connection& conn){handler code goes here})`
 - `#!cpp onmessage([&](crow::websocket::connection& conn, const std::string message, bool is_binary){handler code goes here})`
-- `#!cpp onerror([&](crow::websocket::connection& conn){handler code goes here})`
+- `#!cpp onerror([&](crow::websocket::connection& conn, const std::string error_message){handler code goes here})`
 - `#!cpp onclose([&](crow::websocket::connection& conn, const std::string reason){handler code goes here})`
 
 !!! note

--- a/docs/guides/websockets.md
+++ b/docs/guides/websockets.md
@@ -7,9 +7,9 @@ A websocket route differs from a normal route quite a bit. It uses A slightly al
 
 - `#!cpp onaccept([&](const crow::request& req, void** userdata){handler code goes here})`
 - `#!cpp onopen([&](crow::websocket::connection& conn){handler code goes here})`
-- `#!cpp onmessage([&](crow::websocket::connection& conn, const std::string message, bool is_binary){handler code goes here})`
-- `#!cpp onerror([&](crow::websocket::connection& conn, const std::string error_message){handler code goes here})`
-- `#!cpp onclose([&](crow::websocket::connection& conn, const std::string reason){handler code goes here})`
+- `#!cpp onmessage([&](crow::websocket::connection& conn, const std::string& message, bool is_binary){handler code goes here})`
+- `#!cpp onerror([&](crow::websocket::connection& conn, const std::string& error_message){handler code goes here})`
+- `#!cpp onclose([&](crow::websocket::connection& conn, const std::string& reason){handler code goes here})`
 
 !!! note
 

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -1852,9 +1852,9 @@ namespace crow
                                     case start: // Loop and lookahead until a decimal point is found
                                         if (ch == '.')
                                         {
-                                            char fch  = *(p + 1);
+                                            char fch = *(p + 1);
                                             // if the first character is 0, leave it be (this is so that "1.00000" becomes "1.0" and not "1.")
-                                            if ( fch != '\0' && fch == '0') p++;
+                                            if (fch != '\0' && fch == '0') p++;
                                             f_state = decp;
                                         }
                                         p++;

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -508,7 +508,7 @@ namespace crow
         std::function<void(crow::websocket::connection&)> open_handler_;
         std::function<void(crow::websocket::connection&, const std::string&, bool)> message_handler_;
         std::function<void(crow::websocket::connection&, const std::string&)> close_handler_;
-        std::function<void(crow::websocket::connection&)> error_handler_;
+        std::function<void(crow::websocket::connection&, const std::string&)> error_handler_;
         std::function<bool(const crow::request&, void**)> accept_handler_;
         uint64_t max_payload_;
         bool max_payload_override_ = false;

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -75,7 +75,7 @@ namespace crow
                        std::function<void(crow::websocket::connection&)> open_handler,
                        std::function<void(crow::websocket::connection&, const std::string&, bool)> message_handler,
                        std::function<void(crow::websocket::connection&, const std::string&)> close_handler,
-                       std::function<void(crow::websocket::connection&)> error_handler,
+                       std::function<void(crow::websocket::connection&, const std::string&)> error_handler,
                        std::function<bool(const crow::request&, void**)> accept_handler):
               adaptor_(std::move(adaptor)),
               handler_(handler),
@@ -315,7 +315,7 @@ namespace crow
                                       adaptor_.shutdown_readwrite();
                                       adaptor_.close();
                                       if (error_handler_)
-                                          error_handler_(*this);
+                                          error_handler_(*this, "Client connection not masked.");
                                       check_destroy();
 #endif
                                   }
@@ -341,7 +341,7 @@ namespace crow
                                   adaptor_.shutdown_readwrite();
                                   adaptor_.close();
                                   if (error_handler_)
-                                      error_handler_(*this);
+                                      error_handler_(*this, ec.message());
                                   check_destroy();
                               }
                           });
@@ -379,7 +379,7 @@ namespace crow
                                   adaptor_.shutdown_readwrite();
                                   adaptor_.close();
                                   if (error_handler_)
-                                      error_handler_(*this);
+                                      error_handler_(*this, ec.message());
                                   check_destroy();
                               }
                           });
@@ -414,7 +414,7 @@ namespace crow
                                   adaptor_.shutdown_readwrite();
                                   adaptor_.close();
                                   if (error_handler_)
-                                      error_handler_(*this);
+                                      error_handler_(*this, ec.message());
                                   check_destroy();
                               }
                           });
@@ -426,7 +426,7 @@ namespace crow
                             close_connection_ = true;
                             adaptor_.close();
                             if (error_handler_)
-                                error_handler_(*this);
+                                error_handler_(*this, "Message length exceeds maximum paylaod.");
                             check_destroy();
                         }
                         else if (has_mask_)
@@ -455,7 +455,7 @@ namespace crow
                                   {
                                       close_connection_ = true;
                                       if (error_handler_)
-                                          error_handler_(*this);
+                                          error_handler_(*this, ec.message());
                                       adaptor_.shutdown_readwrite();
                                       adaptor_.close();
                                       check_destroy();
@@ -497,7 +497,7 @@ namespace crow
                               {
                                   close_connection_ = true;
                                   if (error_handler_)
-                                      error_handler_(*this);
+                                      error_handler_(*this, ec.message());
                                   adaptor_.shutdown_readwrite();
                                   adaptor_.close();
                                   check_destroy();
@@ -685,7 +685,7 @@ namespace crow
             std::function<void(crow::websocket::connection&)> open_handler_;
             std::function<void(crow::websocket::connection&, const std::string&, bool)> message_handler_;
             std::function<void(crow::websocket::connection&, const std::string&)> close_handler_;
-            std::function<void(crow::websocket::connection&)> error_handler_;
+            std::function<void(crow::websocket::connection&, const std::string&)> error_handler_;
             std::function<bool(const crow::request&, void**)> accept_handler_;
         };
     } // namespace websocket


### PR DESCRIPTION
Closes #454

also snuck in, fix for GCC warning about comparing pointer addition against nullptr (which was a legitimate error in the code)