### PR TITLE
Fix loghandler memleak

### DIFF
--- a/include/crow/logging.h
+++ b/include/crow/logging.h
@@ -33,6 +33,8 @@ namespace crow
     class ILogHandler
     {
     public:
+        virtual ~ILogHandler() = default;
+
         virtual void log(std::string message, LogLevel level) = 0;
     };
 


### PR DESCRIPTION
Fixed potential memleak, when using dynamic polymorphism.

For all base classes we need to use virtual destructor.

I attach example to reproduce the memleak:

```cpp
class TestLogHandler : public ILogHandler {
  public:
    void log(std::string message, LogLevel level) override {
      // some log logic
    }
};

int main() {
  ILogHandler* handler = new TestLogHandler();
  delete handler;
  return 0;
}
```

Thanks!