### PR TITLE
When compiling with GCC 14.1.0 (C++23)

### DIFF
--- a/include/crow/parser.h
+++ b/include/crow/parser.h
@@ -100,6 +100,7 @@ namespace crow
             return 0;
         }
         HTTPParser(Handler* handler):
+          http_parser(),
           handler_(handler)
         {
             http_parser_init(this);


### PR DESCRIPTION
Hi,

I was unable to compile with GCC 14.1.0 (using C++ 23). The struct parser was not initialized in the `http_parser_init` function. This because the base class of `HTTPParser` was never properly initialized. Adding initialization fixes the issue.