### PR TITLE
#661 Fix

### DIFF
--- a/cmake/CrowConfig.cmake.in
+++ b/cmake/CrowConfig.cmake.in
@@ -26,7 +26,14 @@ include("${CMAKE_CURRENT_LIST_DIR}/CrowTargets.cmake")
 check_required_components("@PROJECT_NAME@")
 
 get_target_property(_CROW_ILL Crow::Crow INTERFACE_LINK_LIBRARIES)
+if(_CROW_ILL STREQUAL "_CROW_ILL-NOTFOUND")
+    set(_CROW_ILL "")
+endif()
+
 get_target_property(_CROW_ICD Crow::Crow INTERFACE_COMPILE_DEFINITIONS)
+if(_CROW_ICD STREQUAL "_CROW_ICD-NOTFOUND")
+    set(_CROW_ICD "")
+endif()
 
 list(REMOVE_ITEM _CROW_ILL "ZLIB::ZLIB" "OpenSSL::SSL")
 list(REMOVE_ITEM _CROW_ICD "CROW_ENABLE_SSL" "CROW_ENABLE_COMPRESSION")


### PR DESCRIPTION
If the non-inherited properties INTERFACE_LINK_LIBRARIES/INTERFACE_COMPILE_DEFINITIONS are not found, _CROW_ILL/_CROW_ICD are set to empty strings to allow further manipulation.