### PR TITLE
Fix websocket example

### DIFF
--- a/examples/websocket/example_ws.cpp
+++ b/examples/websocket/example_ws.cpp
@@ -10,7 +10,8 @@ int main()
     std::mutex mtx;
     std::unordered_set<crow::websocket::connection*> users;
 
-    CROW_WEBSOCKET_ROUTE(app, "/ws")
+    CROW_ROUTE(app, "/ws")
+      .websocket()
       .onopen([&](crow::websocket::connection& conn) {
           CROW_LOG_INFO << "new websocket connection from " << conn.get_remote_ip();
           std::lock_guard<std::mutex> _(mtx);


### PR DESCRIPTION
Fix websocket example to use new syntax. Call `.websocket()` instead of `CROW_WEBSOCKET_ROUTE`