### PR TITLE
Add unix domain socket support

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -93,6 +93,10 @@ add_executable(example_file_upload example_file_upload.cpp)
 add_warnings_optimizations(example_file_upload)
 target_link_libraries(example_file_upload PUBLIC Crow::Crow)
 
+add_executable(example_unix_socket example_unix_socket.cpp)
+add_warnings_optimizations(example_unix_socket)
+target_link_libraries(example_unix_socket PUBLIC Crow::Crow)
+
 if(MSVC)
   add_executable(example_vs example_vs.cpp)
   add_warnings_optimizations(example_vs)

--- a/examples/example_unix_socket.cpp
+++ b/examples/example_unix_socket.cpp
@@ -1,11 +1,6 @@
 #include "crow.h"
 
-#ifdef WIN32
-#include <fileapi.h>
-#else
-#include <unistd.h>
 #include <sys/stat.h>
-#endif
 
 int main()
 {
@@ -17,11 +12,7 @@ int main()
     });
 
     std::string unix_path = "example.sock";
-#ifdef WIN32
-    DeleteFileA(unix_path.c_str());
-#else
     unlink(unix_path.c_str());
-#endif
     app.unix_path(unix_path).run();
 
 }

--- a/examples/example_unix_socket.cpp
+++ b/examples/example_unix_socket.cpp
@@ -1,0 +1,27 @@
+#include "crow.h"
+
+#ifdef WIN32
+#include <fileapi.h>
+#else
+#include <unistd.h>
+#include <sys/stat.h>
+#endif
+
+int main()
+{
+    crow::SimpleApp app;
+
+    CROW_ROUTE(app, "/")
+    ([]() {
+        return "Hello, world!";
+    });
+
+    std::string unix_path = "example.sock";
+#ifdef WIN32
+    DeleteFileA(unix_path.c_str());
+#else
+    unlink(unix_path.c_str());
+#endif
+    app.unix_path(unix_path).run();
+
+}

--- a/include/crow.h
+++ b/include/crow.h
@@ -5,6 +5,7 @@
 #include "crow/TinySHA1.hpp"
 #include "crow/settings.h"
 #include "crow/socket_adaptors.h"
+#include "crow/socket_acceptors.h"
 #include "crow/json.h"
 #include "crow/mustache.h"
 #include "crow/logging.h"

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -134,7 +134,7 @@ namespace crow
             req_.middleware_container = static_cast<void*>(middlewares_);
             req_.io_service = &adaptor_.get_io_service();
             
-            req_.remote_ip_address = adaptor_.remote_endpoint().address().to_string();
+            req_.remote_ip_address = adaptor_.address();
 
             add_keep_alive_ = req_.keep_alive;
             close_connection_ = req_.close_connection;

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -22,21 +22,20 @@
 namespace crow
 {
     using tcp = asio::ip::tcp;
+    using stream_protocol = asio::local::stream_protocol;
 
-    template<typename Handler, typename Adaptor = SocketAdaptor, typename... Middlewares>
+    template<typename Handler, typename Acceptor = TCPAcceptor, typename Adaptor = SocketAdaptor, typename... Middlewares>
     class Server
     {
     public:
-        Server(Handler* handler, std::string bindaddr, uint16_t port, std::string server_name = std::string("Crow/") + VERSION, std::tuple<Middlewares...>* middlewares = nullptr, uint16_t concurrency = 1, uint8_t timeout = 5, typename Adaptor::context* adaptor_ctx = nullptr):
-          acceptor_(io_service_, tcp::endpoint(asio::ip::address::from_string(bindaddr), port)),
+        Server(Handler* handler, typename Acceptor::endpoint endpoint, std::string server_name = std::string("Crow/") + VERSION, std::tuple<Middlewares...>* middlewares = nullptr, uint16_t concurrency = 1, uint8_t timeout = 5, typename Adaptor::context* adaptor_ctx = nullptr):
+          acceptor_(io_service_, endpoint),
           signals_(io_service_),
           tick_timer_(io_service_),
           handler_(handler),
           concurrency_(concurrency),
           timeout_(timeout),
           server_name_(server_name),
-          port_(port),
-          bindaddr_(bindaddr),
           task_queue_length_pool_(concurrency_ - 1),
           middlewares_(middlewares),
           adaptor_ctx_(adaptor_ctx)
@@ -135,11 +134,10 @@ namespace crow
                   });
             }
 
-            port_ = acceptor_.local_endpoint().port();
+            port_ = acceptor_.port();
             handler_->port(port_);
 
-
-            CROW_LOG_INFO << server_name_ << " server is running at " << (handler_->ssl_used() ? "https://" : "http://") << bindaddr_ << ":" << acceptor_.local_endpoint().port() << " using " << concurrency_ << " threads";
+            CROW_LOG_INFO << server_name_ << " server is running at " << acceptor_.url_display(handler_->ssl_used()) << " using " << concurrency_ << " threads";
             CROW_LOG_INFO << "Call `app.loglevel(crow::LogLevel::Warning)` to hide Info level logs.";
 
             signals_.async_wait(
@@ -225,7 +223,7 @@ namespace crow
                   is, handler_, server_name_, middlewares_,
                   get_cached_date_str_pool_[service_idx], *task_timer_pool_[service_idx], adaptor_ctx_, task_queue_length_pool_[service_idx]);
 
