### PR TITLE
Add HTTP status 406

### DIFF
--- a/docs/guides/routes.md
+++ b/docs/guides/routes.md
@@ -125,6 +125,7 @@ Crow defines the following status codes:
 403 Forbidden
 404 Not Found
 405 Method Not Allowed
+406 Not Acceptable
 407 Proxy Authentication Required
 409 Conflict
 410 Gone

--- a/include/crow/common.h
+++ b/include/crow/common.h
@@ -190,6 +190,7 @@ namespace crow
         FORBIDDEN                     = 403,
         NOT_FOUND                     = 404,
         METHOD_NOT_ALLOWED            = 405,
+        NOT_ACCEPTABLE                = 406,
         PROXY_AUTHENTICATION_REQUIRED = 407,
         CONFLICT                      = 409,
         GONE                          = 410,

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -312,6 +312,7 @@ namespace crow
               {status::FORBIDDEN, "HTTP/1.1 403 Forbidden\r\n"},
               {status::NOT_FOUND, "HTTP/1.1 404 Not Found\r\n"},
               {status::METHOD_NOT_ALLOWED, "HTTP/1.1 405 Method Not Allowed\r\n"},
+              {status::NOT_ACCEPTABLE, "HTTP/1.1 406 Not Acceptable\r\n"},
               {status::PROXY_AUTHENTICATION_REQUIRED, "HTTP/1.1 407 Proxy Authentication Required\r\n"},
               {status::CONFLICT, "HTTP/1.1 409 Conflict\r\n"},
               {status::GONE, "HTTP/1.1 410 Gone\r\n"},


### PR DESCRIPTION
found the 406 status code to be missing in the supported return codes (as it was overwritten by the framework when trying to implement basic content negotiation in an application), this adds the status code.

references:
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406
* https://www.rfc-editor.org/rfc/rfc9110#status.406