### PR TITLE
Check start tags were matched to an end tag

### DIFF
--- a/include/crow/mustache.h
+++ b/include/crow/mustache.h
@@ -526,7 +526,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                                                                      body_.substr(matched.start, matched.end - matched.start) + ", " +
                                                                      body_.substr(idx, endIdx - idx));
                                 }
-                                matched.pos = actions_.size();
+                                matched.pos = static_cast<int>(actions_.size());
                             }
                             actions_.emplace_back(ActionType::CloseBlock, idx, endIdx, blockPositions.back());
                             blockPositions.pop_back();
@@ -626,7 +626,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                 }
 
                 // removing standalones
-                for (int i = actions_.size() - 2; i >= 0; i--)
+                for (int i = static_cast<int>(actions_.size()) - 2; i >= 0; i--)
                 {
                     if (actions_[i].t == ActionType::Tag || actions_[i].t == ActionType::UnescapeTag)
                         continue;

--- a/include/crow/mustache.h
+++ b/include/crow/mustache.h
@@ -114,13 +114,36 @@ namespace crow // NOTE: Already documented in "crow/app.h"
          */
         struct Action
         {
+            bool has_end_match;
+            char tag_char;
             int start;
             int end;
             int pos;
             ActionType t;
-            Action(ActionType t_, size_t start_, size_t end_, size_t pos_ = 0):
-              start(static_cast<int>(start_)), end(static_cast<int>(end_)), pos(static_cast<int>(pos_)), t(t_)
+
+            Action(char tag_char_, ActionType t_, size_t start_, size_t end_, size_t pos_ = 0):
+              has_end_match(false), tag_char(tag_char_), start(static_cast<int>(start_)), end(static_cast<int>(end_)), pos(static_cast<int>(pos_)), t(t_)
             {
+            }
+
+            bool missing_end_pair() const {
+                switch (t)
+                {
+                    case ActionType::Ignore:
+                    case ActionType::Tag:
+                    case ActionType::UnescapeTag:
+                    case ActionType::CloseBlock:
+                    case ActionType::Partial:
+                        return false;
+
+                    // requires a match
+                    case ActionType::OpenBlock:
+                    case ActionType::ElseBlock:
+                        return !has_end_match;
+
+                    default:
+                        throw std::logic_error("invalid type");
+                }
             }
         };
 
@@ -483,7 +506,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                     if (idx == body_.npos)
                     {
                         fragments_.emplace_back(static_cast<int>(current), static_cast<int>(body_.size()));
-                        actions_.emplace_back(ActionType::Ignore, 0, 0);
+                        actions_.emplace_back('!', ActionType::Ignore, 0, 0);
                         break;
                     }
                     fragments_.emplace_back(static_cast<int>(current), static_cast<int>(idx));
@@ -500,7 +523,8 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                         throw invalid_template_exception("not matched opening tag");
                     }
                     current = endIdx + tag_close.size();
-                    switch (body_[idx])
+                    char tag_char = body_[idx];
+                    switch (tag_char)
                     {
                         case '#':
                             idx++;
@@ -509,7 +533,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                             while (body_[endIdx - 1] == ' ')
                                 endIdx--;
                             blockPositions.emplace_back(static_cast<int>(actions_.size()));
-                            actions_.emplace_back(ActionType::OpenBlock, idx, endIdx);
+                            actions_.emplace_back(tag_char, ActionType::OpenBlock, idx, endIdx);
                             break;
                         case '/':
                             idx++;
@@ -522,13 +546,18 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                                 if (body_.compare(idx, endIdx - idx,
                                                   body_, matched.start, matched.end - matched.start) != 0)
                                 {
-                                    throw invalid_template_exception("not matched {{# {{/ pair: " +
-                                                                     body_.substr(matched.start, matched.end - matched.start) + ", " +
-                                                                     body_.substr(idx, endIdx - idx));
+                                     throw invalid_template_exception(
+                                             std::string("not matched {{")
+                                             + matched.tag_char
+                                             + "{{/ pair: "
+                                             + body_.substr(matched.start, matched.end - matched.start) + ", "
+                                             + body_.substr(idx, endIdx - idx)
+                                             );
                                 }
                                 matched.pos = static_cast<int>(actions_.size());
+                                matched.has_end_match = true;
                             }
-                            actions_.emplace_back(ActionType::CloseBlock, idx, endIdx, blockPositions.back());
+                            actions_.emplace_back(tag_char, ActionType::CloseBlock, idx, endIdx, blockPositions.back());
                             blockPositions.pop_back();
                             break;
                         case '^':
@@ -538,11 +567,11 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                             while (body_[endIdx - 1] == ' ')
                                 endIdx--;
                             blockPositions.emplace_back(static_cast<int>(actions_.size()));
-                            actions_.emplace_back(ActionType::ElseBlock, idx, endIdx);
+                            actions_.emplace_back(tag_char, ActionType::ElseBlock, idx, endIdx);
                             break;
                         case '!':
                             // do nothing action
-                            actions_.emplace_back(ActionType::Ignore, idx + 1, endIdx);
+                            actions_.emplace_back(tag_char, ActionType::Ignore, idx + 1, endIdx);
                             break;
                         case '>': // partial
                             idx++;
@@ -550,7 +579,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                                 idx++;
                             while (body_[endIdx - 1] == ' ')
                                 endIdx--;
-                            actions_.emplace_back(ActionType::Partial, idx, endIdx);
+                            actions_.emplace_back(tag_char, ActionType::Partial, idx, endIdx);
                             break;
                         case '{':
                             if (tag_open != "{{" || tag_close != "}}")
