### PR TITLE
Cpp17 filesystem usage fixes

### DIFF
--- a/include/crow/settings.h
+++ b/include/crow/settings.h
@@ -45,6 +45,9 @@
 #endif
 #if __cplusplus >= 201703L
 #define CROW_CAN_USE_CPP17
+#if defined(__GNUC__) && __GNUC__ < 8
+#define CROW_FILESYSTEM_IS_EXPERIMENTAL
+#endif
 #endif
 
 #if defined(_MSC_VER)

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -802,7 +802,7 @@ namespace crow
         inline static std::string join_path(std::string path, const std::string& fname)
         {
 #ifdef CROW_CAN_USE_CPP17
-            return std::filesystem::path(path) / fname;
+            return (std::filesystem::path(path) / fname).string();
 #else
             if (!(path.back() == '/' || path.back() == '\\'))
                 path += '/';

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -14,7 +14,7 @@
 
 #include "crow/settings.h"
 
-#ifdef CROW_CAN_USE_CPP17
+#if defined(CROW_CAN_USE_CPP17) && !defined(CROW_FILESYSTEM_IS_EXPERIMENTAL)
 #include <filesystem>
 #endif
 
@@ -801,7 +801,7 @@ namespace crow
 
         inline static std::string join_path(std::string path, const std::string& fname)
         {
-#ifdef CROW_CAN_USE_CPP17
+#if defined(CROW_CAN_USE_CPP17) && !defined(CROW_FILESYSTEM_IS_EXPERIMENTAL)
             return (std::filesystem::path(path) / fname).string();
 #else
             if (!(path.back() == '/' || path.back() == '\\'))


### PR DESCRIPTION
Two fixes: 
 - std::filesystem::path cannot be implicitly converted to std::string (2d04bd4fa626ffdc4aa6834c48da8b8e82583219)
 - Using std::filesystem in C++17 mode on gcc versions prior to gcc 8 is cumbersome (9c496bca6e041f75c6230def9e4abb13935f5445). Proposition avoids using it for the reasons mentioned in the commit message.