### PR TITLE
Fix websocket close when responding to peer close

### DIFF
--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -582,10 +582,14 @@ namespace crow
                           sending_buffers_.clear();
                           if (!ec && !close_connection_)
                           {
+                              if (has_sent_close_)
+                              {
+                                  close_connection_ = true;
+                                  adaptor_.close();
+                                  check_destroy();
+                              }
                               if (!write_buffers_.empty())
                                   do_write();
-                              if (has_sent_close_)
-                                  close_connection_ = true;
                           }
                           else
                           {

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2237,7 +2237,7 @@ TEST_CASE("websocket_missing_host")
     SimpleApp app;
 
     CROW_ROUTE(app, "/ws").websocket()
-      .onaccept([&](const crow::request& req, void**) {
+      .onaccept([&](const crow::request& req) {
           CROW_LOG_INFO << "Accepted websocket with URL " << req.url;
           return true;
       })


### PR DESCRIPTION
As reported here https://stackoverflow.com/q/76022248/85371

Fix for failure to close websocket on full close

RFC6455 5.5.1 states

> After both sending and receiving a Close message, an endpoint considers the
> WebSocket connection closed and MUST close the underlying TCP connection.
> The server MUST close the underlying TCP connection immediately; the client
> SHOULD wait for the server to close the connection but MAY close the
> connection at any time after sending and receiving a Close message, e.g., if
> it has not received a TCP Close from the server in a reasonable time period.

Crow did not conform to "MUST close the underlying TCP connection", let alone
"The server MUST close the underlying TCP connection immediately".

This leads to conformant client potentially blocking on close, unless
they used the leeway given "MAY close the connection [...] a reasonable
time period".

Besides I think the connection resources would be leaked and build up
over time (I did not attempt to test this).

The fix I present also adheres to the spec that "The application MUST
NOT send any more data frames after sending a Close frame".

## Commits and Unit Test

I included a unit test that reproduces the error present in v1.0+5. I had to
fix an unrelated unit test that didn't compile in the first commit.

- Fix (unrelated) broken unit test
- Improve unit test for close websocket behaviour
- Fix for failure to close websocket on full close