-                acceptor_.async_accept(
+                acceptor_.raw_acceptor().async_accept(
                   p->socket(),
                   [this, p, &is, service_idx](asio::error_code ec) {
                       if (!ec)
@@ -258,7 +256,7 @@ namespace crow
         asio::io_service io_service_;
         std::vector<detail::task_timer*> task_timer_pool_;
         std::vector<std::function<std::string()>> get_cached_date_str_pool_;
-        tcp::acceptor acceptor_;
+        Acceptor acceptor_;
         bool shutting_down_ = false;
         bool server_started_{false};
         std::condition_variable cv_started_;
@@ -273,6 +271,7 @@ namespace crow
         std::string server_name_;
         uint16_t port_;
         std::string bindaddr_;
+        bool use_unix_;
         std::vector<std::atomic<unsigned int>> task_queue_length_pool_;
 
         std::chrono::milliseconds tick_interval_;

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -1670,7 +1670,7 @@ namespace crow
                 }
                 else
                 {
-#if defined(__APPLE__) || defined(__MACH__) || defined(__FreeBSD__) || defined(__ANDROID__)
+#if defined(__APPLE__) || defined(__MACH__) || defined(__FreeBSD__) || defined(__ANDROID__) || defined(_LIBCPP_VERSION)
                     o = std::unique_ptr<object>(new object(initializer_list));
 #else
                     (*o) = initializer_list;
@@ -1689,7 +1689,7 @@ namespace crow
                 }
                 else
                 {
-#if defined(__APPLE__) || defined(__MACH__) || defined(__FreeBSD__) || defined(__ANDROID__)
+#if defined(__APPLE__) || defined(__MACH__) || defined(__FreeBSD__) || defined(__ANDROID__) || defined(_LIBCPP_VERSION)
                     o = std::unique_ptr<object>(new object(value));
 #else
                     (*o) = value;

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -118,6 +118,11 @@ namespace crow
             res = response(404);
             res.end();
         }
+        virtual void handle_upgrade(const request&, response& res, UnixSocketAdaptor&&)
+        {
+            res = response(404);
+            res.end();
+        }
 #ifdef CROW_ENABLE_SSL
         virtual void handle_upgrade(const request&, response& res, SSLAdaptor&&)
         {

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -468,6 +468,11 @@ namespace crow
             max_payload_ = max_payload_override_ ? max_payload_ : app_->websocket_max_payload();
             new crow::websocket::Connection<SocketAdaptor, App>(req, std::move(adaptor), app_, max_payload_, open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_);
         }
+        void handle_upgrade(const request& req, response&, UnixSocketAdaptor&& adaptor) override
+        {
+            max_payload_ = max_payload_override_ ? max_payload_ : app_->websocket_max_payload();
+            new crow::websocket::Connection<UnixSocketAdaptor, App>(req, std::move(adaptor), app_, max_payload_, open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_);
+        }
 #ifdef CROW_ENABLE_SSL
         void handle_upgrade(const request& req, response&, SSLAdaptor&& adaptor) override
         {

--- a/include/crow/socket_acceptors.h
+++ b/include/crow/socket_acceptors.h
@@ -1,0 +1,53 @@
+#pragma once
+#ifndef ASIO_STANDALONE
+#define ASIO_STANDALONE
+#endif
+#include <asio.hpp>
+
+namespace crow
+{
+    using tcp = asio::ip::tcp;
+    using stream_protocol = asio::local::stream_protocol;
+
+    struct TCPAcceptor
+    {
+        using endpoint = tcp::endpoint;
+        tcp::acceptor acceptor_;
+        TCPAcceptor(asio::io_service& io_service, const endpoint& endpoint):
+          acceptor_(io_service, endpoint) {}
+
+        int16_t port() const
+        {
+            return acceptor_.local_endpoint().port();
+        }
+        std::string url_display(bool ssl_used) const
+        {
+            return (ssl_used ? "https://" : "http://") + acceptor_.local_endpoint().address().to_string() + ":" + std::to_string(acceptor_.local_endpoint().port());
+        }
+        tcp::acceptor& raw_acceptor()
+        {
+            return acceptor_;
+        }
+    };
+
+    struct UnixSocketAcceptor
+    {
+        using endpoint = stream_protocol::endpoint;
+        stream_protocol::acceptor acceptor_;
+        UnixSocketAcceptor(asio::io_service& io_service, const endpoint& endpoint):
+          acceptor_(io_service, endpoint) {}
+
+        int16_t port() const
+        {
+            return 0;
+        }
+        std::string url_display(bool) const
+        {
+            return acceptor_.local_endpoint().path();
+        }
+        stream_protocol::acceptor& raw_acceptor()
+        {
+            return acceptor_;
+        }
+    };
+} // namespace crow

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -218,7 +218,7 @@ namespace crow
 
             std::string get_remote_ip() override
             {
-                return adaptor_.remote_endpoint().address().to_string();
+                return adaptor_.address();
             }
 
             void set_max_payload_size(uint64_t payload)

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1464,7 +1464,8 @@ struct NullSimpleMiddleware
 TEST_CASE("middleware_simple")
 {
     App<NullMiddleware, NullSimpleMiddleware> app;
-    decltype(app)::server_t server(&app, LOCALHOST_ADDRESS, 45451);
+    TCPAcceptor::endpoint endpoint(asio::ip::address::from_string(LOCALHOST_ADDRESS), 45451);
+    decltype(app)::server_t server(&app, endpoint);
     CROW_ROUTE(app, "/")
     ([&](const crow::request& req) {
         app.get_context<NullMiddleware>(req);


### PR DESCRIPTION
I wanted to use unix domain socket since performance is important in my project, so I implemented based on ipkn/Crow#379.
Instead of duplicating App and Server classes, I created wrapper class of acceptor so the existing Server class can be used for unix socket connection.

By specifying socket path with `app.unix_path()` (instead of `app.port(port_num)`) the server will create and use that socket instead of listening a tcp socket. (I added example as example/example_unix_socket.cpp)
Although it is named unix socket, this also works on windows.

If there is any problem please let me know.
Especially I am not sure if there is a better name than `unix_path()`.
