### PR TITLE
Allow multiple executions of `validate()` (#672)

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -303,10 +303,10 @@ namespace crow
             router_.validate_bp();
         }
 
-        //TODO(Stefano): can this be executed multiple times?
         /// Go through the rules, upgrade them if possible, and add them to the list of rules
         void add_static_dir()
         {
+            if (are_static_routes_added()) return;
             auto static_dir_ = crow::utility::normalize_path(CROW_STATIC_DIRECTORY);
 
             route<crow::black_magic::get_parameter_tag(CROW_STATIC_ENDPOINT)>(CROW_STATIC_ENDPOINT)([static_dir_](crow::response& res, std::string file_path_partial) {
@@ -314,6 +314,7 @@ namespace crow
                 res.set_static_file_info_unsafe(static_dir_ + file_path_partial);
                 res.end();
             });
+            set_static_routes_added();
         }
 
         /// A wrapper for `validate()` in the router
@@ -551,6 +552,13 @@ namespace crow
             cv_started_.notify_all();
         }
 
+        void set_static_routes_added() {
+            static_routes_added_ = true;
+        }
+
+        bool are_static_routes_added() {
+            return static_routes_added_;
+        }
 
     private:
         std::uint8_t timeout_{5};
@@ -561,6 +569,7 @@ namespace crow
         std::string bindaddr_ = "0.0.0.0";
         size_t res_stream_threshold_ = 1048576;
         Router router_;
+        bool static_routes_added_{false};
 
 #ifdef CROW_ENABLE_COMPRESSION
         compression::algorithm comp_algorithm_;

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -150,7 +150,7 @@ namespace crow
 
         std::string rule_;
         std::string name_;
-        bool added_ = false;
+        bool added_{false};
 
         std::unique_ptr<BaseRule> rule_to_upgrade_;
 
@@ -1164,6 +1164,14 @@ namespace crow
             return static_dir_;
         }
 
+        void set_added() {
+            added_ = true;
+        }
+
+        bool is_added() {
+            return added_;
+        }
+
         DynamicRule& new_rule_dynamic(const std::string& rule)
         {
             std::string new_rule = '/' + prefix_ + rule;
@@ -1236,6 +1244,7 @@ namespace crow
         CatchallRule catchall_rule_;
         std::vector<Blueprint*> blueprints_;
         detail::middleware_indices mw_indices_;
+        bool added_{false};
 
         friend class Router;
     };
@@ -1347,6 +1356,9 @@ namespace crow
             for (unsigned i = 0; i < blueprints.size(); i++)
             {
                 Blueprint* blueprint = blueprints[i];
+
+                if (blueprint->is_added()) continue;
+
                 if (blueprint->static_dir_ == "" && blueprint->all_rules_.empty())
                 {
                     std::vector<HTTPMethod> methods;
@@ -1373,6 +1385,7 @@ namespace crow
                 }
                 validate_bp(blueprint->blueprints_, current_mw);
                 current_mw.pop_back(blueprint->mw_indices_);
+                blueprint->set_added();
             }
         }
 

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -96,6 +96,15 @@ namespace crow
         {}
 
         virtual void validate() = 0;
+        
+        void set_added() {
+            added_ = true;
+        }
+
+        bool is_added() {
+            return added_;
+        }
+
         std::unique_ptr<BaseRule> upgrade()
         {
             if (rule_to_upgrade_)
@@ -141,6 +150,7 @@ namespace crow
 
         std::string rule_;
         std::string name_;
+        bool added_ = false;
 
         std::unique_ptr<BaseRule> rule_to_upgrade_;
 
@@ -1261,6 +1271,11 @@ namespace crow
             return catchall_rule_;
         }
 
+        void internal_add_rule_object(const std::string& rule, BaseRule* ruleObject)
+        {
+            internal_add_rule_object(rule, ruleObject, INVALID_BP_ID, blueprints_);
+        }
+
         void internal_add_rule_object(const std::string& rule, BaseRule* ruleObject, const uint16_t& BP_index, std::vector<Blueprint*>& blueprints)
         {
             bool has_trailing_slash = false;
@@ -1285,6 +1300,8 @@ namespace crow
                     per_methods_[method].trie.add(rule_without_trailing_slash, RULE_SPECIAL_REDIRECT_SLASH, BP_index != INVALID_BP_ID ? blueprints[BP_index]->prefix().length() : 0, BP_index);
                 }
             });
+
+            ruleObject->set_added();
         }
 
         void register_blueprint(Blueprint& blueprint)
@@ -1319,6 +1336,12 @@ namespace crow
             }
         }
 
