### PR TITLE
Return correct port if dynamic port allocation is used

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -314,7 +314,20 @@ namespace crow
         /// \brief Get the port that Crow will handle requests on
         std::uint16_t port() const
         {
-            return port_;
+            if (!server_started_)
+            {
+                return port_;
+            }
+#ifdef CROW_ENABLE_SSL
+            if (ssl_used_)
+            {
+                return ssl_server_->port();
+            }
+            else
+#endif
+            {
+                return server_->port();
+            }
         }
 
         /// \brief Set the connection timeout in seconds (default is 5)

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -192,6 +192,10 @@ namespace crow // NOTE: Already documented in "crow/app.h"
             io_service_.stop(); // Close main io_service
         }
 
+        uint16_t port(){
+            return acceptor_.local_endpoint().port();
+        }
+
         /// Wait until the server has properly started
         void wait_for_start()
         {

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -594,6 +594,24 @@ TEST_CASE("server_handling_error_request")
     app.stop();
 } // server_handling_error_request
 
+TEST_CASE("server_dynamic_port_allication")
+{
+    SimpleApp app;
+    CROW_ROUTE(app, "/")
+    ([] {
+        return "A";
+    });
+    auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(0).run_async();
+    app.wait_for_server_start();
+    asio::io_service is;
+    {
+        asio::ip::tcp::socket c(is);
+        c.connect(asio::ip::tcp::endpoint(
+          asio::ip::address::from_string(LOCALHOST_ADDRESS), app.port()));
+    }
+    app.stop();
+} // server_dynamic_port_allication
+
 TEST_CASE("server_handling_error_request_http_version")
 {
     static char buf[2048];


### PR DESCRIPTION
Crow allows binding to port 0. If this is used port() should return the port given by the operating system and not 0.