### PR TITLE
Fix websocket crash from connection pointer dangling

### DIFF
--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -657,9 +657,9 @@ namespace crow
                     asio::async_write(
                       adaptor_.socket(), buffers,
                       [&, watch = std::weak_ptr<void>{anchor_}](const asio::error_code& ec, std::size_t /*bytes_transferred*/) {
-                          sending_buffers_.clear();
                           if (!ec && !close_connection_)
                           {
+                              sending_buffers_.clear();
                               if (!write_buffers_.empty())
                                   do_write();
                               if (has_sent_close_)
@@ -670,6 +670,7 @@ namespace crow
                               auto anchor = watch.lock();
                               if (anchor == nullptr) { return; }
 
+                              sending_buffers_.clear();
                               close_connection_ = true;
                               check_destroy();
                           }

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -715,7 +715,7 @@ namespace crow
             bool pong_received_{false};
             bool is_close_handler_called_{false};
 
-            std::shared_ptr<void> anchor_ = std::make_shared<nullptr_t>();
+            std::shared_ptr<void> anchor_ = std::make_shared<int>(); // Value is just for placeholding
 
             std::function<void(crow::websocket::connection&)> open_handler_;
             std::function<void(crow::websocket::connection&, const std::string&, bool)> message_handler_;


### PR DESCRIPTION
On windows, with error 10053, a websocket instance sometimes deleted before post-ed/dispatch-ed asynchronous I/O events invocation, which makescompletion handler refer to dangled pointer 'this'.

We can detect whether 'this' pointer is deleted already or not, by checking captured `weak_ptr` is expired. Though this introduces a bit of overhead on each message posting/dispatching, it makes concurrent access to single websocket connection instance safe.

