### PR TITLE
Fix order of destructor call of io_service in crow::Server

### DIFF
--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -254,8 +254,8 @@ namespace crow
         }
 
     private:
-        asio::io_service io_service_;
         std::vector<std::unique_ptr<asio::io_service>> io_service_pool_;
+        asio::io_service io_service_;
         std::vector<detail::task_timer*> task_timer_pool_;
         std::vector<std::function<std::string()>> get_cached_date_str_pool_;
         tcp::acceptor acceptor_;


### PR DESCRIPTION
Destructing crow::App object caused Segmentation fault when I built crow with MinGW gcc-13.
There are similar issue #697, but I reproduced with MinGW, not Visual Studio.

<details><summary>Steps to reproduce</summary>

* Install MSYS2
* Install build tools inside MSYS2 MinGW64 (`pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja gdb`)
* Write CMakeLists.txt and main.cc (copied from #697)
```cmake
cmake_minimum_required(VERSION 3.0)
project(main)
add_executable(main main.cc)
target_compile_options(main PRIVATE -g)
target_include_directories(main PRIVATE
	${CMAKE_CURRENT_SOURCE_DIR}/asio/asio/include
	${CMAKE_CURRENT_SOURCE_DIR}/Crow/include
)
target_link_libraries(main PRIVATE ws2_32 wsock32)
```

```cpp
#include <crow.h>

int main(){
	{
		crow::SimpleApp app;
		CROW_ROUTE( app, "/hello" )
		( []() {
			return "Hello World!";
		} );
		auto server_future = app.port( 18080 ).multithreaded().run_async();
		app.wait_for_server_start();
		std::this_thread::sleep_for( std::chrono::seconds( 1 ) );
		app.stop();           // stop server
		server_future.get();  // throw exceptions if any
	}
	return 0;
}
```
* `git clone https://github.com/CrowCpp/Crow.git`
* `git clone https://github.com/chriskohlhoff/asio.git`
* `cmake -Bbuild`
* `cmake --build build`
* `gdb ./build/main.exe` and run
* gives Segmentation fault
</details>

backtrace:
```
#0  0x00007ffb01c91a28 in ntdll!RtlEnterCriticalSection () from /c/Windows/SYSTEM32/ntdll.dll
#1  0x00007ffb01c916c2 in ntdll!RtlEnterCriticalSection () from /c/Windows/SYSTEM32/ntdll.dll
#2  0x00007ff716181eec in asio::detail::win_mutex::lock (this=0x1209d30)
    at C:/Users/shach/projects/crow_test/asio/asio/include/asio/detail/win_mutex.hpp:49
#3  0x00007ff71616f449 in asio::detail::scoped_lock<asio::detail::win_mutex>::scoped_lock (
    this=0x5fe820, m=...)
    at C:/Users/shach/projects/crow_test/asio/asio/include/asio/detail/scoped_lock.hpp:45
#4  0x00007ff71617f8d4 in asio::detail::win_iocp_socket_service_base::destroy (this=0x1209d08,
    impl=...)
    at C:/Users/shach/projects/crow_test/asio/asio/include/asio/detail/impl/win_iocp_socket_service_base.ipp:153
#5  0x00007ff7161729d7 in asio::detail::io_object_impl<asio::detail::win_iocp_socket_service<asio::ip::tcp>, asio::any_io_executor>::~io_object_impl (this=0x120d2c0, __in_chrg=<optimized out>)
    at C:/Users/shach/projects/crow_test/asio/asio/include/asio/detail/io_object_impl.hpp:94
#6  0x00007ff71616a418 in asio::basic_socket<asio::ip::tcp, asio::any_io_executor>::~basic_socket (
    this=0x120d2c0, __in_chrg=<optimized out>)
    at C:/Users/shach/projects/crow_test/asio/asio/include/asio/basic_socket.hpp:1835
#7  0x00007ff71616b498 in asio::basic_stream_socket<asio::ip::tcp, asio::any_io_executor>::~basic_stream_socket (this=0x120d2c0, __in_chrg=<optimized out>)
    at C:/Users/shach/projects/crow_test/asio/asio/include/asio/basic_stream_socket.hpp:340
#8  0x00007ff71618afe8 in crow::SocketAdaptor::~SocketAdaptor (this=0x120d2c0,
    __in_chrg=<optimized out>)
    at C:/Users/shach/projects/crow_test/Crow/include/crow/socket_adaptors.h:21
#9  0x00007ff71618989a in crow::Connection<crow::SocketAdaptor, crow::Crow<>>::~Connection() (
    this=0x120d2b0, __in_chrg=<optimized out>)
    at C:/Users/shach/projects/crow_test/Crow/include/crow/http_connection.h:72
#10 0x00007ff7161d34e8 in std::_Destroy<crow::Connection<crow::SocketAdaptor, crow::Crow<>> >(crow::Connection<crow::SocketAdaptor, crow::Crow<>>*) (__pointer=0x120d2b0)
    at C:/tools/msys64/mingw64/include/c++/13.2.0/bits/stl_construct.h:151
#11 0x00007ff7161b7472 in std::allocator_traits<std::allocator<void> >::destroy<crow::Connection<crow::SocketAdaptor, crow::Crow<>> >(std::allocator<void>&, crow::Connection<crow::SocketAdaptor, crow::Crow<>>*) (__p=0x120d2b0) at C:/tools/msys64/mingw64/include/c++/13.2.0/bits/alloc_traits.h:674
#12 std::_Sp_counted_ptr_inplace<crow::Connection<crow::SocketAdaptor, crow::Crow<>>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() (this=0x120d2a0)
    at C:/tools/msys64/mingw64/include/c++/13.2.0/bits/shared_ptr_base.h:613
#13 0x00007ff7161b6353 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use (
    this=0x120d2a0) at C:/tools/msys64/mingw64/include/c++/13.2.0/bits/shared_ptr_base.h:175
#14 0x00007ff7161b6478 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use_cold (this=0x120d2a0) at C:/tools/msys64/mingw64/include/c++/13.2.0/bits/shared_ptr_base.h:199
#15 0x00007ff7161b61a7 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (
    this=0x120d2a0) at C:/tools/msys64/mingw64/include/c++/13.2.0/bits/shared_ptr_base.h:353
#16 0x00007ff7161b33a7 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (
    this=0x5fec40, __in_chrg=<optimized out>)
    at C:/tools/msys64/mingw64/include/c++/13.2.0/bits/shared_ptr_base.h:1071
#17 0x00007ff7161af1ac in std::__shared_ptr<crow::Connection<crow::SocketAdaptor, crow::Crow<>>, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() (this=0x5fec38, __in_chrg=<optimized out>)
    at C:/tools/msys64/mingw64/include/c++/13.2.0/bits/shared_ptr_base.h:1524
#18 0x00007ff7161a91f8 in std::shared_ptr<crow::Connection<crow::SocketAdaptor, crow::Crow<>> >::~shared_ptr() (this=0x5fec38, __in_chrg=<optimized out>)
    at C:/tools/msys64/mingw64/include/c++/13.2.0/bits/shared_ptr.h:175
#19 0x00007ff7161d6b6c in crow::Server<crow::Crow<>, crow::SocketAdaptor>::do_accept()::{lambda(std::error_code)#1}::~error_code() (this=0x5fec30, __in_chrg=<optimized out>)
    at C:/Users/shach/projects/crow_test/Crow/include/crow/http_server.h:230
#20 0x00007ff716180938 in asio::detail::binder1<crow::Server<crow::Crow<>, crow::SocketAdaptor>::do_accept()::{lambda(std::error_code)#1}, std::error_code>::~binder1() (this=0x5fec30,
    __in_chrg=<optimized out>)
    at C:/Users/shach/projects/crow_test/asio/asio/include/asio/detail/bind_handler.hpp:84
#21 0x00007ff71617e31f in asio::detail::win_iocp_socket_accept_op<asio::basic_socket<asio::ip::tcp, asio::any_io_executor>, asio::ip::tcp, crow::Server<crow::Crow<>, crow::SocketAdaptor>::do_accept()::{lambda(std::error_code)#1}, asio::any_io_executor>::do_complete(void*, asio::detail::win_iocp_operation*, std::error_code const&, unsigned long long) (owner=0x0, base=0x120af40, result_ec=...)
    at C:/Users/shach/projects/crow_test/asio/asio/include/asio/detail/win_iocp_socket_accept_op.hpp:164
#22 0x00007ff716178cce in asio::detail::win_iocp_operation::destroy (this=0x120af40)
    at C:/Users/shach/projects/crow_test/asio/asio/include/asio/detail/win_iocp_operation.hpp:51
#23 0x00007ff71617b035 in asio::detail::win_iocp_io_context::shutdown (this=0x6f2c70)
    at C:/Users/shach/projects/crow_test/asio/asio/include/asio/detail/impl/win_iocp_io_context.ipp:164
#24 0x00007ff716174141 in asio::detail::service_registry::shutdown_services (this=0x6f9fb0)
    at C:/Users/shach/projects/crow_test/asio/asio/include/asio/detail/impl/service_registry.ipp:43
#25 0x00007ff71616b1bb in asio::execution_context::shutdown (this=0x6fa130)
    at C:/Users/shach/projects/crow_test/asio/asio/include/asio/impl/execution_context.ipp:40
#26 0x00007ff716169f88 in asio::io_context::~io_context (this=0x6fa130, __in_chrg=<optimized out>)
    at C:/Users/shach/projects/crow_test/asio/asio/include/asio/impl/io_context.ipp:57
#27 0x00007ff716195738 in crow::Server<crow::Crow<>, crow::SocketAdaptor>::~Server() (
    this=0x6fa130, __in_chrg=<optimized out>)
    at C:/Users/shach/projects/crow_test/Crow/include/crow/http_server.h:27
#28 0x00007ff7161a25b4 in std::default_delete<crow::Server<crow::Crow<>, crow::SocketAdaptor> >::operator()(crow::Server<crow::Crow<>, crow::SocketAdaptor>*) const (this=0x5ffdf0, __ptr=0x6fa130)
    at C:/tools/msys64/mingw64/include/c++/13.2.0/bits/unique_ptr.h:99
#29 0x00007ff7161a9874 in std::unique_ptr<crow::Server<crow::Crow<>, crow::SocketAdaptor>, std::default_delete<crow::Server<crow::Crow<>, crow::SocketAdaptor> > >::~unique_ptr() (this=0x5ffdf0,
    __in_chrg=<optimized out>) at C:/tools/msys64/mingw64/include/c++/13.2.0/bits/unique_ptr.h:404
#30 0x00007ff7161908c6 in crow::Crow<>::~Crow() (this=0x5ff050, __in_chrg=<optimized out>)
    at C:/Users/shach/projects/crow_test/Crow/include/crow/app.h:49
#31 0x00007ff716161da1 in main () at C:/Users/shach/projects/crow_test/main.cc:15
```

This pr fixes this Segmentation fault, as described in the comment in #697.
