### PR TITLE
static directory slash fix

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -283,7 +283,7 @@ namespace crow
                 std::string static_dir_(CROW_STATIC_DIRECTORY);
                 std::replace(static_dir_.begin(), static_dir_.end(), '\\', '/');
                 if (static_dir_[static_dir_.length() - 1] != '/')
-                  static_dir_ += '/';
+                    static_dir_ += '/';
 
                 route<crow::black_magic::get_parameter_tag(CROW_STATIC_ENDPOINT)>(CROW_STATIC_ENDPOINT)([static_dir_](crow::response& res, std::string file_path_partial) {
                     utility::sanitize_filename(file_path_partial);


### PR DESCRIPTION
This PR makes it so that the static directory can have either `'/'` or `'\'` in the path. It also allows the directory to not have any slash at the end.

Tested on Linux and Windows.