### PR TITLE
Adapt CROW_WEBSOCKET_ROUTE to accept app reference

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -30,7 +30,7 @@
 #else
 #define CROW_ROUTE(app, url) app.template route<crow::black_magic::get_parameter_tag(url)>(url)
 #define CROW_BP_ROUTE(blueprint, url) blueprint.new_rule_tagged<crow::black_magic::get_parameter_tag(url)>(url)
-#define CROW_WEBSOCKET_ROUTE(app, url) app.route<crow::black_magic::get_parameter_tag(url)>(url).websocket<decltype(app)>(&app)
+#define CROW_WEBSOCKET_ROUTE(app, url) app.route<crow::black_magic::get_parameter_tag(url)>(url).websocket<std::remove_reference<decltype(app)>::type>(&app)
 #define CROW_MIDDLEWARES(app, ...) template middlewares<typename std::remove_reference<decltype(app)>::type, __VA_ARGS__>()
 #endif
 #define CROW_CATCHALL_ROUTE(app) app.catchall_route()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 
 add_subdirectory(template)
 add_subdirectory(multi_file)
+add_subdirectory(external_definition)
 if ("ssl" IN_LIST CROW_FEATURES)
 	add_subdirectory(ssl)
 endif()

--- a/tests/external_definition/CMakeLists.txt
+++ b/tests/external_definition/CMakeLists.txt
@@ -1,0 +1,16 @@
+project(test_external_definition)
+
+add_executable(
+  ${PROJECT_NAME}
+  main.cpp
+)
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}
+  PUBLIC Crow::Crow
+)

--- a/tests/external_definition/main.cpp
+++ b/tests/external_definition/main.cpp
@@ -1,8 +1,10 @@
 // Testing whether crow routes can be defined in an external function.
 #include "crow.h"
 
-void define_endpoints(crow::SimpleApp& app) {
-    CROW_ROUTE(app, "/") ([]() {
+void define_endpoints(crow::SimpleApp& app)
+{
+    CROW_ROUTE(app, "/")
+    ([]() {
         return "Hello, world!";
     });
     CROW_WEBSOCKET_ROUTE(app, "/ws")

--- a/tests/external_definition/main.cpp
+++ b/tests/external_definition/main.cpp
@@ -10,7 +10,7 @@ void define_endpoints(crow::SimpleApp& app) {
           return true;
       })
       .onopen([](crow::websocket::connection&) {})
-      .onclose([](crow::websocket::connection&, std::string_view) {});
+      .onclose([](crow::websocket::connection&, const std::string&) {});
 }
 
 int main()

--- a/tests/external_definition/main.cpp
+++ b/tests/external_definition/main.cpp
@@ -1,0 +1,23 @@
+// Testing whether crow routes can be defined in an external function.
+#include "crow.h"
+
+void define_endpoints(crow::SimpleApp& app) {
+    CROW_ROUTE(app, "/") ([]() {
+        return "Hello, world!";
+    });
+    CROW_WEBSOCKET_ROUTE(app, "/ws")
+      .onaccept([&](const crow::request&, void**) {
+          return true;
+      })
+      .onopen([](crow::websocket::connection&) {})
+      .onclose([](crow::websocket::connection&, std::string_view) {});
+}
+
+int main()
+{
+    crow::SimpleApp app;
+
+    define_endpoints(app);
+
+    app.port(18080).run();
+}


### PR DESCRIPTION
Hello,

I noticed today that it is not possible to use the CROW_WEBSOCKET_ROUTE macro to define WebSocket routes in other functions. E.g., something like this:
```C++
void define_endpoints(crow::SimpleApp& app) {
    CROW_ROUTE(app, "/") ([]() {
        return "Hello, world!";
    });
    CROW_WEBSOCKET_ROUTE(app, "/ws")
      .onaccept([&](const crow::request&, void**) {
          return true;
      })
      .onopen([](crow::websocket::connection&) {})
      .onclose([](crow::websocket::connection&, std::string_view) {});
}
```
Resulted in the error:
```
error: no matching member function for call to 'websocket'
    CROW_WEBSOCKET_ROUTE(app, "/ws")
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/simon/Code/Crow/include/crow/app.h:33:98: note: expanded from macro 'CROW_WEBSOCKET_ROUTE'
#define CROW_WEBSOCKET_ROUTE(app, url) app.route<crow::black_magic::get_parameter_tag(url)>(url).websocket<decltype(app)>(&app)
                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
/Users/simon/Code/Crow/include/crow/routing.h:527:29: note: candidate template ignored: substitution failure [with App = crow::Crow<> &]: 'app' declared as a pointer to a reference of type 'crow::Crow<> &'
        WebSocketRule<App>& websocket(App* app)
                            ^            ~
1 error generated.
```

The issue was that `decltype(app)` then returned a reference. I fixed the problem by using `std::remove_reference<decltype(app)>::type` instead. I also added a test to assure that it is working.