### PR TITLE
Enable -Wshadow warnings

### DIFF
--- a/cmake/compiler_options.cmake
+++ b/cmake/compiler_options.cmake
@@ -20,6 +20,7 @@ function(add_warnings_optimizations target_name)
         -Wextra
         -Wpedantic
         -Wsuggest-override
+        -Wshadow
         $<$<CONFIG:RELEASE>:-O2>
         $<$<CONFIG:DEBUG>:-O0 -g>
     )
@@ -31,6 +32,7 @@ function(add_warnings_optimizations target_name)
         -Wextra
         -Wpedantic
         -Wsuggest-override
+        -Wshadow
         $<$<CONFIG:RELEASE>:-O2>
         $<$<CONFIG:DEBUG>:-O0 -g -pg>
     )
@@ -41,6 +43,7 @@ function(add_warnings_optimizations target_name)
         -Wextra
         -Wpedantic
         -Wsuggest-override
+        -Wshadow
         $<$<CONFIG:RELEASE>:-O2>
         $<$<CONFIG:DEBUG>:-O0 -g -p -pg>
     )

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -44,7 +44,7 @@ namespace crow
 
     /// An HTTP connection.
     template<typename Adaptor, typename Handler, typename... Middlewares>
-    class Connection: public std::enable_shared_from_this<Connection<Adaptor, Handler, Middlewares...>>
+    class Connection : public std::enable_shared_from_this<Connection<Adaptor, Handler, Middlewares...>>
     {
         friend struct crow::response;
 
@@ -455,12 +455,12 @@ namespace crow
                 if (res.body.length() > 0)
                 {
                     std::vector<asio::const_buffer> buffers{1};
-                    const uint8_t *data = reinterpret_cast<const uint8_t*>(res.body.data());
+                    const uint8_t* data = reinterpret_cast<const uint8_t*>(res.body.data());
                     size_t length = res.body.length();
-                    for(size_t transferred = 0; transferred < length;)
+                    for (size_t transferred = 0; transferred < length;)
                     {
-                        size_t to_transfer = CROW_MIN(16384UL, length-transferred);
-                        buffers[0] = asio::const_buffer(data+transferred, to_transfer);
+                        size_t to_transfer = CROW_MIN(16384UL, length - transferred);
+                        buffers[0] = asio::const_buffer(data + transferred, to_transfer);
                         do_write_sync(buffers);
                         transferred += to_transfer;
                     }

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -194,7 +194,6 @@ namespace crow
 
                 if (!res.completed_)
                 {
-                    auto self = this->shared_from_this();
                     res.complete_request_handler_ = [self] {
                         self->complete_request();
                     };

--- a/include/crow/http_request.h
+++ b/include/crow/http_request.h
@@ -56,8 +56,8 @@ namespace crow // NOTE: Already documented in "crow/app.h"
         {}
 
         /// Construct a request with all values assigned.
-        request(HTTPMethod method, std::string raw_url, std::string url, query_string url_params, ci_map headers, std::string body, unsigned char http_major, unsigned char http_minor, bool has_keep_alive, bool has_close_connection, bool is_upgrade):
-          method(method), raw_url(std::move(raw_url)), url(std::move(url)), url_params(std::move(url_params)), headers(std::move(headers)), body(std::move(body)), http_ver_major(http_major), http_ver_minor(http_minor), keep_alive(has_keep_alive), close_connection(has_close_connection), upgrade(is_upgrade)
+        request(HTTPMethod method_, std::string raw_url_, std::string url_, query_string url_params_, ci_map headers_, std::string body_, unsigned char http_major, unsigned char http_minor, bool has_keep_alive, bool has_close_connection, bool is_upgrade):
+          method(method_), raw_url(std::move(raw_url_)), url(std::move(url_)), url_params(std::move(url_params_)), headers(std::move(headers_)), body(std::move(body_)), http_ver_major(http_major), http_ver_minor(http_minor), keep_alive(has_keep_alive), close_connection(has_close_connection), upgrade(is_upgrade)
         {}
 
         void add_header(std::string key, std::string value)

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -118,9 +118,9 @@ namespace crow
 
         // clang-format off
         response() {}
-        explicit response(int code) : code(code) {}
-        response(std::string body) : body(std::move(body)) {}
-        response(int code, std::string body) : code(code), body(std::move(body)) {}
+        explicit response(int code_) : code(code_) {}
+        response(std::string body_) : body(std::move(body_)) {}
+        response(int code_, std::string body_) : code(code_), body(std::move(body_)) {}
         // clang-format on
         response(returnable&& value)
         {
@@ -132,14 +132,14 @@ namespace crow
             body = value.dump();
             set_header("Content-Type", value.content_type);
         }
-        response(int code, returnable& value):
-          code(code)
+        response(int code_, returnable& value):
+          code(code_)
         {
             body = value.dump();
             set_header("Content-Type", value.content_type);
         }
-        response(int code, returnable&& value):
-          code(code), body(value.dump())
+        response(int code_, returnable&& value):
+          code(code_), body(value.dump())
         {
             set_header("Content-Type", std::move(value.content_type));
         }
@@ -149,14 +149,14 @@ namespace crow
             *this = std::move(r);
         }
 
-        response(std::string contentType, std::string body):
-          body(std::move(body))
+        response(std::string contentType, std::string body_):
+          body(std::move(body_))
         {
             set_header("Content-Type", get_mime_type(contentType));
         }
 
-        response(int code, std::string contentType, std::string body):
-          code(code), body(std::move(body))
+        response(int code_, std::string contentType, std::string body_):
+          code(code_), body(std::move(body_))
         {
             set_header("Content-Type", get_mime_type(contentType));
         }

--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -11,7 +11,7 @@
 #endif
 #include <sys/stat.h>
 #if !defined(S_ISREG) && defined(S_IFMT) && defined(S_IFREG)
-#define S_ISREG(m) (((m)&S_IFMT) == S_IFREG)
+#define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
 #endif
 
 #include "crow/http_request.h"

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -1889,8 +1889,8 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                                 snprintf(outbuf, sizeof(outbuf), "%f", v.num.d);
 #endif
                             }
-                            char *p = &outbuf[0];
-                            char *pos_first_trailing_0 = nullptr;
+                            char* p = &outbuf[0];
+                            char* pos_first_trailing_0 = nullptr;
                             f_state = start;
                             while (*p != '\0')
                             {

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -52,11 +52,12 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                         if (c >= 0 && c < 0x20)
                         {
                             ret += "\\u00";
-                            auto to_hex = [](char c) {
-                                c = c & 0xf;
-                                if (c < 10)
-                                    return '0' + c;
-                                return 'a' + c - 10;
+                            // TODO
+                            auto to_hex = [](char c_) {
+                                c_ = c_ & 0xf;
+                                if (c_ < 10)
+                                    return '0' + c_;
+                                return 'a' + c_ - 10;
                             };
                             ret += to_hex(c / 16);
                             ret += to_hex(c % 16);
@@ -878,8 +879,8 @@ namespace crow // NOTE: Already documented in "crow/app.h"
             //static const char* escaped = "\"\\/\b\f\n\r\t";
             struct Parser
             {
-                Parser(char* data, size_t /*size*/):
-                  data(data)
+                Parser(char* data_, size_t /*size*/):
+                  data(data_)
                 {
                 }
 
@@ -1887,7 +1888,8 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                                 snprintf(outbuf, sizeof(outbuf), "%f", v.num.d);
 #endif
                             }
-                            char *p = &outbuf[0], *o = nullptr; // o is the position of the first trailing 0
+                            char *p = &outbuf[0];
+                            char *pos_first_trailing_0 = nullptr;
                             f_state = start;
                             while (*p != '\0')
                             {
@@ -1909,22 +1911,22 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                                         if (ch == '0')
                                         {
                                             f_state = zero;
-                                            o = p;
+                                            pos_first_trailing_0 = p;
                                         }
                                         p++;
                                         break;
                                     case zero: // if a non 0 is found (e.g. 1.00004) remove the earlier recorded 0 position and look for more trailing 0s
                                         if (ch != '0')
                                         {
-                                            o = nullptr;
+                                            pos_first_trailing_0 = nullptr;
                                             f_state = decp;
                                         }
                                         p++;
                                         break;
                                 }
                             }
-                            if (o != nullptr) // if any trailing 0s are found, terminate the string where they begin
-                                *o = '\0';
+                            if (pos_first_trailing_0 != nullptr) // if any trailing 0s are found, terminate the string where they begin
+                                *pos_first_trailing_0 = '\0';
                             out += outbuf;
                         }
                         else if (v.nt == num_type::Signed_integer)

--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -34,6 +34,14 @@ namespace crow // NOTE: Already documented in "crow/app.h"
 
     namespace json
     {
+        static inline char to_hex(char c)
+        {
+            c = c & 0xf;
+            if (c < 10)
+                return '0' + c;
+            return 'a' + c - 10;
+        };
+
         inline void escape(const std::string& str, std::string& ret)
         {
             ret.reserve(ret.size() + str.size() + str.size() / 4);
@@ -52,13 +60,6 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                         if (c >= 0 && c < 0x20)
                         {
                             ret += "\\u00";
-                            // TODO
-                            auto to_hex = [](char c_) {
-                                c_ = c_ & 0xf;
-                                if (c_ < 10)
-                                    return '0' + c_;
-                                return 'a' + c_ - 10;
-                            };
                             ret += to_hex(c / 16);
                             ret += to_hex(c % 16);
                         }

--- a/include/crow/middleware.h
+++ b/include/crow/middleware.h
@@ -286,8 +286,8 @@ namespace crow // NOTE: Already documented in "crow/app.h"
         template<>
         struct middleware_call_criteria_dynamic<false>
         {
-            middleware_call_criteria_dynamic(const std::vector<int>& indices):
-              indices(indices), slider(0) {}
+            middleware_call_criteria_dynamic(const std::vector<int>& indices_):
+              indices(indices_), slider(0) {}
 
             template<typename>
             bool enabled(int mw_index) const
@@ -308,8 +308,8 @@ namespace crow // NOTE: Already documented in "crow/app.h"
         template<>
         struct middleware_call_criteria_dynamic<true>
         {
-            middleware_call_criteria_dynamic(const std::vector<int>& indices):
-              indices(indices), slider(int(indices.size()) - 1) {}
+            middleware_call_criteria_dynamic(const std::vector<int>& indices_):
+              indices(indices_), slider(int(indices_.size()) - 1) {}
 
             template<typename>
             bool enabled(int mw_index) const

--- a/include/crow/multipart.h
+++ b/include/crow/multipart.h
@@ -127,8 +127,8 @@ namespace crow
             }
 
             /// Default constructor using default values
-            message(const ci_map& headers, const std::string& boundary, const std::vector<part>& sections):
-              returnable("multipart/form-data; boundary=CROW-BOUNDARY"), headers(headers), boundary(boundary), parts(sections)
+            message(const ci_map& headers_, const std::string& boundary_, const std::vector<part>& sections):
+              returnable("multipart/form-data; boundary=CROW-BOUNDARY"), headers(headers_), boundary(boundary_), parts(sections)
             {
                 if (!boundary.empty())
                     content_type = "multipart/form-data; boundary=" + boundary;
@@ -168,7 +168,8 @@ namespace crow
                 return std::string();
             }
 
-            void parse_body(std::string body, std::vector<part>& sections, mp_map& part_map)
+            // TODO
+            void parse_body(std::string body, std::vector<part>& sections, mp_map& part_map_ref)
             {
 
                 std::string delimiter = dd + boundary;
@@ -190,7 +191,7 @@ namespace crow
                     if (!section.empty())
                     {
                         part parsed_section(parse_section(section));
-                        part_map.emplace(
+                        part_map_ref.emplace(
                           (get_header_object(parsed_section.headers, "Content-Disposition").params.find("name")->second),
                           parsed_section);
                         sections.push_back(std::move(parsed_section));
@@ -217,17 +218,17 @@ namespace crow
                 {
                     header to_add;
 
-                    size_t found = lines.find(crlf);
-                    std::string line = lines.substr(0, found);
+                    const size_t found_crlf = lines.find(crlf);
+                    std::string line = lines.substr(0, found_crlf);
                     std::string key;
-                    lines.erase(0, found + 2);
+                    lines.erase(0, found_crlf + 2);
                     // Add the header if available
                     if (!line.empty())
                     {
-                        size_t found = line.find("; ");
-                        std::string header = line.substr(0, found);
-                        if (found != std::string::npos)
-                            line.erase(0, found + 2);
+                        const size_t found_semicolon = line.find("; ");
+                        std::string header = line.substr(0, found_semicolon);
+                        if (found_semicolon != std::string::npos)
+                            line.erase(0, found_semicolon + 2);
                         else
                             line = std::string();
 
@@ -240,10 +241,10 @@ namespace crow
                     // Add the parameters
                     while (!line.empty())
                     {
-                        size_t found = line.find("; ");
-                        std::string param = line.substr(0, found);
-                        if (found != std::string::npos)
-                            line.erase(0, found + 2);
+                        const size_t found_semicolon = line.find("; ");
+                        std::string param = line.substr(0, found_semicolon);
+                        if (found_semicolon != std::string::npos)
+                            line.erase(0, found_semicolon + 2);
                         else
                             line = std::string();
 

--- a/include/crow/multipart.h
+++ b/include/crow/multipart.h
@@ -148,7 +148,7 @@ namespace crow
             {
                 if (!boundary.empty())
                     content_type = "multipart/form-data; boundary=" + boundary;
-                parse_body(req.body, parts, part_map);
+                parse_body(req.body);
             }
 
         private:
@@ -168,10 +168,8 @@ namespace crow
                 return std::string();
             }
 
-            // TODO
-            void parse_body(std::string body, std::vector<part>& sections, mp_map& part_map_ref)
+            void parse_body(std::string body)
             {
-
                 std::string delimiter = dd + boundary;
 
                 // TODO(EDev): Exit on error
@@ -191,10 +189,10 @@ namespace crow
                     if (!section.empty())
                     {
                         part parsed_section(parse_section(section));
-                        part_map_ref.emplace(
+                        part_map.emplace(
                           (get_header_object(parsed_section.headers, "Content-Disposition").params.find("name")->second),
                           parsed_section);
-                        sections.push_back(std::move(parsed_section));
+                        parts.push_back(std::move(parsed_section));
                     }
                 }
             }

--- a/include/crow/multipart_view.h
+++ b/include/crow/multipart_view.h
@@ -62,9 +62,9 @@ namespace crow
             const char padding = '"'; ///< Padding to use
 
             /// Outputs padded value to the stream
-            friend std::ostream& operator<<(std::ostream& stream, const padded value)
+            friend std::ostream& operator<<(std::ostream& stream, const padded value_)
             {
-                return stream << value.padding << value.value << value.padding;
+                return stream << value_.padding << value_.value << value_.padding;
             }
         };
 

--- a/include/crow/multipart_view.h
+++ b/include/crow/multipart_view.h
@@ -186,7 +186,7 @@ namespace crow
               headers(req.headers),
               boundary(get_boundary(get_header_value("Content-Type")))
             {
-                parse_body(req.body, parts, part_map);
+                parse_body(req.body);
             }
 
         private:
@@ -207,8 +207,7 @@ namespace crow
                 return to_return;
             }
 
-            // TODO why not use parts and part_map directly?
-            void parse_body(std::string_view body, std::vector<part_view>& sections, mp_view_map& part_map_ref)
+            void parse_body(std::string_view body)
             {
                 const std::string delimiter = dd + boundary;
 
@@ -230,10 +229,10 @@ namespace crow
                     if (!section.empty())
                     {
                         part_view parsed_section = parse_section(section);
-                        part_map_ref.emplace(
+                        part_map.emplace(
                           (get_header_object(parsed_section.headers, "Content-Disposition").params.find("name")->second),
                           parsed_section);
-                        sections.push_back(std::move(parsed_section));
+                        parts.push_back(std::move(parsed_section));
                     }
                 }
             }

--- a/include/crow/mustache.h
+++ b/include/crow/mustache.h
@@ -51,8 +51,8 @@ namespace crow // NOTE: Already documented in "crow/app.h"
         class invalid_template_exception : public std::exception
         {
         public:
-            invalid_template_exception(const std::string& msg):
-              msg("crow::mustache error: " + msg)
+            invalid_template_exception(const std::string& msg_):
+              msg("crow::mustache error: " + msg_)
             {}
             virtual const char* what() const throw() override
             {
@@ -118,8 +118,8 @@ namespace crow // NOTE: Already documented in "crow/app.h"
             int end;
             int pos;
             ActionType t;
-            Action(ActionType t, size_t start, size_t end, size_t pos = 0):
-              start(static_cast<int>(start)), end(static_cast<int>(end)), pos(static_cast<int>(pos)), t(t)
+            Action(ActionType t_, size_t start_, size_t end_, size_t pos_ = 0):
+              start(static_cast<int>(start_)), end(static_cast<int>(end_)), pos(static_cast<int>(pos_)), t(t_)
             {
             }
         };

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -260,8 +260,8 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                 template<typename Req, typename... Args>
                 struct req_handler_wrapper
                 {
-                    req_handler_wrapper(Func f):
-                      f(std::move(f))
+                    req_handler_wrapper(Func fun):
+                      f(std::move(fun))
                     {
                     }
 
@@ -1375,8 +1375,8 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                     get_recursive_child_methods(blueprint, methods);
                     for (HTTPMethod x : methods)
                     {
-                        int i = static_cast<int>(x);
-                        per_methods_[i].trie.add(blueprint->prefix(), 0, blueprint->prefix().length(), i);
+                        int method_index = static_cast<int>(x);
+                        per_methods_[method_index].trie.add(blueprint->prefix(), 0, blueprint->prefix().length(), method_index);
                     }
                 }
 
@@ -1431,9 +1431,9 @@ namespace crow // NOTE: Already documented in "crow/app.h"
 
             if (!rule_index)
             {
-                for (auto& per_method : per_methods_)
+                for (auto& method : per_methods_)
                 {
-                    if (per_method.trie.find(req.url).rule_index)
+                    if (method.trie.find(req.url).rule_index)
                     {
                         CROW_LOG_DEBUG << "Cannot match method " << req.url << " " << method_name(req.method);
                         res = response(405);

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -97,11 +97,13 @@ namespace crow // NOTE: Already documented in "crow/app.h"
 
         virtual void validate() = 0;
 
-        void set_added() {
+        void set_added()
+        {
             added_ = true;
         }
 
-        bool is_added() {
+        bool is_added()
+        {
             return added_;
         }
 
@@ -1110,11 +1112,10 @@ namespace crow // NOTE: Already documented in "crow/app.h"
     class Blueprint
     {
     public:
-        Blueprint(const std::string& prefix)
-          : prefix_(prefix),
-            static_dir_(prefix),
-            templates_dir_(prefix)
-            {};
+        Blueprint(const std::string& prefix):
+          prefix_(prefix),
+          static_dir_(prefix),
+          templates_dir_(prefix){};
 
         Blueprint(const std::string& prefix, const std::string& static_dir):
           prefix_(prefix), static_dir_(static_dir){};
@@ -1174,11 +1175,13 @@ namespace crow // NOTE: Already documented in "crow/app.h"
             return static_dir_;
         }
 
-        void set_added() {
+        void set_added()
+        {
             added_ = true;
         }
 
-        bool is_added() {
+        bool is_added()
+        {
             return added_;
         }
 
@@ -1355,7 +1358,8 @@ namespace crow // NOTE: Already documented in "crow/app.h"
             }
         }
 
-        void validate_bp() {
+        void validate_bp()
+        {
             //Take all the routes from the registered blueprints and add them to `all_rules_` to be processed.
             detail::middleware_indices blueprint_mw;
             validate_bp(blueprints_, blueprint_mw);

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -642,9 +642,9 @@ namespace crow
 
             // Padded
             else if (size >= 2 && data[size - 2] == '=') // padded with '=='
-                size = (size / 4 * 3) - 2;  // == padding means the last block only has 1 character instead of 3, hence the '-2'
+                size = (size / 4 * 3) - 2;               // == padding means the last block only has 1 character instead of 3, hence the '-2'
             else if (size >= 1 && data[size - 1] == '=') // padded with '='
-                size = (size / 4 * 3) - 1;  // = padding means the last block only has 2 character instead of 3, hence the '-1'
+                size = (size / 4 * 3) - 1;               // = padding means the last block only has 2 character instead of 3, hence the '-1'
 
             // Padding not needed
             else
@@ -934,7 +934,7 @@ namespace crow
          * @param last2 end() iterator of the second range
          * @return first occurence that matches between two ranges of iterators 
         */
-        template <typename Iter1, typename Iter2>
+        template<typename Iter1, typename Iter2>
         inline static Iter1 find_first_of(Iter1 first1, Iter1 last1, Iter2 first2, Iter2 last2)
         {
             for (; first1 != last1; ++first1)

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -724,7 +724,7 @@ namespace crow
             // Check for special device names. The Windows behavior is really odd here, it will consider both AUX and AUX.txt
             // a special device. Thus we search for the string (case-insensitive), and then check if the string ends or if
             // is has a dangerous follow up character (.:\/)
-            auto sanitizeSpecialFile = [](std::string& source, unsigned ofs, const char* pattern, bool includeNumber, char replacement) {
+            auto sanitizeSpecialFile = [](std::string& source, unsigned ofs, const char* pattern, bool includeNumber, char replacement_) {
                 unsigned i = ofs;
                 size_t len = source.length();
                 const char* p = pattern;
@@ -743,7 +743,7 @@ namespace crow
                 if ((i >= len) || (source[i] == '.') || (source[i] == ':') || (source[i] == '/') || (source[i] == '\\'))
                 {
                     source.erase(ofs + 1, (i - ofs) - 1);
-                    source[ofs] = replacement;
+                    source[ofs] = replacement_;
                 }
             };
             bool checkForSpecialEntries = true;

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -666,8 +666,8 @@ TEST_CASE("multi_server")
 
         for (auto ch : sendmsg)
         {
-            char buf[1] = {ch};
-            c.send(asio::buffer(buf));
+            char tmp[1] = {ch};
+            c.send(asio::buffer(tmp));
         }
 
         size_t recved = c.receive(asio::buffer(buf, 2048));
@@ -2701,9 +2701,9 @@ TEST_CASE("stream_response")
                 b.commit(n);
                 received += n;
 
-                std::istream is(&b);
+                std::istream istream(&b);
                 std::string s;
-                is >> s;
+                istream >> s;
 
                 CHECK(key_response.substr(received - n, n) == s);
             }

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -541,16 +541,25 @@ TEST_CASE("http_method")
 TEST_CASE("validate can be called multiple times")
 {
     SimpleApp app;
-    CROW_ROUTE(app, "/")([]() { return "1"; });
+    CROW_ROUTE(app, "/")
+    ([]() {
+        return "1";
+    });
     app.validate();
     app.validate();
 
-    CROW_ROUTE(app, "/test")([]() { return "1"; });
+    CROW_ROUTE(app, "/test")
+    ([]() {
+        return "1";
+    });
     app.validate();
 
     try
     {
-        CROW_ROUTE(app, "/")([]() { return "1"; });
+        CROW_ROUTE(app, "/")
+        ([]() {
+            return "1";
+        });
         app.validate();
         FAIL_CHECK();
     }
@@ -2990,7 +2999,8 @@ TEST_CASE("websocket_close")
     {
         std::fill_n(buf, 2048, 0);
         // Close message with, len = 2, status code = 1001
-        char close_message[9]("\x88\x06\x03\xE9" "fail");
+        char close_message[9]("\x88\x06\x03\xE9"
+                              "fail");
 
         c.send(asio::buffer(close_message, 8));
         c.receive(asio::buffer(buf, 2048));
@@ -3011,7 +3021,7 @@ TEST_CASE("websocket_close")
         //----------Text----------
         std::fill_n(buf, 2048, 0);
         char text_message[2 + 12 + 1]("\x81\x0C"
-                                     "quit-default");
+                                      "quit-default");
 
         c.send(asio::buffer(text_message, 14));
         c.receive(asio::buffer(buf, 2048));
@@ -3061,7 +3071,8 @@ TEST_CASE("websocket_close")
         CHECK(close_calls == 0);
 
         // Reply with client close
-        char client_close_response[11]("\x88\x08\x0\x0" "custom");
+        char client_close_response[11]("\x88\x08\x0\x0"
+                                       "custom");
         client_close_response[2] = buf[2];
         client_close_response[3] = buf[3];
 
@@ -3760,7 +3771,8 @@ TEST_CASE("base64")
     CHECK(crow::utility::base64decode(sample_bin2_enc_np, 6) == sample_bin2_str);
 } // base64
 
-TEST_CASE("normalize_path") {
+TEST_CASE("normalize_path")
+{
     CHECK(crow::utility::normalize_path("/abc/def") == "/abc/def/");
     CHECK(crow::utility::normalize_path("path\\to\\directory") == "path/to/directory/");
 } // normalize_path
@@ -3961,8 +3973,7 @@ TEST_CASE("http2_upgrade_is_ignored")
     static char buf[5012];
 
     SimpleApp app;
-    CROW_ROUTE(app, "/echo").methods("POST"_method)
-    ([](crow::request const& req) {
+    CROW_ROUTE(app, "/echo").methods("POST"_method)([](crow::request const& req) {
         return req.body;
     });
 
@@ -3982,15 +3993,15 @@ TEST_CASE("http2_upgrade_is_ignored")
     };
 
     std::string request =
-        "POST /echo HTTP/1.1\r\n"
-        "user-agent: unittest.cpp\r\n"
-        "host: " LOCALHOST_ADDRESS ":45451\r\n"
-        "content-length: 48\r\n"
-        "connection: upgrade\r\n"
-        "upgrade: h2c\r\n"
-        "\r\n"
-        "http2 upgrade is not supported so body is parsed\r\n"
-        "\r\n";
+      "POST /echo HTTP/1.1\r\n"
+      "user-agent: unittest.cpp\r\n"
+      "host: " LOCALHOST_ADDRESS ":45451\r\n"
+      "content-length: 48\r\n"
+      "connection: upgrade\r\n"
+      "upgrade: h2c\r\n"
+      "\r\n"
+      "http2 upgrade is not supported so body is parsed\r\n"
+      "\r\n";
 
     auto res = make_request(request);
     CHECK(res.find("http2 upgrade is not supported so body is parsed") != std::string::npos);


### PR DESCRIPTION
Shadowing variables makes it harder to understand whats happening.
Enabled as warning and fixed all current violations.  