### PR TITLE
Fix some valgrind reported issues

### DIFF
--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -622,7 +622,7 @@ namespace crow
         std::string date_str_;
         std::string res_body_copy_;
 
-        detail::task_timer::identifier_type task_id_;
+        detail::task_timer::identifier_type task_id_{};
 
         bool is_reading{};
         bool is_writing{};


### PR DESCRIPTION
This PR addresses two smaller issues that I found using valgrind:

1. routing/Trie: use object references instead of raw pointers
   
   This way, we don't need to free the `Trie` when stopping the program (what we don't do right now).
   Also remove unused `get_size` method and simplify code a bit.
2. http_connection: initialize `task_id_`

The former change addresses one of the leaks mentioned in #546. The other one, that is caused in `do_accept` by creating new `Connection` objects for every request seems to be harder to solve. This one should really be addressed, as it leaks around 5KB **for every request**.