### PR TITLE
Performance fix for non-static streaming data

### DIFF
--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -441,7 +441,7 @@ namespace crow
                     size_t length = res.body.length();
                     for(size_t transferred = 0; transferred < length;)
                     {
-                        size_t to_transfer = std::min(16385UL, length-transferred);
+                        size_t to_transfer = std::min(16384UL, length-transferred);
                         buffers[0] = asio::const_buffer(data+transferred, to_transfer);
                         do_write_sync(buffers);
                         transferred += to_transfer;

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -442,7 +442,7 @@ namespace crow
                     size_t length = res.body.length();
                     for(size_t transferred = 0; transferred < length;)
                     {
-                        size_t to_transfer = std::min(16384UL, length-transferred);
+                        size_t to_transfer = CROW_MIN(16384UL, length-transferred);
                         buffers[0] = asio::const_buffer(data+transferred, to_transfer);
                         do_write_sync(buffers);
                         transferred += to_transfer;

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -3,6 +3,7 @@
 #define ASIO_STANDALONE
 #endif
 #include <asio.hpp>
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <vector>


### PR DESCRIPTION
I am using your project at work for controlling a high performance fpga project. Sometimes i want to peek into the data, and get a bunch of bytes from the device. This may vary from some several kilobytes to megabytes, depending on how much data i need.
I noticed that when i start pulling 20Megs or more the response is terribly slow (this is when it comes into Crow's streaming-handling). So i took a look. I believe using substr there is not so good, because of all the alloc/dealloc. 
You can verify, use the code below:

```#include "crow.h"

int main()
{
    crow::SimpleApp app;

    std::string test;
    test.resize(1024*1024*20);

    for(int i = 0; i < 20*1024*1024; i++)
        test[i] = (char)(i % 255);

    FILE *fp = fopen("/tmp/testcmp", "wb");
    fwrite(test.data(), 1, 1024*1024*20, fp);
    fclose(fp);

    CROW_ROUTE(app, "/")([&test](const crow::request &req, crow::response &resp ){
            resp.add_header("Content-Length", std::to_string(20*1024*1024));
            resp.body = test;
            resp.end();
    });

    app.port(18080).run();
}
```

I write to /tmp/testcmp to verify the checksums with the data i get via curl: `/usr/bin/time -f "+%E" curl http://localhost:18080/ > /tmp/test`
With current Crow the transfer takes several seconds. With this patch it takes some milliseconds.

Thank you for the amazing work on Crow. I really like it (especially the json stuff).
Kind regards,
jfm