### PR TITLE
fix CrowConfig.cmake not being able to find Findasio.cmake module.

### DIFF
--- a/cmake/CrowConfig.cmake.in
+++ b/cmake/CrowConfig.cmake.in
@@ -4,7 +4,7 @@ include(CMakeFindDependencyMacro)
 
 get_filename_component(CROW_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${CROW_CMAKE_DIR})
 find_dependency(asio)
 list(REMOVE_AT CMAKE_MODULE_PATH -1)
 


### PR DESCRIPTION
I added the wrong directory to CMake's module path, which leads to it not being able to find `Findasio.cmake`.