### PR TITLE
Enable suggest-override warning and fix instances

### DIFF
--- a/cmake/compiler_options.cmake
+++ b/cmake/compiler_options.cmake
@@ -19,6 +19,7 @@ function(add_warnings_optimizations target_name)
         -Wall
         -Wextra
         -Wpedantic
+        -Wsuggest-override
         $<$<CONFIG:RELEASE>:-O2>
         $<$<CONFIG:DEBUG>:-O0 -g>
     )
@@ -29,6 +30,7 @@ function(add_warnings_optimizations target_name)
         -Wall
         -Wextra
         -Wpedantic
+        -Wsuggest-override
         $<$<CONFIG:RELEASE>:-O2>
         $<$<CONFIG:DEBUG>:-O0 -g -pg>
     )
@@ -38,6 +40,7 @@ function(add_warnings_optimizations target_name)
         -Wall
         -Wextra
         -Wpedantic
+        -Wsuggest-override
         $<$<CONFIG:RELEASE>:-O2>
         $<$<CONFIG:DEBUG>:-O0 -g -p -pg>
     )

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -2033,7 +2033,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                 return ret;
             }
 
-            std::string dump() const
+            std::string dump() const override
             {
                 static constexpr int DontIndent = -1;
 

--- a/include/crow/mustache.h
+++ b/include/crow/mustache.h
@@ -54,7 +54,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
             invalid_template_exception(const std::string& msg):
               msg("crow::mustache error: " + msg)
             {}
-            virtual const char* what() const throw()
+            virtual const char* what() const throw() override
             {
                 return msg.c_str();
             }


### PR DESCRIPTION
How would we feel about making this and error?
I made it just a warning and fixed the 2 places where it could be marked as `override`.

Unfortunately `Wpedantic` is not as pedantic as i would hope so there are more flags to consider :) 

(Mostly because the downstream project im working in requires more strict flags)