### PR TITLE
Fixed issue where an index in qs_parse is incorrectly incremented beyond the maximum possible value

### DIFF
--- a/include/crow/query_string.h
+++ b/include/crow/query_string.h
@@ -119,11 +119,10 @@ inline int qs_parse(char* qs, char* qs_kv[], int qs_kv_size, bool parse_url = tr
     {
         qs_kv[i] = substr_ptr;
         j = strcspn(substr_ptr, "&");
-        if ( substr_ptr[j] == '\0' ) {  break;  }
+        if ( substr_ptr[j] == '\0' ) { i++; break;  } // x &'s -> means x iterations of this loop -> means *x+1* k/v pairs
         substr_ptr += j + 1;
         i++;
     }
-    i++;  // x &'s -> means x iterations of this loop -> means *x+1* k/v pairs
 
     // we only decode the values in place, the keys could have '='s in them
     // which will hose our ability to distinguish keys from values later


### PR DESCRIPTION
Thanks to Dejan Alvadzijevic (I'm sorry, I didn't find a github account) for pointing this issue out.