### PR TITLE
Get rid of unnecessary string copies in the the keys() method

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ enable_testing()
 
 set(TEST_SRCS
   unittest.cpp
+  query_string_tests.cpp
 )
 
 add_executable(unittest ${TEST_SRCS})

--- a/tests/query_string_tests.cpp
+++ b/tests/query_string_tests.cpp
@@ -1,0 +1,45 @@
+
+#include <iostream>
+#include <vector>
+
+#include "catch.hpp"
+#include "crow/query_string.h"
+
+namespace
+{
+    std::string buildQueryStr(const std::vector<std::pair<std::string, std::string>>& paramList)
+    {
+        std::string paramsStr{};
+        for (const auto& param : paramList)
+            paramsStr.append(param.first).append(1, '=').append(param.second).append(1, '&');
+        if (!paramsStr.empty())
+            paramsStr.resize(paramsStr.size() - 1);
+        return paramsStr;
+    }
+}
+
+TEST_CASE( "empty query params" )
+{
+    const crow::query_string query_params("");
+    const std::vector<std::string> keys = query_params.keys();
+
+    REQUIRE(keys.empty() == true);
+}
+
+TEST_CASE( "query string keys" )
+{
+    const std::vector<std::pair<std::string, std::string>> params {
+      {"foo", "bar"}, {"mode", "night"}, {"page", "2"},
+      {"tag", "js"}, {"name", "John Smith"}, {"age", "25"},
+    };
+
+    const crow::query_string query_params("params?" + buildQueryStr(params));
+    const std::vector<std::string> keys = query_params.keys();
+
+    for (const auto& entry: params)
+    {
+        const bool exist = std::any_of(keys.cbegin(), keys.cend(), [&](const std::string& key) {
+            return key == entry.first;});
+        REQUIRE(exist == true);
+    }
+}


### PR DESCRIPTION
Two small performance fixes for query_string class methods:

1. `std::vector<std::string> keys()`
   Removed unnecessary string copies in the the keys() method
   according to the results of benchmarks, the **performance of the method increased by 3x+ times**

2. Constructor: `query_string(std::string params, bool url = true)`
   Added deallocation of excessive allocated memory
   `vector<T>::resize()` - keeps vector capacity

3. Couple of unit-tests has been added