### PR TITLE
Improve Middleware documentation and compile time static assertions

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -708,6 +708,8 @@ namespace crow
         template<typename... Ts>
         std::tuple<Middlewares...> make_middleware_tuple(Ts&&... ts)
         {
+            static_assert(black_magic::type_pack<Middlewares...>::template is_superset_of<Ts...>::value, "Constructor argument types must be a subset of the Crow template types");
+
             auto fwd = std::forward_as_tuple((ts)...);
             return std::make_tuple(
               std::forward<Middlewares>(

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -453,6 +453,19 @@ namespace crow
         struct contains<Tp> : std::false_type
         {};
 
+        template<typename Tp, typename... List>
+        struct contains_decayed : std::true_type
+        {};
+
+        template<typename Tp, typename Head, typename... Rest>
+        struct contains_decayed<Tp, Head, Rest...> :
+            std::conditional<std::is_same<typename std::decay<Tp>::type, typename std::decay<Head>::type>::value, std::true_type, contains_decayed<Tp, Rest...>>::type
+        {};
+
+        template<typename Tp>
+        struct contains_decayed<Tp> : std::false_type
+        {};
+
         template<typename T>
         struct empty_context
         {};

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -466,6 +466,19 @@ namespace crow
         struct contains_decayed<Tp> : std::false_type
         {};
 
+        template<typename... Tsuper>
+        struct type_pack
+        {
+            template<typename... Tsub>
+            struct is_superset_of : std::true_type
+            {};
+
+            template<typename T, typename... Tsub>
+            struct is_superset_of<T, Tsub...> :
+                std::conditional<contains_decayed<T, Tsuper...>::value, is_superset_of<Tsub...>, std::false_type>::type
+            {};
+        };
+
         template<typename T>
         struct empty_context
         {};


### PR DESCRIPTION
Closes #861

Currently there is some ambiguity in the documentation surrounding middlewares:

- `CROW_MIDDLEWARES`: In the [reference docs](https://crowcpp.org/master/reference/app_8h.html#a12ac01cb1979c953ac1c1203114c5e0e) the example uses `crow::SimpleApp`, yet the [example in Crow/examples](https://github.com/CrowCpp/Crow/blob/master/examples/example_middleware.cpp) states `// ALL middleware (including per handler) is listed` and the [guide](https://crowcpp.org/master/guides/middleware/#local-middleware) doesn't mention this at all:

  ```c++
  auto app = [crow::SimpleApp](https://crowcpp.org/master/reference/namespacecrow.html#a3603179c9794548cac2c9990685178b4)(); // or crow::App()
  [CROW_ROUTE](https://crowcpp.org/master/reference/app_8h.html#a6aa7ec3a2f3ee3f17d5f9acd879e7381)(app, "/with_middleware")
  .CROW_MIDDLEWARES(app, LocalMiddleware) // Can be used more than one
  ([]() {                                 // middleware.
      return "Hello world!";
  });
  ```

  ```c++
  // ALL middleware (including per handler) is listed
  crow::App<RequestLogger, SecretContentGuard, RequestAppend> app;
  ...
  CROW_ROUTE(app, "/secret")
      // Enable SecretContentGuard for this handler
      .CROW_MIDDLEWARES(app, SecretContentGuard)([]() {
          return "";
      });
  ```

  It needs to be clarified, does `CROW_MIDDLEWARES` require the specified middleware be also specified in the referenced app template arguments?

- The [reference docs](https://crowcpp.org/master/reference/classcrow_1_1_crow.html) mention the Crow constructor `Construct Crow with a subset of middleware.`, yet this is not explained in the Guide, and there's no example of the usage in the examples.

  The guide should include a section on configuring middlewares, which should include both with the constructor and with `app.get_middleware<>`.

  The examples should include an example on using the app constructor.

Also, we can reduce the confusion by implementing compile time static assertions:

- When passing a middleware to the app constructor, it should be validated that the type of that middleware is within the middlewares defined in the app class template types.
- When passing a middleware to `CROW_MIDDLEWARES`, it should be validated that the type of that middleware is within the middlewares defined in the app class template types.


## TODO:

- [ ] Guide: Local middleware need to be defined in the app middlewares.
- [ ] Reference docs: `CROW_MIDDLEWARES` comment and example.
- [ ] Guide: Middlewares configuration using app constructor and using `app.get_middleware<>`.
- [ ] Ecamples: Middleware configuration using app constructor.
- [ ] Validate middlewares passed to the app constructor.
- [x] Validate middlewares passed to `CROW_MIDDLEWARES`.

As of writing, the PR includes an implementation that validates middlewares passed to the app constructor, however, the current implementation uses `std::decay` when comparing types. This needs to be discussed. It also needs more testing for edge cases IMO. Also, I'd like to do the same for `CROW_MIDDLEWARES` but I don't know where to do so, a suggestion would be appreciated.