+        void validate_bp() {
+            //Take all the routes from the registered blueprints and add them to `all_rules_` to be processed.
+            detail::middleware_indices blueprint_mw;
+            validate_bp(blueprints_, blueprint_mw);
+        }
+
         void validate_bp(std::vector<Blueprint*> blueprints, detail::middleware_indices& current_mw)
         {
             for (unsigned i = 0; i < blueprints.size(); i++)
@@ -1338,7 +1361,7 @@ namespace crow
                 current_mw.merge_back(blueprint->mw_indices_);
                 for (auto& rule : blueprint->all_rules_)
                 {
-                    if (rule)
+                    if (rule && !rule->is_added())
                     {
                         auto upgraded = rule->upgrade();
                         if (upgraded)
@@ -1355,19 +1378,15 @@ namespace crow
 
         void validate()
         {
-            //Take all the routes from the registered blueprints and add them to `all_rules_` to be processed.
-            detail::middleware_indices blueprint_mw;
-            validate_bp(blueprints_, blueprint_mw);
-
             for (auto& rule : all_rules_)
             {
-                if (rule)
+                if (rule && !rule->is_added())
                 {
                     auto upgraded = rule->upgrade();
                     if (upgraded)
                         rule = std::move(upgraded);
                     rule->validate();
-                    internal_add_rule_object(rule->rule(), rule.get(), INVALID_BP_ID, blueprints_);
+                    internal_add_rule_object(rule->rule(), rule.get());
                 }
             }
             for (auto& per_method : per_methods_)

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <unordered_map>
 #include <random>
+#include <algorithm>
 
 #include "crow/settings.h"
 
@@ -702,6 +703,14 @@ namespace crow
             return base64decode(data.data(), data.length());
         }
 
+        inline static std::string normalize_path(const std::string& directoryPath)
+        {
+            std::string normalizedPath = directoryPath;
+            std::replace(normalizedPath.begin(), normalizedPath.end(), '\\', '/');
+            if (!normalizedPath.empty() && normalizedPath.back() != '/')
+                normalizedPath += '/';
+            return normalizedPath;
+        }
 
         inline static void sanitize_filename(std::string& data, char replacement = '_')
         {
@@ -715,8 +724,8 @@ namespace crow
             // a special device. Thus we search for the string (case-insensitive), and then check if the string ends or if
             // is has a dangerous follow up character (.:\/)
             auto sanitizeSpecialFile = [](std::string& source, unsigned ofs, const char* pattern, bool includeNumber, char replacement) {
-	      unsigned i = ofs;
-	      size_t len = source.length();
+                unsigned i = ofs;
+                size_t len = source.length();
                 const char* p = pattern;
                 while (*p)
                 {

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1589,6 +1589,10 @@ TEST_CASE("local_middleware")
           return "works!";
       });
 
+#ifndef CROW_DISABLE_STATIC_DIR
+    app.add_static_dir();
+    app.add_blueprint();
+#endif
     app.validate();
 
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
@@ -3141,6 +3145,8 @@ TEST_CASE("blueprint")
     bp.register_blueprint(sub_bp);
     sub_bp.register_blueprint(sub_sub_bp);
 
+    app.add_blueprint();
+    app.add_static_dir();
     app.validate();
 
     {

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -532,6 +532,28 @@ TEST_CASE("http_method")
     }
 } // http_method
 
+TEST_CASE("validate can be called multiple times")
+{
+    SimpleApp app;
+    CROW_ROUTE(app, "/")([]() { return "1"; });
+    app.validate();
+    app.validate();
+
+    CROW_ROUTE(app, "/test")([]() { return "1"; });
+    app.validate();
+
+    try
+    {
+        CROW_ROUTE(app, "/")([]() { return "1"; });
+        app.validate();      
+        FAIL_CHECK();
+    }
+    catch (std::exception& e)
+    {
+        CROW_LOG_DEBUG << e.what();
+    }
+} // validate can be called multiple times
+
 TEST_CASE("server_handling_error_request")
 {
     static char buf[2048];
@@ -1589,10 +1611,6 @@ TEST_CASE("local_middleware")
           return "works!";
       });
 
-#ifndef CROW_DISABLE_STATIC_DIR
-    app.add_static_dir();
-    app.add_blueprint();
-#endif
     app.validate();
 
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
@@ -3265,6 +3283,11 @@ TEST_CASE("base64")
     CHECK(crow::utility::base64decode(sample_bin2_enc, 8) == sample_bin2_str);
     CHECK(crow::utility::base64decode(sample_bin2_enc_np, 6) == sample_bin2_str);
 } // base64
+
+TEST_CASE("normalize_path") {
+    CHECK(crow::utility::normalize_path("/abc/def") == "/abc/def/");
+    CHECK(crow::utility::normalize_path("path\\to\\directory") == "path/to/directory/");
+} // normalize_path
 
 TEST_CASE("sanitize_filename")
 {


### PR DESCRIPTION
#672 
I separated the different `validate()` responsibilities into other functions. It's now possible to execute `validate()` multiple times as it only performs validation.

Is this proposed solution all right? If so I will proceed with writing the tests.