### PR TITLE
Add indentation to json dump method

### DIFF
--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -1826,7 +1826,14 @@ namespace crow
                 out.push_back('"');
             }
 
-            inline void dump_internal(const wvalue& v, std::string& out) const
+            inline void dump_indentation_part(std::string& out, const int indent, const char separator, const int indent_level) const
+            {
+                out.push_back('\n');
+                out.append(indent_level * indent, separator);
+            }
+
+
+            inline void dump_internal(const wvalue& v, std::string& out, const int indent, const char separator, const int indent_level = 0) const
             {
                 switch (v.t_)
                 {
@@ -1909,6 +1916,12 @@ namespace crow
                     case type::List:
                     {
                         out.push_back('[');
+
+                        if (indent >= 0)
+                        {
+                            dump_indentation_part(out, indent, separator, indent_level + 1);
+                        }
+
                         if (v.l)
                         {
                             bool first = true;
@@ -1917,17 +1930,34 @@ namespace crow
                                 if (!first)
                                 {
                                     out.push_back(',');
+
+                                    if (indent >= 0)
+                                    {
+                                        dump_indentation_part(out, indent, separator, indent_level + 1);
+                                    }
                                 }
                                 first = false;
-                                dump_internal(x, out);
+                                dump_internal(x, out, indent, separator, indent_level + 1);
                             }
                         }
+
+                        if (indent >= 0)
+                        {
+                            dump_indentation_part(out, indent, separator, indent_level);
+                        }
+
                         out.push_back(']');
                     }
                     break;
                     case type::Object:
                     {
                         out.push_back('{');
+
+                        if (indent >= 0)
+                        {
+                            dump_indentation_part(out, indent, separator, indent_level + 1);
+                        }
+
                         if (v.o)
                         {
                             bool first = true;
@@ -1936,13 +1966,29 @@ namespace crow
                                 if (!first)
                                 {
                                     out.push_back(',');
+                                    if (indent >= 0)
+                                    {
+                                        dump_indentation_part(out, indent, separator, indent_level + 1);
+                                    }
                                 }
                                 first = false;
                                 dump_string(kv.first, out);
                                 out.push_back(':');
-                                dump_internal(kv.second, out);
+
+                                if (indent >= 0)
+                                {
+                                    out.push_back(' ');
+                                }
+
+                                dump_internal(kv.second, out, indent, separator, indent_level + 1);
                             }
                         }
+
+                        if (indent >= 0)
+                        {
+                            dump_indentation_part(out, indent, separator, indent_level);
+                        }
+
                         out.push_back('}');
                     }
                     break;
@@ -1954,12 +2000,19 @@ namespace crow
             }
 
         public:
-            std::string dump() const
+            std::string dump(const int indent, const char separator = ' ') const
             {
                 std::string ret;
                 ret.reserve(estimate_length());
-                dump_internal(*this, ret);
+                dump_internal(*this, ret, indent, separator);
                 return ret;
+            }
+
+            std::string dump() const
+            {
+                static constexpr int DontIndent = -1;
+
+                return dump(DontIndent);
             }
         };
 

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -921,6 +921,72 @@ TEST_CASE("json_write")
     CHECK(R"({"scores":[1,2,3]})" == y.dump());
 } // json_write
 
+TEST_CASE("json_write_with_indent")
+{
+    static constexpr int IndentationLevelOne = 1;
+    static constexpr int IndentationLevelTwo = 2;
+    static constexpr int IndentationLevelFour = 4;
+
+    json::wvalue y;
+
+    y["scores"][0] = 1;
+    y["scores"][1] = "king";
+    y["scores"][2][0] = "real";
+    y["scores"][2][1] = false;
+    y["scores"][2][2] = true;
+
+    CHECK(R"({
+ "scores": [
+  1,
+  "king",
+  [
+   "real",
+   false,
+   true
+  ]
+ ]
+})" == y.dump(IndentationLevelOne));
+
+    CHECK(R"({
+  "scores": [
+    1,
+    "king",
+    [
+      "real",
+      false,
+      true
+    ]
+  ]
+})" == y.dump(IndentationLevelTwo));
+
+    CHECK(R"({
+    "scores": [
+        1,
+        "king",
+        [
+            "real",
+            false,
+            true
+        ]
+    ]
+})" == y.dump(IndentationLevelFour));
+
+    static constexpr char TabSeparator = '\t';
+
+    CHECK(R"({
+	"scores": [
+		1,
+		"king",
+		[
+			"real",
+			false,
+			true
+		]
+	]
+})" == y.dump(IndentationLevelOne, TabSeparator));
+} // json_write_with_indent
+
+
 TEST_CASE("json_copy_r_to_w_to_w_to_r")
 {
     json::rvalue r = json::load(


### PR DESCRIPTION
The problem is specified in issue #747 .

This is a simple solution to improve the dump method without breaking any APIs and is fully backward-compatible.
