### PR TITLE
Apply workaround for Apple to FreeBSD aswell

### DIFF
--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -1653,7 +1653,7 @@ namespace crow
                 }
                 else
                 {
-#if defined(__APPLE__) || defined(__MACH__)
+#if defined(__APPLE__) || defined(__MACH__) || defined (__FreeBSD__)
                     o = std::unique_ptr<object>(new object(initializer_list));
 #else
                     (*o) = initializer_list;
@@ -1672,7 +1672,7 @@ namespace crow
                 }
                 else
                 {
-#if defined(__APPLE__) || defined(__MACH__)
+#if defined(__APPLE__) || defined(__MACH__) || defined (__FreeBSD__)
                     o = std::unique_ptr<object>(new object(value));
 #else
                     (*o) = value;


### PR DESCRIPTION
This fixes #576 , 
Maybe these workarounds should be triggered by __clang__?
