### PR TITLE
Use `const std::string&` as argument to `route()`

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -97,25 +97,25 @@ namespace crow
         }
 
         /// Create a dynamic route using a rule (**Use CROW_ROUTE instead**)
-        DynamicRule& route_dynamic(std::string&& rule)
+        DynamicRule& route_dynamic(const std::string& rule)
         {
-            return router_.new_rule_dynamic(std::move(rule));
+            return router_.new_rule_dynamic(rule);
         }
 
-        ///Create a route using a rule (**Use CROW_ROUTE instead**)
+        /// Create a route using a rule (**Use CROW_ROUTE instead**)
         template<uint64_t Tag>
 #ifdef CROW_GCC83_WORKAROUND
-        auto& route(std::string&& rule)
+        auto& route(const std::string& rule)
 #else
-        auto route(std::string&& rule)
+        auto route(const std::string& rule)
 #endif
 #if defined CROW_CAN_USE_CPP17 && !defined CROW_GCC83_WORKAROUND
-          -> typename std::invoke_result<decltype(&Router::new_rule_tagged<Tag>), Router, std::string&&>::type
+          -> typename std::invoke_result<decltype(&Router::new_rule_tagged<Tag>), Router, const std::string&>::type
 #elif !defined CROW_GCC83_WORKAROUND
-          -> typename std::result_of<decltype (&Router::new_rule_tagged<Tag>)(Router, std::string&&)>::type
+          -> typename std::result_of<decltype (&Router::new_rule_tagged<Tag>)(Router, const std::string&)>::type
 #endif
         {
-            return router_.new_rule_tagged<Tag>(std::move(rule));
+            return router_.new_rule_tagged<Tag>(rule);
         }
 
         /// Create a route for any requests without a proper route (**Use CROW_CATCHALL_ROUTE instead**)
@@ -187,7 +187,7 @@ namespace crow
             bindaddr_ = bindaddr;
             return *this;
         }
-        
+
         /// Get the address that Crow will handle requests on
         std::string bindaddr()
         {
@@ -208,7 +208,7 @@ namespace crow
             concurrency_ = concurrency;
             return *this;
         }
-        
+
         /// Get the number of threads that server is using
         std::uint16_t concurrency()
         {

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -1154,11 +1154,10 @@ namespace crow
             return static_dir_;
         }
 
-        DynamicRule& new_rule_dynamic(std::string&& rule)
+        DynamicRule& new_rule_dynamic(const std::string& rule)
         {
-            std::string new_rule = std::move(rule);
-            new_rule = '/' + prefix_ + new_rule;
-            auto ruleObject = new DynamicRule(new_rule);
+            std::string new_rule = '/' + prefix_ + rule;
+            auto ruleObject = new DynamicRule(std::move(new_rule));
             ruleObject->custom_templates_base = templates_dir_;
             all_rules_.emplace_back(ruleObject);
 
@@ -1166,13 +1165,12 @@ namespace crow
         }
 
         template<uint64_t N>
-        typename black_magic::arguments<N>::type::template rebind<TaggedRule>& new_rule_tagged(std::string&& rule)
+        typename black_magic::arguments<N>::type::template rebind<TaggedRule>& new_rule_tagged(const std::string& rule)
         {
-            std::string new_rule = std::move(rule);
-            new_rule = '/' + prefix_ + new_rule;
+            std::string new_rule = '/' + prefix_ + rule;
             using RuleT = typename black_magic::arguments<N>::type::template rebind<TaggedRule>;
 
-            auto ruleObject = new RuleT(new_rule);
+            auto ruleObject = new RuleT(std::move(new_rule));
             ruleObject->custom_templates_base = templates_dir_;
             all_rules_.emplace_back(ruleObject);
 


### PR DESCRIPTION
Fixes #671. 

NB: I went for `const std::string&` rather than `std::string + std::move()` for simplicity. Performance-wise it may not even be a loss; `std::string` isn't extremely cheap to move because of small-string optimisation (e.g., `sizeof(std::string)` is 32 bytes with libstdc++). Nevertheless, route creation is unlikely to be a performance bottleneck, so performance probably does not matter and the simplest solution will be the best. If performance did matter, then the ideal solution would probably involve `std::string_view` (C++17). With a bit of work we could also use `crow::black_magic::const_str` from `utility.h`, which is similar to `std::string_view`, but again I don't think this is worth the complication.