### PR TITLE
Add option to use Boost.Asio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ option(CROW_BUILD_EXAMPLES     "Build the examples in the project"      ${CROW_I
 option(CROW_BUILD_TESTS        "Build the tests in the project"         ${CROW_IS_MAIN_PROJECT})
 option(CROW_AMALGAMATE         "Combine all headers into one"           OFF)
 option(CROW_INSTALL            "Add install step for Crow"              ON )
+option(CROW_USE_BOOST          "Use Boost.Asio for Crow"                OFF)
 
 # Possible values: ssl, compression
 option(CROW_FEATURES					 "Enable features extending Crow's abilities" "")
@@ -62,12 +63,20 @@ target_include_directories(Crow
 		$<INSTALL_INTERFACE:include>
 )
 
-find_package(asio REQUIRED)
-
-target_link_libraries(Crow
-	INTERFACE
-		asio::asio
-)
+if(CROW_USE_BOOST)
+	find_package(Boost 1.64 COMPONENTS system date_time REQUIRED)
+	target_link_libraries(Crow
+		INTERFACE
+			Boost::boost Boost::system Boost::date_time
+	)
+	target_compile_definitions(Crow INTERFACE CROW_USE_BOOST)
+else()
+    find_package(asio REQUIRED)
+	target_link_libraries(Crow
+		INTERFACE
+			asio::asio
+	)
+endif()
 
 target_compile_definitions(Crow INTERFACE "")
 

--- a/include/crow/http_request.h
+++ b/include/crow/http_request.h
@@ -1,9 +1,13 @@
 #pragma once
 
+#ifdef CROW_USE_BOOST
+#include <boost/asio.hpp>
+#else
 #ifndef ASIO_STANDALONE
 #define ASIO_STANDALONE
 #endif
 #include <asio.hpp>
+#endif
 
 #include "crow/common.h"
 #include "crow/ci_map.h"
@@ -11,6 +15,10 @@
 
 namespace crow
 {
+#ifdef CROW_USE_BOOST
+    namespace asio = boost::asio;
+#endif
+
     /// Find and return the value associated with the key. (returns an empty string if nothing is found)
     template<typename T>
     inline const std::string& get_header_value(const T& headers, const std::string& key)

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -1,6 +1,11 @@
 #pragma once
 
-#include <chrono>
+#ifdef CROW_USE_BOOST
+#include <boost/asio.hpp>
+#ifdef CROW_ENABLE_SSL
+#include <boost/asio/ssl.hpp>
+#endif
+#else
 #ifndef ASIO_STANDALONE
 #define ASIO_STANDALONE
 #endif
@@ -8,11 +13,14 @@
 #ifdef CROW_ENABLE_SSL
 #include <asio/ssl.hpp>
 #endif
-#include <cstdint>
+#endif
+
 #include <atomic>
+#include <chrono>
+#include <cstdint>
 #include <future>
-#include <vector>
 #include <memory>
+#include <vector>
 
 #include "crow/version.h"
 #include "crow/http_connection.h"
@@ -21,6 +29,12 @@
 
 namespace crow
 {
+#ifdef CROW_USE_BOOST
+    namespace asio = boost::asio;
+    using error_code = boost::system::error_code;
+#else
+    using error_code = asio::error_code;
+#endif
     using tcp = asio::ip::tcp;
 
     template<typename Handler, typename Adaptor = SocketAdaptor, typename... Middlewares>
@@ -52,7 +66,7 @@ namespace crow
         {
             tick_function_();
             tick_timer_.expires_after(std::chrono::milliseconds(tick_interval_.count()));
-            tick_timer_.async_wait([this](const asio::error_code& ec) {
+            tick_timer_.async_wait([this](const error_code& ec) {
                 if (ec)
                     return;
                 on_tick();
@@ -128,7 +142,7 @@ namespace crow
             {
                 tick_timer_.expires_after(std::chrono::milliseconds(tick_interval_.count()));
                 tick_timer_.async_wait(
-                  [this](const asio::error_code& ec) {
+                  [this](const error_code& ec) {
                       if (ec)
                           return;
                       on_tick();
@@ -143,7 +157,7 @@ namespace crow
             CROW_LOG_INFO << "Call `app.loglevel(crow::LogLevel::Warning)` to hide Info level logs.";
 
             signals_.async_wait(
-              [&](const asio::error_code& /*error*/, int /*signal_number*/) {
+              [&](const error_code& /*error*/, int /*signal_number*/) {
                   stop();
               });
 
@@ -227,7 +241,7 @@ namespace crow
 
                 acceptor_.async_accept(
                   p->socket(),
-                  [this, p, &is, service_idx](asio::error_code ec) {
+                  [this, p, &is, service_idx](error_code ec) {
                       if (!ec)
                       {
                           is.post(

--- a/include/crow/socket_adaptors.h
+++ b/include/crow/socket_adaptors.h
@@ -6,11 +6,6 @@
 #ifdef CROW_ENABLE_SSL
 #include <boost/asio/ssl.hpp>
 #endif
-#if BOOST_VERSION >= 107000
-#define GET_IO_SERVICE(s) ((boost::asio::io_context&)(s).get_executor().context())
-#else
-#define GET_IO_SERVICE(s) ((s).get_io_service())
-#endif
 #else
 #ifndef ASIO_STANDALONE
 #define ASIO_STANDALONE
@@ -20,13 +15,14 @@
 #ifdef CROW_ENABLE_SSL
 #include <asio/ssl.hpp>
 #endif
-#if ASIO_VERSION >= 101300 // 1.13.0
+#endif
+#include "crow/settings.h"
+
+#if (CROW_USE_BOOST && BOOST_VERSION >= 107000) || (ASIO_VERSION >= 101300)
 #define GET_IO_SERVICE(s) ((asio::io_context&)(s).get_executor().context())
 #else
 #define GET_IO_SERVICE(s) ((s).get_io_service())
 #endif
-#endif
-#include "crow/settings.h"
 
 namespace crow
 {

--- a/include/crow/socket_adaptors.h
+++ b/include/crow/socket_adaptors.h
@@ -1,20 +1,41 @@
 #pragma once
+
+#ifdef CROW_USE_BOOST
+#include <boost/asio.hpp>
+#include <boost/asio/version.hpp>
+#ifdef CROW_ENABLE_SSL
+#include <boost/asio/ssl.hpp>
+#endif
+#if BOOST_VERSION >= 107000
+#define GET_IO_SERVICE(s) ((boost::asio::io_context&)(s).get_executor().context())
+#else
+#define GET_IO_SERVICE(s) ((s).get_io_service())
+#endif
+#else
 #ifndef ASIO_STANDALONE
 #define ASIO_STANDALONE
 #endif
 #include <asio.hpp>
+#include <asio/version.hpp>
 #ifdef CROW_ENABLE_SSL
 #include <asio/ssl.hpp>
 #endif
-#include "crow/settings.h"
-#include <asio/version.hpp>
 #if ASIO_VERSION >= 101300 // 1.13.0
 #define GET_IO_SERVICE(s) ((asio::io_context&)(s).get_executor().context())
 #else
 #define GET_IO_SERVICE(s) ((s).get_io_service())
 #endif
+#endif
+#include "crow/settings.h"
+
 namespace crow
 {
+#ifdef CROW_USE_BOOST
+    namespace asio = boost::asio;
+    using error_code = boost::system::error_code;
+#else
+    using error_code = asio::error_code;
+#endif
     using tcp = asio::ip::tcp;
 
     /// A wrapper for the asio::ip::tcp::socket and asio::ssl::stream
@@ -54,32 +75,32 @@ namespace crow
 
         void close()
         {
-            asio::error_code ec;
+            error_code ec;
             socket_.close(ec);
         }
 
         void shutdown_readwrite()
         {
-            asio::error_code ec;
+            error_code ec;
             socket_.shutdown(asio::socket_base::shutdown_type::shutdown_both, ec);
         }
 
         void shutdown_write()
         {
-            asio::error_code ec;
+            error_code ec;
             socket_.shutdown(asio::socket_base::shutdown_type::shutdown_send, ec);
         }
 
         void shutdown_read()
         {
-            asio::error_code ec;
+            error_code ec;
             socket_.shutdown(asio::socket_base::shutdown_type::shutdown_receive, ec);
         }
 
         template<typename F>
         void start(F f)
         {
-            f(asio::error_code());
+            f(error_code());
         }
 
         tcp::socket socket_;
@@ -119,7 +140,7 @@ namespace crow
         {
             if (is_open())
             {
-                asio::error_code ec;
+                error_code ec;
                 raw_socket().close(ec);
             }
         }
@@ -128,7 +149,7 @@ namespace crow
         {
             if (is_open())
             {
-                asio::error_code ec;
+                error_code ec;
                 raw_socket().shutdown(asio::socket_base::shutdown_type::shutdown_both, ec);
             }
         }
@@ -137,7 +158,7 @@ namespace crow
         {
             if (is_open())
             {
-                asio::error_code ec;
+                error_code ec;
                 raw_socket().shutdown(asio::socket_base::shutdown_type::shutdown_send, ec);
             }
         }
@@ -146,7 +167,7 @@ namespace crow
         {
             if (is_open())
             {
-                asio::error_code ec;
+                error_code ec;
                 raw_socket().shutdown(asio::socket_base::shutdown_type::shutdown_receive, ec);
             }
         }
@@ -160,7 +181,7 @@ namespace crow
         void start(F f)
         {
             ssl_socket_->async_handshake(asio::ssl::stream_base::server,
-                                         [f](const asio::error_code& ec) {
+                                         [f](const error_code& ec) {
                                              f(ec);
                                          });
         }

--- a/include/crow/task_timer.h
+++ b/include/crow/task_timer.h
@@ -1,10 +1,15 @@
 #pragma once
 
+#ifdef CROW_USE_BOOST
+#include <boost/asio.hpp>
+#include <boost/asio/basic_waitable_timer.hpp>
+#else
 #ifndef ASIO_STANDALONE
 #define ASIO_STANDALONE
 #endif
 #include <asio.hpp>
 #include <asio/basic_waitable_timer.hpp>
+#endif
 
 #include <chrono>
 #include <functional>
@@ -15,6 +20,12 @@
 
 namespace crow
 {
+#ifdef CROW_USE_BOOST
+    namespace asio = boost::asio;
+    using error_code = boost::system::error_code;
+#else
+    using error_code = asio::error_code;
+#endif
     namespace detail
     {
 
@@ -112,7 +123,7 @@ namespace crow
                 if (tasks_.empty()) highest_id_ = 0;
             }
 
-            void tick_handler(const asio::error_code& ec)
+            void tick_handler(const error_code& ec)
             {
                 if (ec) return;
 

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -8,6 +8,12 @@
 
 namespace crow
 {
+#ifdef CROW_USE_BOOST
+    namespace asio = boost::asio;
+    using error_code = boost::system::error_code;
+#else
+    using error_code = asio::error_code;
+#endif
     namespace websocket
     {
         enum class WebSocketReadState
@@ -299,7 +305,7 @@ namespace crow
                         //asio::async_read(adaptor_.socket(), asio::buffer(&mini_header_, 1),
                         adaptor_.socket().async_read_some(
                           asio::buffer(&mini_header_, 2),
-                          [this](const asio::error_code& ec, std::size_t
+                          [this](const error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
                                                                bytes_transferred
 #endif
@@ -367,7 +373,7 @@ namespace crow
                         remaining_length16_ = 0;
                         asio::async_read(
                           adaptor_.socket(), asio::buffer(&remaining_length16_, 2),
-                          [this](const asio::error_code& ec, std::size_t
+                          [this](const error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
                                                                bytes_transferred
 #endif
@@ -403,7 +409,7 @@ namespace crow
                     {
                         asio::async_read(
                           adaptor_.socket(), asio::buffer(&remaining_length_, 8),
-                          [this](const asio::error_code& ec, std::size_t
+                          [this](const error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
                                                                bytes_transferred
 #endif
@@ -447,7 +453,7 @@ namespace crow
                         {
                             asio::async_read(
                               adaptor_.socket(), asio::buffer((char*)&mask_, 4),
-                              [this](const asio::error_code& ec, std::size_t
+                              [this](const error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
                                                                    bytes_transferred
 #endif
@@ -489,7 +495,7 @@ namespace crow
                             to_read = remaining_length_;
                         adaptor_.socket().async_read_some(
                           asio::buffer(buffer_, static_cast<std::size_t>(to_read)),
-                          [this](const asio::error_code& ec, std::size_t bytes_transferred) {
+                          [this](const error_code& ec, std::size_t bytes_transferred) {
                               is_reading = false;
 
                               if (!ec)
@@ -641,7 +647,7 @@ namespace crow
                     auto watch = std::weak_ptr<void>{anchor_};
                     asio::async_write(
                       adaptor_.socket(), buffers,
-                      [&, watch](const asio::error_code& ec, std::size_t /*bytes_transferred*/) {
+                      [&, watch](const error_code& ec, std::size_t /*bytes_transferred*/) {
                           if (!ec && !close_connection_)
                           {
                               sending_buffers_.clear();

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -19,6 +19,13 @@
 using namespace std;
 using namespace crow;
 
+#ifdef CROW_USE_BOOST
+namespace asio = boost::asio;
+using asio_error_code = boost::system::error_code;
+#else
+using asio_error_code = asio::error_code;
+#endif
+
 #define LOCALHOST_ADDRESS "127.0.0.1"
 
 TEST_CASE("Rule")
@@ -2925,7 +2932,7 @@ TEST_CASE("websocket_max_payload")
         }
     }
 
-    asio::error_code ec;
+    asio_error_code ec;
     c.lowest_layer().shutdown(asio::socket_base::shutdown_type::shutdown_both, ec);
 
     app.stop();
@@ -3510,7 +3517,7 @@ TEST_CASE("timeout")
               asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451));
 
             auto receive_future = async(launch::async, [&]() {
-                asio::error_code ec;
+                asio_error_code ec;
                 c.receive(asio::buffer(buf, 2048), 0, ec);
                 return ec;
             });
@@ -3530,7 +3537,7 @@ TEST_CASE("timeout")
 
             size_t received;
             auto receive_future = async(launch::async, [&]() {
-                asio::error_code ec;
+                asio_error_code ec;
                 received = c.receive(asio::buffer(buf, 2048), 0, ec);
                 return ec;
             });


### PR DESCRIPTION
Closes #490

Add a cmake option CROW_USE_BOOST to link to Boost.Asio instead of standalone ASIO.