### PR TITLE
Validate if CROW_ROUTE starts with a '/'

### DIFF
--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -649,6 +649,9 @@ namespace crow
 
         void validate() override
         {
+            if (rule_.at(0) != '/')
+                throw std::runtime_error("Internal error: Routes must start with a '/'");
+
             if (!handler_)
             {
                 throw std::runtime_error(name_ + (!name_.empty() ? ": " : "") + "no handler for url " + rule_);

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -4,7 +4,6 @@
 #include <sys/stat.h>
 
 #include <iostream>
-#include <sstream>
 #include <vector>
 #include <thread>
 #include <chrono>
@@ -148,6 +147,27 @@ TEST_CASE("PathRouting")
         CHECK(200 == res.code);
     }
 } // PathRouting
+
+TEST_CASE("InvalidPathRouting")
+{
+    SimpleApp app;
+
+    CROW_ROUTE(app, "invalid_route")
+    ([] {
+        return "should not arrive here";
+    });
+
+    try
+    {
+        app.validate();
+        FAIL_CHECK();
+    }
+    catch (std::exception& e)
+    {
+        auto expected_exception_text = "Internal error: Routes must start with a '/'";
+        CHECK(strcmp(expected_exception_text, e.what()) == 0);
+    }
+} // InvalidPathRouting
 
 TEST_CASE("RoutingTest")
 {
@@ -1256,7 +1276,7 @@ TEST_CASE("template_false_tag")
 {
     auto t = crow::mustache::compile(R"---({{false_value}})---");
     crow::mustache::context ctx;
-    ctx["false_value"] = false;d
+    ctx["false_value"] = false;
     auto result = t.render_string(ctx);
     CHECK("false" == result);
 } // template_false_tag


### PR DESCRIPTION
#559 This PR adds a verification in the CROW_ROUTE validation to make sure that the route starts with a '/'.