@@ -565,7 +594,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                                 idx++;
                             while (body_[endIdx - 1] == ' ')
                                 endIdx--;
-                            actions_.emplace_back(ActionType::UnescapeTag, idx, endIdx);
+                            actions_.emplace_back(tag_char, ActionType::UnescapeTag, idx, endIdx);
                             current++;
                             break;
                         case '&':
@@ -574,12 +603,12 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                                 idx++;
                             while (body_[endIdx - 1] == ' ')
                                 endIdx--;
-                            actions_.emplace_back(ActionType::UnescapeTag, idx, endIdx);
+                            actions_.emplace_back(tag_char, ActionType::UnescapeTag, idx, endIdx);
                             break;
                         case '=':
                             // tag itself is no-op
                             idx++;
-                            actions_.emplace_back(ActionType::Ignore, idx, endIdx);
+                            actions_.emplace_back(tag_char, ActionType::Ignore, idx, endIdx);
                             endIdx--;
                             if (body_[endIdx] != '=')
                                 throw invalid_template_exception("{{=: not matching = tag: " + body_.substr(idx, endIdx - idx));
@@ -620,8 +649,22 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                                 idx++;
                             while (body_[endIdx - 1] == ' ')
                                 endIdx--;
-                            actions_.emplace_back(ActionType::Tag, idx, endIdx);
+                            actions_.emplace_back(tag_char, ActionType::Tag, idx, endIdx);
                             break;
+                    }
+                }
+
+                // ensure no unmatched tags
+                for (int i = 0; i < static_cast<int>(actions_.size()); i++)
+                {
+                    if (actions_[i].missing_end_pair())
+                    {
+                        throw invalid_template_exception(
+                                std::string("open tag has no matching end tag {{")
+                                + actions_[i].tag_char
+                                + " {{/ pair: "
+                                + body_.substr(actions_[i].start, actions_[i].end - actions_[i].start)
+                                );
                     }
                 }
 

--- a/tests/template/crow_extra_mustache_tests.json
+++ b/tests/template/crow_extra_mustache_tests.json
@@ -1,0 +1,15 @@
+{
+  "overview": "Check Crow's behaviour when given invalid mustache templates",
+  "tests": [
+    {
+      "name": "Missing end-tags",
+      "desc": "Missing end-tags should fail to render ... and not enter infinite loops or other undefined behaviour",
+      "data": {
+        "boolean": true
+      },
+      "template": "\"{{#boolean}}{{^boolean}}\"",
+      "expected": "COMPILE EXCEPTION: crow::mustache error: open tag has no matching end tag {{# {{/ pair: boolean"
+    }
+  ],
+  "__ATTN__": "This file was hand-written"
+}

--- a/tests/template/mustachetest.cpp
+++ b/tests/template/mustachetest.cpp
@@ -18,17 +18,23 @@ string read_all(const string& filename)
 
 int main()
 {
-    auto data = json::load(read_all("data"));
-    auto templ = compile(read_all("template"));
-    auto partials = json::load(read_all("partials"));
-    set_loader([&](std::string name) -> std::string {
-        if (partials.count(name))
-        {
-            return partials[name].s();
-        }
-        return "";
-    });
-    context ctx(data);
-    cout << templ.render_string(ctx);
+    try {
+        auto data = json::load(read_all("data"));
+        auto templ = compile(read_all("template"));
+        auto partials = json::load(read_all("partials"));
+        set_loader([&](std::string name) -> std::string {
+            if (partials.count(name))
+            {
+                return partials[name].s();
+            }
+            return "";
+        });
+        context ctx(data);
+        cout << templ.render_string(ctx);
+    }
+    // catch and return compile errors as text, for the python test to compare
+    catch (invalid_template_exception & err) {
+        cout << "COMPILE EXCEPTION: " << err.what();
+    }
     return 0;
 }

--- a/tests/template/test.py
+++ b/tests/template/test.py
@@ -30,7 +30,7 @@ for testfile in glob.glob("*.json"):
             print('Data: ', json.dumps(test["data"]))
             print('Template: ', test["template"])
             print('Expected:', repr(test["expected"]))
-            print('Actual:', repr(ret))
+            print('Actual:  ', repr(ret))
         assert ret == test["expected"]
 
         os.unlink('data')


### PR DESCRIPTION
Template:
```
{#username}
{^username}
```

Context:
`{ "username": "" }`

The problem appears to be in `ActionType::ElseBlock`, which find the context, but doesn't have a switch case for `json::type::String`, and instead sets `current=action.pos`
https://github.com/CrowCpp/Crow/blob/25ca2f54e19e7c266d55fb3485d315d639d3f3f0/include/crow/mustache.h#L349

For this template, there are 2 actions.
At this point we are on the second action (current=1)
But this action's "pos" is = 0.
So, current is reset to zero, and it loops through again and again, never progressing.

This seems related to #899 
I think the problem is pos is never set to a valid point... this is done in case'/', ie when the parser sees the end tag.
But, if there is never an end-tag, it never checks if there are unmatched pairs, and pos is never set.

So, I've adjusted the code so it always expects a non-negative pos.
pos is initialised by default to -1 for start tags.
And end tag will match it and set it to a valid pos.

For all other normal tags, it is initialised to zero.

THIS was a quick first-pass patch, as I'm not familiar with mustache, so I imagine this patch is NOT COMPLETE.
It needs to be run through a test suite.