### PR TITLE
CrowCpp/Crow#585 : Resolves issue with blueprint assignments.

### DIFF
--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -1122,8 +1122,12 @@ namespace crow
         Blueprint& operator=(Blueprint&& value) noexcept
         {
             prefix_ = std::move(value.prefix_);
+            static_dir_ = std::move(value.static_dir_);
+            templates_dir_ = std::move(value.templates_dir_);
             all_rules_ = std::move(value.all_rules_);
             catchall_rule_ = std::move(value.catchall_rule_);
+            blueprints_ = std::move(value.blueprints_);
+            mw_indices_ = std::move(value.mw_indices_);
             return *this;
         }
 


### PR DESCRIPTION
Adds static_dir_, templates_dir_, blueprints_, and mw_indices_ to the assignment. This ensures that the Blueprint is assigned all the information. See discussion on CrowCpp/Crow#585 for additional context. This may also be related to CrowCpp/Crow#569.

### Tests
I've confirmed that this introduced no compilation or linking issues on the following systems:
* Debian 10 
    * GCC 10.2.1
    * Cmake 3.18.4
    * ASIO [a71f5232d207b4f3bbd253eb1041e30b5e4ea606](https://github.com/chriskohlhoff/asio/commit/a71f5232d207b4f3bbd253eb1041e30b5e4ea606)
* Windows 11
    * MSVC 19.29.30146.0
    * CMake 3.24.2
    * ASIO [a71f5232d207b4f3bbd253eb1041e30b5e4ea606](https://github.com/chriskohlhoff/asio/commit/a71f5232d207b4f3bbd253eb1041e30b5e4ea606)

Unittests are still failing, but no new failures are generated from this change as far as I can tell.