### PR TITLE
Update GitHub actions runners to macos12

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -26,7 +26,8 @@ jobs:
               windows-latest,
               macos-latest,
               ubuntu-20.04,
-              macos-11
+              ubuntu-24.04,
+              macos-13
             ]
             # ubuntu-18.04 does not work due to compile error on asio
             # windows-2019 not included to spare free minutes   


### PR DESCRIPTION
Removed macos11 runner and replaced by macos13, also added ubuntu24.04 runner