### PR TITLE
add spdx license id to compiled header

### DIFF
--- a/scripts/merge_all.py
+++ b/scripts/merge_all.py
@@ -86,7 +86,8 @@ for x in edges:
         assert order.index(x) < order.index(y), 'cyclic include detected'
 
 print(order)
-build = [lsc, '#pragma once']
+spdx_lsc = '// SPDX-License-Identifier: BSD-3-Clause AND ISC AND MIT'
+build = [spdx_lsc, lsc, '#pragma once']
 for header in order:
     d = open(pt.join(header_path, header), encoding='UTF-8').read()
     d_no_depend = re_depends.sub(lambda x: '', d)


### PR DESCRIPTION
This commit adjusts the merging script to include a SPDX license identifier at the start of the single header file. This can help users of Crow which have environments using license scanning tools to help manage/monitor used implementation.

----

Feel free to drop is not preferred, but this merge request attempts to introduce the use of a SPDX identifier into the generate single-header file. Defined the license set based on the referenced license information seen in LICENSE (BSD-3-Clause) as well as README.md (ISC: TinySHA1; MIT: http-parser, qs_parse).