### PR TITLE
fix: compilation error with libc++

### DIFF
--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -1670,7 +1670,7 @@ namespace crow
                 }
                 else
                 {
-#if defined(__APPLE__) || defined(__MACH__) || defined(__FreeBSD__) || defined(__ANDROID__)
+#if defined(__APPLE__) || defined(__MACH__) || defined(__FreeBSD__) || defined(__ANDROID__) || defined(_LIBCPP_VERSION)
                     o = std::unique_ptr<object>(new object(initializer_list));
 #else
                     (*o) = initializer_list;
@@ -1689,7 +1689,7 @@ namespace crow
                 }
                 else
                 {
-#if defined(__APPLE__) || defined(__MACH__) || defined(__FreeBSD__) || defined(__ANDROID__)
+#if defined(__APPLE__) || defined(__MACH__) || defined(__FreeBSD__) || defined(__ANDROID__) || defined(_LIBCPP_VERSION)
                     o = std::unique_ptr<object>(new object(value));
 #else
                     (*o) = value;


### PR DESCRIPTION
I use Crow on Windows, MacOS, and Linux. On Windows, I compile with the MSVC compiler, while on MacOS and Linux, I use the Clang compiler. It works well.

The issue arose when migrating from my local development environment on Linux (WSL, Ubuntu Preview 24.04 daily live) to a cloud server (Debian 12). Since Debian 12 lacks the latest Clang compiler and C++ Library, I had to install libc++ as a replacement for libstdc++, which led to compilation problems. Subsequently, linking the version that ran correctly on WSL to libc++ instead of libstdc++ also resulted in the same issue.

After searching for relevant information in this repository, I found that issues #229, #481, and #636, as well as pull requests #229 and #634, might be related. After modifying json.h, my code compiled and ran successfully.

I'm unsure if `_LIBCPP_VERSION` would be defined under `defined(__APPLE__) || defined(__MACH__) || defined(__FreeBSD__) || defined(__ANDROID__)`, so I didn't remove the conditional checks in the original code. Instead, I added checks for `_LIBCPP_VERSION` directly after them. If possible, you can further investigate this.

I'm a beginner in C++, and English is not my first language, so please forgive any inaccuracies in my wording.