### PR TITLE
Added possibility to return empty JSON object instead of NULL

### DIFF
--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -1299,6 +1299,9 @@ namespace crow
 
             type t() const { return t_; }
 
+            /// Create an empty json value (outputs "{}" instead of a "null" string)
+            static crow::json::wvalue empty_object() { return crow::json::wvalue(std::move(crow::json::wvalue::object())); }
+
         private:
             type t_{type::Null};         ///< The type of the value.
             num_type nt{num_type::Null}; ///< The specific type of the number if \ref t_ is a number.


### PR DESCRIPTION
The problem is that having an empty json object `{}` is complicated to obtain because the serialization always outputs `null`.

With this method it is easy to have the desired output. Of course, it can be used as _response_ or as a _value_.

```
#include "crow.h"

int main()
{
    MyProgram program;
    crow::SimpleApp app;

    // This route will return "{}" instead of "null"
    CROW_ROUTE(app, "/notify-alive")([](){
        program.notify_alive();
        return crow::json::wvalue::empty_object();
    });

    app.port(18080).run();
}
```