### PR TITLE
fix: call after_handlers for legitimate requests without body part

### DIFF
--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -103,6 +103,7 @@ namespace crow
             if (!routing_handle_result_->rule_index)
             {
                 parser_.done();
+                need_to_call_after_handlers_ = true;
                 complete_request();
             }
         }


### PR DESCRIPTION
This PR fixes #764 