### PR TITLE
get_part_by_name doesn't crash on nonexistent keys

### DIFF
--- a/include/crow/multipart.h
+++ b/include/crow/multipart.h
@@ -86,7 +86,7 @@ namespace crow
             part get_part_by_name(const std::string& name)
             {
                 mp_map::iterator result = part_map.find(name);
-                if(result != part_map.end())
+                if (result != part_map.end())
                     return result->second;
                 else
                     return {};

--- a/include/crow/multipart.h
+++ b/include/crow/multipart.h
@@ -89,7 +89,7 @@ namespace crow
                 if(result != part_map.end())
                     return result->second;
                 else
-                    return {}; 
+                    return {};
             }
 
             /// Represent all parts as a string (**does not include message headers**)

--- a/include/crow/multipart.h
+++ b/include/crow/multipart.h
@@ -85,7 +85,11 @@ namespace crow
 
             part get_part_by_name(const std::string& name)
             {
-                return part_map.find(name)->second;
+                mp_map::iterator result = part_map.find(name);
+                if(result != part_map.end())
+                    return result->second;
+                else
+                    return {}; 
             }
 
             /// Represent all parts as a string (**does not include message headers**)


### PR DESCRIPTION
This no longer causes a segfault if the key that is being searched for does not exist