### PR TITLE
Fix/boost asio io context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# IMPORTANT NOTICE
+
+NOT MAINTAINED ANYMORE.
+
+Working fork is here: [CrowCpp/Crow](https://github.com/CrowCpp/Crow)
+
+  
+
 ![Crow logo](http://i.imgur.com/wqivvjK.jpg)
 
 Crow is C++ microframework for web. (inspired by Python Flask)

--- a/include/crow/socket_adaptors.h
+++ b/include/crow/socket_adaptors.h
@@ -19,8 +19,7 @@ namespace crow
 
         boost::asio::io_service& get_io_service()
         {
-            return static_cast<boost::asio::io_context&>(socket_.get_executor().context()); // Fix compilation error
-            // return socket_.get_io_service();
+            return static_cast<boost::asio::io_context&>(socket_.get_executor().context());
         }
 
         tcp::socket& raw_socket()

--- a/include/crow/socket_adaptors.h
+++ b/include/crow/socket_adaptors.h
@@ -19,7 +19,8 @@ namespace crow
 
         boost::asio::io_service& get_io_service()
         {
-            return socket_.get_io_service();
+            return static_cast<boost::asio::io_context&>(socket_.get_executor().context()); // Fix compilation error
+            // return socket_.get_io_service();
         }
 
         tcp::socket& raw_socket()

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -390,6 +390,7 @@ namespace crow
                                         message_handler_(*this, message_, is_binary_);
                                     message_.clear();
                                 }
+                                break; // Fixing fallthrough error
                             }
                         case 1: // Text
                             {

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -390,7 +390,7 @@ namespace crow
                                         message_handler_(*this, message_, is_binary_);
                                     message_.clear();
                                 }
-                                break; // Fixing fallthrough error
+                                break;
                             }
                         case 1: // Text
                             {


### PR DESCRIPTION
I am using Crow (single include) in a private project on Ubuntu. When trying to compile (g++ 9.4.0-1) with my other C++ 17 code, I got a compiler error in the socket_adaptors.h file, specifically the boost::asio::io_service& get_io_service() function, which I corrected with a cast to boost::asio::io_context&. Furthermore in I fixed a fallthrough warning in websocket.h.

This is my first open source contribution, I am not a professional or even advanced developer. I hope this helps and I did everything right on the pull request (never done this before either).  