### PR TITLE
Add define to set significant digits when writing json floats and dou…

### DIFF
--- a/docs/guides/json.md
+++ b/docs/guides/json.md
@@ -35,6 +35,7 @@ A `wvalue` can be treated as an object or even a list (setting a value by using 
 
     JSON does not allow floating point values like `NaN` or `INF`, Crow will output `null` instead of `NaN` or `INF` when converting `wvalue` to a string. (`{"Key": NaN}` becomes `{"Key": null}`)
 
+To serialize `#!cpp float` and `#!cpp double` with a given number of significant digits, say 6 (the default), use the macros `#!cpp #define CROW_JSON_FLOAT_PRECISION 6` and `#!cpp #define CROW_JSON_DOUBLE_PRECISION 6`.
 <br><br>
 
 Additionally, a `wvalue` can be initialized as an object using an initializer list, an example object would be `wvalue x = {{"a", 1}, {"b", 2}}`. Or as a list using `wvalue x = json::wvalue::list({1, 2, 3})`, lists can include any type that `wvalue` supports.<br><br>

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -2,6 +2,15 @@
 
 //#define CROW_JSON_NO_ERROR_CHECK
 //#define CROW_JSON_USE_MAP
+//#define CROW_JSON_FLOAT_PRECISION FLT_DIG
+//#define CROW_JSON_DOUBLE_PRECISION DBL_DIG
+
+#ifndef CROW_JSON_FLOAT_PRECISION
+#define CROW_JSON_FLOAT_PRECISION 6
+#endif
+#ifndef CROW_JSON_DOUBLE_PRECISION
+#define CROW_JSON_DOUBLE_PRECISION 6
+#endif
 
 #include <string>
 #ifdef CROW_JSON_USE_MAP
@@ -1874,17 +1883,17 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                             if (v.nt == num_type::Double_precision_floating_point)
                             {
 #ifdef _MSC_VER
-                                sprintf_s(outbuf, sizeof(outbuf), "%.*g", DECIMAL_DIG, v.num.d);
+                                sprintf_s(outbuf, sizeof(outbuf), "%.*g", CROW_JSON_DOUBLE_PRECISION, v.num.d);
 #else
-                                snprintf(outbuf, sizeof(outbuf), "%.*g", DECIMAL_DIG, v.num.d);
+                                snprintf(outbuf, sizeof(outbuf), "%.*g", CROW_JSON_DOUBLE_PRECISION, v.num.d);
 #endif
                             }
                             else
                             {
 #ifdef _MSC_VER
-                                sprintf_s(outbuf, sizeof(outbuf), "%f", v.num.d);
+                                sprintf_s(outbuf, sizeof(outbuf), "%.*g", CROW_JSON_FLOAT_PRECISION, v.num.d);
 #else
-                                snprintf(outbuf, sizeof(outbuf), "%f", v.num.d);
+                                snprintf(outbuf, sizeof(outbuf), "%.*g", CROW_JSON_FLOAT_PRECISION, v.num.d);
 #endif
                             }
                             char *p = &outbuf[0], *o = nullptr; // o is the position of the first trailing 0

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1124,22 +1124,38 @@ TEST_CASE("json::wvalue::wvalue(std::int64_t)")
 
 TEST_CASE("json::wvalue::wvalue(float)")
 {
-    float f = 4.2;
-    json::wvalue value = f;
+    {
+        float f = 3.14159265359;
+        json::wvalue value = f;
 
-    CHECK(value.t() == json::type::Number);
-    CHECK(value.dump() == "4.2");
+        CHECK(value.t() == json::type::Number);
+        CHECK(value.dump() == "3.14159");
+    }
+    {
+        float f = 314159265.359;
+        json::wvalue value = f;
+
+        CHECK(value.t() == json::type::Number);
+        CHECK(value.dump() == "3.14159e+08");
+    }
 } // json::wvalue::wvalue(float)
 
 TEST_CASE("json::wvalue::wvalue(double)")
 {
-    double d = 0.036303908355795146;
-    json::wvalue value = d;
+    {
+        double d = 0.036303908355795146;
+        json::wvalue value = d;
 
-    CHECK(value.t() == json::type::Number);
-    auto dumped_value = value.dump();
-    CROW_LOG_DEBUG << dumped_value;
-    CHECK(std::abs(utility::lexical_cast<double>(dumped_value) - d) < numeric_limits<double>::epsilon());
+        CHECK(value.t() == json::type::Number);
+        CHECK(value.dump() == "0.0363039");
+    }
+    {
+        double d = 36303908355795.146;
+        json::wvalue value = d;
+
+        CHECK(value.t() == json::type::Number);
+        CHECK(value.dump() == "3.63039e+13");
+    }
 } // json::wvalue::wvalue(double)
 
 TEST_CASE("json::wvalue::wvalue(char const*)")


### PR DESCRIPTION
Add define to set significant digits when writing json floats and doubles

## Usecase

### Issue
I use snapshot testing to compare the JSON output of my service to an expected JSON output file. At the moment a slight change in the computations of the service causes the last decimals of floating-point numbers to change, the diffs then have to be manually validated which is time-consuming. The output is also not very readable because there are way too many decimals.

### Solution
This commit allows users of Crow to choose the number of significant digits they want in serialized floating-points. This enables more readable output and more robust JSON diffs. 6 significant digits seems like a reasonable default.

### Example
#### Before
```json
      "max": {
        "real": 0.0416054263979028227105,
        "imag": 0.0311738103389676488031
      },
      "min": {
        "real": 0.0301375840886710585909,
        "imag": 0.030686107921196179027
      }
```

#### After
```json
      "max": {
        "real": 0.0416054,
        "imag": 0.0311738
      },
      "min": {
        "real": 0.0301376,
        "imag": 0.0306861
      }
```