### PR TITLE
Templated cast function for reading JSON values

### DIFF
--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -456,6 +456,13 @@ namespace crow
                 return detail::r_string{start_, end_};
             }
 
+            /// Any stringstream lexical cast.
+            template <typename cast_t>
+            cast_t cast() const
+            {
+                return utility::lexical_cast<cast_t>(start_, end_ - start_);
+            }
+
             /// The list or object value
             std::vector<rvalue> lo()
             {


### PR DESCRIPTION
I have not tested this code (sorry) but it aims to solve the problem of reading to smaller types like uint32_t and uint16_t.
The string stream implementation should throw up warnings where applicable for unsupported types.