### PR TITLE
Redirect to url with trailing slash, WITHOUT the protocol and host.

### DIFF
--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -258,18 +258,6 @@ namespace crow
                 }
             }
 #endif
-            //if there is a redirection with a partial URL, treat the URL as a route.
-            std::string location = res.get_header_value("Location");
-            if (!location.empty() && location.find("://", 0) == std::string::npos)
-            {
-#ifdef CROW_ENABLE_SSL
-                if (handler_->ssl_used())
-                    location.insert(0, "https://" + req_.get_header_value("Host"));
-                else
-#endif
-                    location.insert(0, "http://" + req_.get_header_value("Host"));
-                res.set_header("location", location);
-            }
 
             prepare_buffers();
 

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -1462,16 +1462,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
             {
                 CROW_LOG_INFO << "Redirecting to a url with trailing slash: " << req.url;
                 res = response(301);
-
-                // TODO(ipkn) absolute url building
-                if (req.get_header_value("Host").empty())
-                {
-                    res.add_header("Location", req.url + "/");
-                }
-                else
-                {
-                    res.add_header("Location", (using_ssl ? "https://" : "http://") + req.get_header_value("Host") + req.url + "/");
-                }
+                res.add_header("Location", req.url + "/");
                 res.end();
                 return;
             }
@@ -1710,16 +1701,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
             {
                 CROW_LOG_INFO << "Redirecting to a url with trailing slash: " << req.url;
                 res = response(301);
-
-                // TODO(ipkn) absolute url building
-                if (req.get_header_value("Host").empty())
-                {
-                    res.add_header("Location", req.url + "/");
-                }
-                else
-                {
-                    res.add_header("Location", (using_ssl ? "https://" : "http://") + req.get_header_value("Host") + req.url + "/");
-                }
+                res.add_header("Location", req.url + "/");
                 res.end();
                 return;
             }


### PR DESCRIPTION
Crow does not know the correct protocol when behind a reverse proxy. So instead, simply redirect to the same url and add a trailing slash.

Regarding #915 
I've just realised that this fails when behind a reverse proxy.

Situation: running crowcpp as a HTTP behind a HTTPS reverse proxy
Crow wants to redirect.
It sets the location to the full URL, including protocol.
It assumes http:// is correct, as that is what it is running.
But, it needs https:// to correctly hit the reverse proxy...

Why do we need to specify the host?  Is there a good reason?
I couldn't see any reasoning given in prior commits or issues.

https://github.com/CrowCpp/Crow/commit/967adf0de55afcb52881cdb1a7b16788c7c283db#diff-83f8db2c08b899a7b155ca1ddbef781d51babff4553c79cd20fb3a216ffc7780R937
https://github.com/CrowCpp/Crow/commit/4cdde73388dc1a17d6401b2df923c717f2e53649#diff-cce8b59e628bdbbe6a329eea27b56b908c8a1d5926a4b44f697f39a301046c93L1402

https://github.com/CrowCpp/Crow/commit/07042b55fdeaab1170cd5ad244939b5ed1f486a9#diff-83f8db2c08b899a7b155ca1ddbef781d51babff4553c79cd20fb3a216ffc7780R677
