### PR TITLE
Fixed CMP0167 CMake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,10 @@ target_include_directories(Crow
 )
 
 if(CROW_USE_BOOST)
+	if(POLICY CMP0167)
+		# Use Boost CMake module from Boost instead of the one from CMake
+		cmake_policy(SET CMP0167 NEW)
+	endif()
 	find_package(Boost 1.64 COMPONENTS system date_time REQUIRED)
 	target_link_libraries(Crow
 		INTERFACE


### PR DESCRIPTION
Enabled NEW CMP0167 behavior, as this project does not depend on using CMake Boost module provided by CMake specifically.

https://cmake.org/cmake/help/latest/policy/CMP0167.html

