### PR TITLE
support websocket compression

### DIFF
--- a/include/crow/compression.h
+++ b/include/crow/compression.h
@@ -1,6 +1,11 @@
 #ifdef CROW_ENABLE_COMPRESSION
 #pragma once
 
+#ifndef ASIO_STANDALONE
+#define ASIO_STANDALONE
+#endif
+#include <asio.hpp>
+#include <memory>
 #include <string>
 #include <zlib.h>
 
@@ -93,6 +98,152 @@ namespace crow
 
             return inflated_string;
         }
+
+        class Compressor
+        {
+        public:
+            Compressor(bool reset_before_compress, int window_bits, int level):
+              reset_before_compress_(reset_before_compress), window_bits_(window_bits)
+            {
+                stream_ = std::make_unique<z_stream>();
+                stream_->zalloc = 0;
+                stream_->zfree = 0;
+                stream_->opaque = 0;
+
+                ::deflateInit2(stream_.get(),
+                               level,
+                               Z_DEFLATED,
+                               -window_bits_,
+                               8,
+                               Z_DEFAULT_STRATEGY);
+            }
+
+            ~Compressor()
+            {
+                ::deflateEnd(stream_.get());
+            }
+
+            bool needs_reset() const
+            {
+                return reset_before_compress_;
+            }
+
+            int window_bits() const
+            {
+                return window_bits_;
+            }
+
+            std::string compress(const std::string& src)
+            {
+                if (reset_before_compress_)
+                {
+                    ::deflateReset(stream_.get());
+                }
+
+                stream_->next_in = reinterpret_cast<uint8_t*>(const_cast<char*>(src.c_str()));
+                stream_->avail_in = src.size();
+
+                constexpr const uint64_t bufferSize = 8192;
+                asio::streambuf buffer;
+                do
+                {
+                    asio::streambuf::mutable_buffers_type chunk = buffer.prepare(bufferSize);
+
+                    uint8_t* next_out = asio::buffer_cast<uint8_t*>(chunk);
+
+                    stream_->next_out = next_out;
+                    stream_->avail_out = bufferSize;
+
+                    ::deflate(stream_.get(), reset_before_compress_ ? Z_FINISH : Z_SYNC_FLUSH);
+
+                    uint64_t outputSize = stream_->next_out - next_out;
+                    buffer.commit(outputSize);
+                } while (stream_->avail_out == 0);
+
+                uint64_t buffer_size = buffer.size();
+                if (!reset_before_compress_)
+                {
+                    buffer_size -= 4;
+                }
+
+                return std::string(asio::buffer_cast<const char*>(buffer.data()), buffer_size);
+            }
+
+        private:
+            std::unique_ptr<z_stream> stream_;
+
+            bool reset_before_compress_;
+            int window_bits_;
+        };
+
+        class Decompressor
+        {
+        public:
+            Decompressor(bool reset_before_decompress, int window_bits):
+              reset_before_decompress_(reset_before_decompress), window_bits_(window_bits)
+            {
+                stream_ = std::make_unique<z_stream>();
+                stream_->zalloc = 0;
+                stream_->zfree = 0;
+                stream_->opaque = 0;
+
+                ::inflateInit2(stream_.get(), -window_bits_);
+            }
+
+            ~Decompressor()
+            {
+                inflateEnd(stream_.get());
+            }
+
+            bool needs_reset() const
+            {
+                return reset_before_decompress_;
+            }
+
+            int window_bits() const
+            {
+                return window_bits_;
+            }
+
+            std::string decompress(std::string src)
+            {
+                if (reset_before_decompress_)
+                {
+                    inflateReset(stream_.get());
+                }
+
+                src.push_back('\x00');
+                src.push_back('\x00');
+                src.push_back('\xff');
+                src.push_back('\xff');
+
+                stream_->next_in = reinterpret_cast<uint8_t*>(const_cast<char*>(src.c_str()));
+                stream_->avail_in = src.size();
+
+                constexpr const uint64_t bufferSize = 8192;
+                asio::streambuf buffer;
+                do
+                {
+                    asio::streambuf::mutable_buffers_type chunk = buffer.prepare(bufferSize);
+
+                    uint8_t* next_out = asio::buffer_cast<uint8_t*>(chunk);
+
+                    stream_->next_out = next_out;
+                    stream_->avail_out = bufferSize;
+
+                    ::inflate(stream_.get(), reset_before_decompress_ ? Z_FINISH : Z_SYNC_FLUSH);
+                    buffer.commit(stream_->next_out - next_out);
+                } while (stream_->avail_out == 0);
+
+                return std::string(asio::buffer_cast<const char*>(buffer.data()), buffer.size());
+            }
+
+        private:
+            std::unique_ptr<z_stream> stream_;
+
+            bool reset_before_decompress_;
+            int window_bits_;
+        };
     } // namespace compression
 } // namespace crow
 

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -603,7 +603,11 @@ namespace crow
                         if (is_FIN())
                         {
                             if (message_handler_)
+#ifdef CROW_ENABLE_COMPRESSION
                                 message_handler_(*this, is_compressed() && decompressor_ ? decompressor_->decompress(message_) : message_, is_binary_);
+#else
+                                message_handler_(*this, message_, is_binary_);
+#endif
                             message_.clear();
                         }
                     }
@@ -615,7 +619,11 @@ namespace crow
                         if (is_FIN())
                         {
                             if (message_handler_)
+#ifdef CROW_ENABLE_COMPRESSION
                                 message_handler_(*this, is_compressed() && decompressor_ ? decompressor_->decompress(message_) : message_, is_binary_);
+#else
+                                message_handler_(*this, message_, is_binary_);
+#endif
                             message_.clear();
                         }
                     }
@@ -627,7 +635,11 @@ namespace crow
                         if (is_FIN())
                         {
                             if (message_handler_)
+#ifdef CROW_ENABLE_COMPRESSION
                                 message_handler_(*this, is_compressed() && decompressor_ ? decompressor_->decompress(message_) : message_, is_binary_);
+#else
+                                message_handler_(*this, message_, is_binary_);
+#endif
                             message_.clear();
                         }
                     }
@@ -782,9 +794,10 @@ namespace crow
 
             std::shared_ptr<void> anchor_ = std::make_shared<int>(); // Value is just for placeholding
 
+#ifdef CROW_ENABLE_COMPRESSION
             std::unique_ptr<compression::Compressor> compressor_;
             std::unique_ptr<compression::Decompressor> decompressor_;
-
+#endif
             std::function<void(crow::websocket::connection&)> open_handler_;
             std::function<void(crow::websocket::connection&, const std::string&, bool)> message_handler_;
             std::function<void(crow::websocket::connection&, const std::string&)> close_handler_;


### PR DESCRIPTION
This adds support for websocket compression via permessage-deflate extension. It's based on https://github.com/ipkn/crow/pull/329, with a few changes to better match current crow. It resolves https://github.com/CrowCpp/Crow/issues/92
I was not able to use the current implementation of zlib. This needs state, which the current implementation does not support. It's enabled whenever CROW_ENABLE_COMPRESSION is defined.
I tested it with my very websocket heavy app on recent chrome and firefox and it works as expected. Please let me know, if there's anything I need to change.