### PR TITLE
rework the way asio is handled as a dependency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ project(Crow
 	LANGUAGES CXX
 )
 
+# Make sure Findasio.cmake module is found
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
 # Check if Crow is the main project
 set(CROW_IS_MAIN_PROJECT OFF)
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
@@ -52,16 +55,11 @@ target_include_directories(Crow
 		$<INSTALL_INTERFACE:include>
 )
 
-find_path(ASIO_INCLUDE_DIR asio.hpp REQUIRED)
-find_package(Threads REQUIRED)
+find_package(asio REQUIRED)
 
 target_link_libraries(Crow
 	INTERFACE
-		Threads::Threads
-)
-target_include_directories(Crow
-	INTERFACE
-		${ASIO_INCLUDE_DIR}
+		asio::asio
 )
 
 if("compression" IN_LIST CROW_FEATURES)
@@ -130,6 +128,7 @@ if(CROW_INSTALL)
 		INSTALL_DESTINATION lib/cmake/Crow
 	)
 	install(FILES
+		"${CMAKE_CURRENT_SOURCE_DIR}/cmake/Findasio.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/CrowConfig.cmake"
     DESTINATION lib/cmake/Crow
   )

--- a/cmake/CrowConfig.cmake.in
+++ b/cmake/CrowConfig.cmake.in
@@ -1,8 +1,12 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_path(ASIO_INCLUDE_DIR asio.hpp REQUIRED)
-find_dependency(Threads)
+
+get_filename_component(CROW_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+find_dependency(asio)
+list(REMOVE_AT CMAKE_MODULE_PATH -1)
 
 set(CROW_INSTALLED_FEATURES "@CROW_FEATURES@")
 
@@ -40,9 +44,4 @@ endif()
 set_target_properties(Crow::Crow PROPERTIES
   INTERFACE_COMPILE_DEFINITIONS "${_CROW_ICD}"
   INTERFACE_LINK_LIBRARIES "${_CROW_ILL}"
-)
-
-target_include_directories(Crow::Crow
-  INTERFACE
-    ${ASIO_INCLUDE_DIR}
 )

--- a/cmake/Findasio.cmake
+++ b/cmake/Findasio.cmake
@@ -1,0 +1,50 @@
+#Findasio.cmake
+#
+# Finds the asio library
+#
+# from https://think-async.com/Asio/
+#
+# This will define the following variables
+#
+#    ASIO_FOUND
+#    ASIO_INCLUDE_DIR
+#
+# and the following imported targets
+#
+#     asio::asio
+#
+
+find_package(Threads QUIET)
+if (Threads_FOUND)
+  find_path(ASIO_INCLUDE_DIR asio.hpp)
+
+  mark_as_advanced(ASIO_FOUND ASIO_INCLUDE_DIR)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(asio
+    FOUND_VAR ASIO_FOUND
+    REQUIRED_VARS ASIO_INCLUDE_DIR
+  )
+
+  if(ASIO_FOUND AND NOT TARGET asio::asio)
+      add_library(asio::asio INTERFACE IMPORTED)
+      target_include_directories(asio::asio
+        INTERFACE
+          ${ASIO_INCLUDE_DIR}
+      )
+      target_compile_definitions(asio::asio
+        INTERFACE
+          "ASIO_STANDALONE"
+      )
+      target_link_libraries(asio::asio
+        INTERFACE
+          Threads::Threads
+      )
+  endif()
+else()
+  if(asio_FIND_REQUIRED)
+    message(FATAL_ERROR "asio requires Threads, which couldn't be found.")
+  elseif(asio_FIND_QUIETLY)
+    message(STATUS "asio requires Threads, which couldn't be found.")
+  endif()
+endif()

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -1,5 +1,7 @@
 #pragma once
+#ifndef ASIO_STANDALONE
 #define ASIO_STANDALONE
+#endif
 #include <asio.hpp>
 #include <atomic>
 #include <chrono>

--- a/include/crow/http_request.h
+++ b/include/crow/http_request.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#ifndef ASIO_STANDALONE
 #define ASIO_STANDALONE
+#endif
 #include <asio.hpp>
 
 #include "crow/common.h"

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <chrono>
+#ifndef ASIO_STANDALONE
 #define ASIO_STANDALONE
+#endif
 #include <asio.hpp>
 #ifdef CROW_ENABLE_SSL
 #include <asio/ssl.hpp>

--- a/include/crow/socket_adaptors.h
+++ b/include/crow/socket_adaptors.h
@@ -1,5 +1,7 @@
 #pragma once
+#ifndef ASIO_STANDALONE
 #define ASIO_STANDALONE
+#endif
 #include <asio.hpp>
 #ifdef CROW_ENABLE_SSL
 #include <asio/ssl.hpp>

--- a/include/crow/task_timer.h
+++ b/include/crow/task_timer.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#ifndef ASIO_STANDALONE
 #define ASIO_STANDALONE
+#endif
 #include <asio.hpp>
 #include <asio/basic_waitable_timer.hpp>
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,15 +2,8 @@
     "name": "crow-examples",
     "version-string": "master",
     "dependencies": [
-        {
-            "name": "asio"
-        },
-        {
-            "name": "openssl"
-        },
-        {
-            "name": "zlib"
-        }
-    ],
-    "builtin-baseline": "44d94c2edbd44f0c01d66c2ad95eb6982a9a61bc"
+        "asio",
+        "openssl",
+        "zlib"
+    ]
 }


### PR DESCRIPTION
Introduces a `Findasio.cmake` module helping with adding `asio` as a dependency.
The module looks for the `asio.hpp` file and creates a CMake interface target for it and automatically links against `Threads` which `asio` relies on.

This has the advantage of improving `find_package` support and it fixes #477.