### PR TITLE
Fix compilation error: ambiguous overload

### DIFF
--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1220,9 +1220,9 @@ TEST_CASE("template_function")
     auto t = crow::mustache::compile("attack of {{func}}");
     crow::mustache::context ctx;
     ctx["name"] = "killer tomatoes";
-    ctx["func"] = [&](std::string) {
+    ctx["func"] = std::function<std::string(std::string)>([&](std::string) {
         return std::string("{{name}}, IN SPACE!");
-    };
+    });
     auto result = t.render_string(ctx);
     CHECK("attack of killer tomatoes, IN SPACE!" == result);
 }


### PR DESCRIPTION
On gcc 5.3.0, you get a compilation error when assigning a lambda
function to a json::wvalue. The compilation error is due to a lambda
function being implicitly convertible to a function pointer, which again
can be implicitly converted to both a bool and a std::function. Avoid
the ambiguity by explicitly casting the lambda to a std::function.