### PR TITLE
added function to set static directory during runtime

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -283,7 +283,7 @@ namespace crow
 
         ///
         /// Go through the rules, upgrade them if possible, and add them to the list of rules
-        void validate()
+        void validate(std::string staticDir = CROW_STATIC_DIRECTORY)
         {
             if (!validated_)
             {
@@ -291,7 +291,7 @@ namespace crow
 #ifndef CROW_DISABLE_STATIC_DIR
 
                 // stat on windows doesn't care whether '/' or '\' is being used. on Linux however, using '\' doesn't work. therefore every instance of '\' gets replaced with '/' then a check is done to make sure the directory ends with '/'.
-                std::string static_dir_(CROW_STATIC_DIRECTORY);
+                std::string static_dir_(staticDir);
                 std::replace(static_dir_.begin(), static_dir_.end(), '\\', '/');
                 if (static_dir_[static_dir_.length() - 1] != '/')
                     static_dir_ += '/';
@@ -332,10 +332,10 @@ namespace crow
         }
 
         /// Run the server
-        void run()
+        void run(std::string staticDir = CROW_STATIC_DIRECTORY)
         {
 
-            validate();
+            validate(staticDir);
 
 #ifdef CROW_ENABLE_SSL
             if (ssl_used_)
@@ -368,10 +368,10 @@ namespace crow
         ///
         /// The output from this method needs to be saved into a variable!
         /// Otherwise the call will be made on the same thread.
-        std::future<void> run_async()
+        std::future<void> run_async(std::string staticDir = CROW_STATIC_DIRECTORY)
         {
             return std::async(std::launch::async, [&] {
-                this->run();
+                this->run(staticDir);
             });
         }
 

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -1675,7 +1675,7 @@ namespace crow
                 }
                 else
                 {
-#if defined(__APPLE__) || defined(__MACH__) || defined (__FreeBSD__)
+#if defined(__APPLE__) || defined(__MACH__) || defined (__FreeBSD__) || defined (__ANDROID__)
                     o = std::unique_ptr<object>(new object(value));
 #else
                     (*o) = value;


### PR DESCRIPTION
I can only get the static directory path during runtime, and can therefore not use the defines to set it.
So this is more of a tiny feature request.
Would be convenient to not have to maintain a fork.