### PR TITLE
Handle _CROW_ILL or _CROW_ICD being NOTFOUND

### DIFF
--- a/cmake/CrowConfig.cmake.in
+++ b/cmake/CrowConfig.cmake.in
@@ -28,6 +28,13 @@ check_required_components("@PROJECT_NAME@")
 get_target_property(_CROW_ILL Crow::Crow INTERFACE_LINK_LIBRARIES)
 get_target_property(_CROW_ICD Crow::Crow INTERFACE_COMPILE_DEFINITIONS)
 
+if(_CROW_ILL STREQUAL "_CROW_ILL-NOTFOUND")
+        set(_CROW_ILL "")
+endif()
+if(_CROW_ICD STREQUAL "_CROW_ICD-NOTFOUND")
+        set(_CROW_ICD "")
+endif()
+
 list(REMOVE_ITEM _CROW_ILL "ZLIB::ZLIB" "OpenSSL::SSL")
 list(REMOVE_ITEM _CROW_ICD "CROW_ENABLE_SSL" "CROW_ENABLE_COMPRESSION")
 
@@ -41,7 +48,13 @@ if("ssl" IN_LIST CROW_FEATURES)
   list(APPEND _CROW_ICD "CROW_ENABLE_SSL")
 endif()
 
-set_target_properties(Crow::Crow PROPERTIES
-  INTERFACE_COMPILE_DEFINITIONS "${_CROW_ICD}"
-  INTERFACE_LINK_LIBRARIES "${_CROW_ILL}"
-)
+if( NOT (_CROW_ICD STREQUAL "" ) )
+  set_target_properties(Crow::Crow PROPERTIES
+    INTERFACE_COMPILE_DEFINITIONS "${_CROW_ICD}"
+  )
+endif()
+if( NOT (_CROW_ILL STREQUAL "" ) )
+  set_target_properties(Crow::Crow PROPERTIES
+    INTERFACE_LINK_LIBRARIES "${_CROW_ILL}"
+  )
+endif()


### PR DESCRIPTION
There is a big warning that may appear when compiling user code:
```
In file included from <built-in>:461:
<command line>:6:18: warning: ISO C99 requires whitespace after the macro name [-Wc99-extensions]
    6 | #define _CROW_ICD-NOTFOUND 1
      |
```

When using `get_target_property` in cmake and the property is not found it will define the content of the variable `<var>-NOTFOUND` and because these variables were being used as compile definitions it causes a bunch of warnings due to the `-` in the name.

### Solution:

If the variable is `NOTFOUND` then set it to `""`. Then at the end after possible list appends. If the variable is not `""` then update the target properties. This means we do not add the compile definition at all.

This gets rid of a warning. And since there is nowhere in the code looking for NOTFOUND it does not change functionality.