### PR TITLE
Get server running port, bindaddr and threads

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -167,7 +167,6 @@ namespace crow
             return port_;
         }
 
-
         /// Set the connection timeout in seconds (default is 5)
         self_t& timeout(std::uint8_t timeout)
         {
@@ -188,6 +187,12 @@ namespace crow
             bindaddr_ = bindaddr;
             return *this;
         }
+        
+        /// Get the address that Crow will handle requests on
+        std::string bindaddr()
+        {
+            return bindaddr_;
+        }
 
         /// Run the server on multiple threads using all available threads
         self_t& multithreaded()
@@ -202,6 +207,12 @@ namespace crow
                 concurrency = 2;
             concurrency_ = concurrency;
             return *this;
+        }
+        
+        /// Get the number of threads that server is using
+        std::uint16_t concurrency()
+        {
+            return concurrency_;
         }
 
         /// Set the server's log level


### PR DESCRIPTION
- Added methods to get usefull information about running server instance: 
std::uint16_t port() -> Get the port that Crow will handle requests on 
std::string bindaddr() -> Get the address that Crow will handle requests on 
std::uint16_t concurrency() -> Get the number of threads that server is using