### PR TITLE
Make Crow::port getter const

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -312,7 +312,7 @@ namespace crow
         }
 
         /// \brief Get the port that Crow will handle requests on
-        std::uint16_t port()
+        std::uint16_t port() const
         {
             return port_;
         }


### PR DESCRIPTION
According to the C++ Core Guidelines, all methods should be `const` where possible

https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#con2-by-default-make-member-functions-const