### PR TITLE
 #839 Make `multipart::message` constructor from `request` explicit

### DIFF
--- a/include/crow/multipart.h
+++ b/include/crow/multipart.h
@@ -141,7 +141,7 @@ namespace crow
             }
 
             /// Create a multipart message from a request data
-            message(const request& req):
+            explicit message(const request& req):
               returnable("multipart/form-data; boundary=CROW-BOUNDARY"),
               headers(req.headers),
               boundary(get_boundary(get_header_value("Content-Type")))


### PR DESCRIPTION
As discussed in  #839 I've made a PR with the change.