### PR TITLE
websocket: Reduce number of re-allocation of string parameters

### DIFF
--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -122,14 +122,14 @@ namespace crow
             template<typename CompletionHandler>
             void dispatch(CompletionHandler&& handler)
             {
-                adaptor_.get_io_service().dispatch(std::forward<CompletionHandler>(handler));
+                asio::dispatch(adaptor_.get_io_service(), std::forward<CompletionHandler>(handler));
             }
 
             /// Send data through the socket and return immediately.
             template<typename CompletionHandler>
             void post(CompletionHandler&& handler)
             {
-                adaptor_.get_io_service().post(std::forward<CompletionHandler>(handler));
+                asio::post(adaptor_.get_io_service(), std::forward<CompletionHandler>(handler));
             }
 
             /// Send a "Ping" message.
@@ -648,6 +648,14 @@ namespace crow
                 {
                     self->send_data_impl(this);
                 }
+
+                SendMessageType() noexcept = default;
+
+                SendMessageType(SendMessageType const&) = delete;
+                SendMessageType& operator=(SendMessageType const&) = delete;
+
+                SendMessageType(SendMessageType&&) noexcept = default;
+                SendMessageType& operator=(SendMessageType&&) noexcept = default;
             };
 
             static_assert(

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -22,13 +22,13 @@ namespace crow
         /// A base class for websocket connection.
         struct connection
         {
-            virtual void send_binary(const std::string& msg) = 0;
-            virtual void send_text(const std::string& msg) = 0;
-            virtual void send_ping(const std::string& msg) = 0;
-            virtual void send_pong(const std::string& msg) = 0;
-            virtual void close(const std::string& msg = "quit") = 0;
+            virtual void send_binary(std::string msg) = 0;
+            virtual void send_text(std::string msg) = 0;
+            virtual void send_ping(std::string msg) = 0;
+            virtual void send_pong(std::string msg) = 0;
+            virtual void close(std::string msg = "quit") = 0;
             virtual std::string get_remote_ip() = 0;
-            virtual ~connection() {}
+            virtual ~connection() = default;
 
             void userdata(void* u) { userdata_ = u; }
             void* userdata() { return userdata_; }
@@ -136,12 +136,12 @@ namespace crow
 
             ///
             /// Usually invoked to check if the other point is still online.
-            void send_ping(const std::string& msg) override
+            void send_ping(std::string msg) override
             {
-                dispatch([this, msg] {
+                dispatch([this, msg = std::move(msg)]() mutable {
                     auto header = build_header(0x9, msg.size());
                     write_buffers_.emplace_back(std::move(header));
-                    write_buffers_.emplace_back(msg);
+                    write_buffers_.emplace_back(std::move(msg));
                     do_write();
                 });
             }
@@ -150,34 +150,34 @@ namespace crow
 
             ///
             /// Usually automatically invoked as a response to a "Ping" message.
-            void send_pong(const std::string& msg) override
+            void send_pong(std::string msg) override
             {
-                dispatch([this, msg] {
+                dispatch([this, msg = std::move(msg)]() mutable {
                     auto header = build_header(0xA, msg.size());
                     write_buffers_.emplace_back(std::move(header));
-                    write_buffers_.emplace_back(msg);
+                    write_buffers_.emplace_back(std::move(msg));
                     do_write();
                 });
             }
 
             /// Send a binary encoded message.
-            void send_binary(const std::string& msg) override
+            void send_binary(std::string msg) override
             {
-                dispatch([this, msg] {
+                dispatch([this, msg = std::move(msg)]() mutable {
                     auto header = build_header(2, msg.size());
                     write_buffers_.emplace_back(std::move(header));
-                    write_buffers_.emplace_back(msg);
+                    write_buffers_.emplace_back(std::move(msg));
                     do_write();
                 });
             }
 
             /// Send a plaintext message.
-            void send_text(const std::string& msg) override
+            void send_text(std::string msg) override
             {
-                dispatch([this, msg] {
+                dispatch([this, msg = std::move(msg)]() mutable {
                     auto header = build_header(1, msg.size());
                     write_buffers_.emplace_back(std::move(header));
-                    write_buffers_.emplace_back(msg);
+                    write_buffers_.emplace_back(std::move(msg));
                     do_write();
                 });
             }
@@ -186,9 +186,9 @@ namespace crow
 
             ///
             /// Sets a flag to destroy the object once the message is sent.
-            void close(const std::string& msg) override
+            void close(std::string msg) override
             {
-                dispatch([this, msg] {
+                dispatch([this, msg = std::move(msg)]() mutable {
                     has_sent_close_ = true;
                     if (has_recv_close_ && !is_close_handler_called_)
                     {
@@ -198,7 +198,7 @@ namespace crow
                     }
                     auto header = build_header(0x8, msg.size());
                     write_buffers_.emplace_back(std::move(header));
-                    write_buffers_.emplace_back(msg);
+                    write_buffers_.emplace_back(std::move(msg));
                     do_write();
                 });
             }
@@ -244,10 +244,11 @@ namespace crow
             /// Finishes the handshake process, then starts reading messages from the socket.
             void start(std::string&& hello)
             {
-                static std::string header = "HTTP/1.1 101 Switching Protocols\r\n"
-                                            "Upgrade: websocket\r\n"
-                                            "Connection: Upgrade\r\n"
-                                            "Sec-WebSocket-Accept: ";
+                static const std::string header =
+                  "HTTP/1.1 101 Switching Protocols\r\n"
+                  "Upgrade: websocket\r\n"
+                  "Connection: Upgrade\r\n"
+                  "Sec-WebSocket-Accept: ";
                 write_buffers_.emplace_back(header);
                 write_buffers_.emplace_back(std::move(hello));
                 write_buffers_.emplace_back(crlf);

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -120,16 +120,16 @@ namespace crow
 
             /// Send data through the socket.
             template<typename CompletionHandler>
-            void dispatch(CompletionHandler handler)
+            void dispatch(CompletionHandler&& handler)
             {
-                adaptor_.get_io_service().dispatch(handler);
+                adaptor_.get_io_service().dispatch(std::forward<CompletionHandler>(handler));
             }
 
             /// Send data through the socket and return immediately.
             template<typename CompletionHandler>
-            void post(CompletionHandler handler)
+            void post(CompletionHandler&& handler)
             {
-                adaptor_.get_io_service().post(handler);
+                adaptor_.get_io_service().post(std::forward<CompletionHandler>(handler));
             }
 
             /// Send a "Ping" message.


### PR DESCRIPTION
Removed multiple payload copy operations during sending payload

1. Capturing 'msg' as value.
    https://github.com/kang-sw/Crow/blob/6f832f82fafea2c831f154869888041cd0a6a3e4/include/crow/websocket.h#L177
2. Pushing back msg by copy
    https://github.com/kang-sw/Crow/blob/6f832f82fafea2c831f154869888041cd0a6a3e4/include/crow/websocket.h#L180 
3. Copying lambda function to executor
    https://github.com/kang-sw/Crow/blob/6f832f82fafea2c831f154869888041cd0a6a3e4/include/crow/websocket.h#L141

On this PR, all send_* parameter series will be refactored to take 'std::string' as value, and moved to lambda capture when dispatched to executor. This removes first copy. Lambda function will be declared as mutable, which enables modifying(moving) captured variable on invocation. This makes removing second copy available, by moving captured 'msg' instance to `write_buffers_`.
Lambda function itself is also copied to executor when `this->dispatch()` invocation, so it changed to use perfect forwarding to prevent redundant copy of captured variables, which removes third copy.





