### PR TITLE
"crow::multipart::message throws when the boundary is empty or malformed

### DIFF
--- a/include/crow/multipart.h
+++ b/include/crow/multipart.h
@@ -147,8 +147,14 @@ namespace crow
               boundary(get_boundary(get_header_value("Content-Type")))
             {
                 if (!boundary.empty())
+                {
                     content_type = "multipart/form-data; boundary=" + boundary;
-                parse_body(req.body);
+                    parse_body(req.body);
+                }
+                else
+                {
+                    throw std::runtime_error("Empty boundary in multipart message");
+                }
             }
 
         private:
@@ -178,8 +184,8 @@ namespace crow
                     size_t found = body.find(delimiter);
                     if (found == std::string::npos)
                     {
-                        // did not find delimiter; probably an ill-formed body; ignore the rest
-                        break;
+                        // did not find delimiter; probably an ill-formed body; throw to indicate the issue to user
+                        throw std::runtime_error("Unable to find delimiter. Probably ill-formed body");
                     }
                     std::string section = body.substr(0, found);
 

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2510,6 +2510,63 @@ TEST_CASE("multipart")
 
         CHECK(test_string == res.body);
     }
+
+    //Test against empty boundary
+    {
+        request req;
+
+        req.url = "/multipart";
+        req.add_header("Content-Type", "multipart/form-data; boundary=");
+        req.body = test_string;
+
+        try
+        {
+            multipart::message msg(req);
+            CHECK(false);
+        }
+        catch(const std::exception& e)
+        {
+            CHECK(std::string(e.what()) == "Empty boundary in multipart message");
+        }
+
+    }
+
+    //Boundary that differs from actual boundary
+    {
+        const char alphabet[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        std::random_device dev;
+        std::mt19937 rng(dev());
+        std::uniform_int_distribution<std::mt19937::result_type> dist(0, sizeof(alphabet) - 2);
+        std::uniform_int_distribution<std::mt19937::result_type> boundary_sizes(1, 50);
+        std::array<std::string, 100> test_boundaries;
+
+        for (auto& boundary : test_boundaries)
+        {
+            const size_t boundary_size = boundary_sizes(rng);
+            boundary.reserve(boundary_size);
+            for (size_t idx = 0; idx < boundary_size; idx++)
+                boundary.push_back(alphabet[dist(rng)]);
+        }
+
+        for (const auto& boundary : test_boundaries)
+        {
+            request req;
+
+            req.url = "/multipart";
+            req.add_header("Content-Type", "multipart/form-data; boundary=" + boundary);
+            req.body = test_string;
+
+            try
+            {
+                multipart::message msg(req);
+                CHECK(false);
+            }
+            catch(const std::exception& e)
+            {
+                CHECK(std::string(e.what()) == "Unable to find delimiter. Probably ill-formed body");
+            }
+        }
+    }
 } // multipart
 
 TEST_CASE("multipart_view")


### PR DESCRIPTION
This related to issue #916 where the multipart message causes a segmentation fault when a multipart request with an empty boundary is received. 

I added two throws to indicate whenever the boundary is empty or it could not be found/differs from the boundary inside the body.

I hope these changes are enough to prevent the code from being unable to parse the headers thus leaving to the segmentation faults.

I also added two new tests that aim to check that these exceptions are thrown whenever the boundary is either missing or not matching 