### PR TITLE
Add response constructor overload

### DIFF
--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -87,6 +87,11 @@ namespace crow
             body = value.dump();
             set_header("Content-Type", value.content_type);
         }
+        response(int code, returnable&& value):
+          code(code), body(std::move(value.dump()))
+        {
+            set_header("Content-Type", std::move(value.content_type));
+        }
 
         response(response&& r)
         {


### PR DESCRIPTION
Added a constructor accepting a status code and a r-value returnable. This is convenient so we can return custom returnables along with a status code without having to create an l-value first like this:

```cpp
class ApiResponse: public crow::returnable
{
  ...
};

// Inside a handler
return crow::response(201, ApiResponse{...});
```

Before we had to do
```cpp
ApiResponse response{...};
return crow::response(201, response);
```