### PR TITLE
remove the judgment on whether a character is between 0x80 and 0x9f

### DIFF
--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -769,7 +769,7 @@ namespace crow
 
                 // Sanitize individual characters
                 unsigned char c = data[i];
-                if ((c < ' ') || ((c >= 0x80) && (c <= 0x9F)) || (c == '?') || (c == '<') || (c == '>') || (c == ':') || (c == '*') || (c == '|') || (c == '\"'))
+                if ((c < ' ') || (c == '?') || (c == '<') || (c == '>') || (c == ':') || (c == '*') || (c == '|') || (c == '\"'))
                 {
                     data[i] = replacement;
                 }


### PR DESCRIPTION
#668 
this pr do remove the judgment on whether a character is between 0x80 and 0x9f in order to accepting file with UTF-8 encoded name with Static Files.
When filename is UTF-8 encoded string, the character may be between 0x80 and 0x9f, such as "ファイル_Sumita_Matsubi_Bridge_wide_shot.jpg".
This statement will modify the string so that client cannot get the file so I removed it.