### PR TITLE
Add compilation with libc++ and libstdc++ in CI (#785)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,6 +1,5 @@
 name: Build and test
 
-#on: push
 on:
   push:
     branches: [ "master" ]
@@ -8,10 +7,8 @@ on:
     branches: [ "master" ]
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
   COVERALLS_PULL_REQUEST: ${{ github.event.number }}
-  #COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
 jobs:
   build:
@@ -30,17 +27,18 @@ jobs:
               macos-13
             ]
             # ubuntu-18.04 does not work due to compile error on asio
-            # windows-2019 not included to spare free minutes   
+            # windows-2019 not included to spare free minutes
     steps:
     - uses: actions/checkout@v4
     - name: Prepare dependencies
-      run:   |
+      run: |
          if [ "$RUNNER_OS" == "Linux" ]; then
               sudo apt-get update && \
               sudo apt-get install -yq \
                 libasio-dev \
                 libssl-dev zlib1g-dev \
-                cmake
+                cmake \
+                g++ clang
          elif [ "$RUNNER_OS" == "Windows" ]; then
               VCPKG_DEFAULT_TRIPLET=x64-windows vcpkg install
          elif [ "$RUNNER_OS" == "macOS" ]; then
@@ -53,31 +51,33 @@ jobs:
 
     - name: Configure CMake
       run: |
+         cmake_flags=""
          if [ "$RUNNER_OS" == "Windows" ]; then
-              cmake \
-                -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake  \
-                -DCROW_ENABLE_SSL=ON \
-                -DCROW_ENABLE_COMPRESSION=ON \
-                -DCROW_AMALGAMATE=ON \
-                -DCROW_BUILD_TESTS=ON \
-                -B build
-          elif [ "$RUNNER_OS" == "macOS" ]; then
-              LDFLAGS="-L/usr/local/opt/openssl@1.1/lib" \
-              CPPFLAGS="-I/usr/local/opt/openssl@1.1/include" \
-              cmake \
-                -DCROW_ENABLE_SSL=ON \
-                -DCROW_ENABLE_COMPRESSION=ON \
-                -DCROW_AMALGAMATE=ON \
-                -DCROW_BUILD_TESTS=ON \
-                -B build
-         else
-              cmake \
-                -DCROW_ENABLE_SSL=ON \
-                -DCROW_ENABLE_COMPRESSION=ON \
-                -DCROW_AMALGAMATE=ON \
-                -DCROW_BUILD_TESTS=ON \
-                -B build
-          fi
+              cmake_flags="-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
+         elif [ "$RUNNER_OS" == "macOS" ]; then
+              export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
+              export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
+              if [ "${{ matrix.compiler }}" == "clang" ] && [ "${{ matrix.cxx_stdlib }}" == "libc++" ]; then
+                  cmake_flags="-DCMAKE_CXX_FLAGS='-stdlib=libc++'"
+              fi
+         elif [ "$RUNNER_OS" == "Linux" ]; then
+              if [ "${{ matrix.compiler }}" == "clang" ] && [ "${{ matrix.cxx_stdlib }}" == "libc++" ]; then
+                  cmake_flags="-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS='-stdlib=libc++'"
+                  sudo apt-get install libc++-dev libc++abi-dev -y
+              elif [ "${{ matrix.compiler }}" == "clang" ]; then
+                  cmake_flags="-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS='-stdlib=libstdc++'"
+              else
+                  cmake_flags="-DCMAKE_CXX_COMPILER=g++"
+              fi
+         fi
+
+         cmake \
+            ${cmake_flags} \
+            -DCROW_ENABLE_SSL=ON \
+            -DCROW_ENABLE_COMPRESSION=ON \
+            -DCROW_AMALGAMATE=ON \
+            -DCROW_BUILD_TESTS=ON \
+            -B build
       shell: bash
 
     - name: Build
@@ -90,12 +90,13 @@ jobs:
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest --output-on-failure -C ${{env.BUILD_TYPE}}
+      shell: bash
 
     - name: Generate coverage report
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc' && matrix.cxx_stdlib == 'libstdc++'
       run: |
         export CI_BRANCH=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
-          echo "CI_BRANCH=$CI_BRANCH" >> $GITHUB_ENV && \
+        echo "CI_BRANCH=$CI_BRANCH" >> $GITHUB_ENV && \
         export TRAVIS_JOB_ID=$GITHUB_RUN_NUMBER && \
         git clone https://github.com/CrowCpp/cpp-coveralls.git && \
         cd cpp-coveralls && \
@@ -104,10 +105,9 @@ jobs:
         coveralls --verbose --exclude-pattern .*/http_parser_merged.h --exclude-pattern .*/TinySHA1.hpp --dump coveralls.json
       shell: bash
 
-
     - name: Save report
       uses: actions/upload-artifact@v4
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc' && matrix.cxx_stdlib == 'libstdc++'
       with:
         name: coveralls.json
         path: coveralls.json
@@ -115,8 +115,8 @@ jobs:
 
     #- name: Package
     #  working-directory: ${{github.workspace}}/build
-    #  run: | 
-    #    cmake --build . --target ALL_BUILD && \ 
+    #  run: |
+    #    cmake --build . --target ALL_BUILD && \
     #    cmake --build . --target doc && \
-    #    cmake --build . --target package && \ 
+    #    cmake --build . --target package && \
     #    cpack --config CPackSourceConfig.cmake


### PR DESCRIPTION
As outlined by #785, using both libc++ and libstdc++ and both clang and gcc will allow catching some more errors.
In this pull request I performed the follwoing refactoring of the action:
- Updated GitHub Actions workflow to include a build matrix for both gcc and clang compilers.
- Added support for compiling with both libstdc++ and libc++ on Linux and macOS.

In addition to these changes I took the opportunity to also remove some stale comments and trailing spaces in the file.
