### PR TITLE
Remove `CROW_CAN_USE_CPP14` and `CROW_CAN_USE_CPP17` macros

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -254,16 +254,8 @@ namespace crow
 
         /// \brief Create a route using a rule (**Use CROW_ROUTE instead**)
         template<uint64_t Tag>
-#ifdef CROW_GCC83_WORKAROUND
-        auto& route(const std::string& rule)
-#else
         auto route(const std::string& rule)
-#endif
-#if defined CROW_CAN_USE_CPP17 && !defined CROW_GCC83_WORKAROUND
           -> typename std::invoke_result<decltype(&Router::new_rule_tagged<Tag>), Router, const std::string&>::type
-#elif !defined CROW_GCC83_WORKAROUND
-          -> typename std::result_of<decltype (&Router::new_rule_tagged<Tag>)(Router, const std::string&)>::type
-#endif
         {
             return router_.new_rule_tagged<Tag>(rule);
         }

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -248,16 +248,10 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                 template<typename... Args>
                 void set_(Func f, typename std::enable_if<!std::is_same<typename std::tuple_element<0, std::tuple<Args..., void>>::type, const request&>::value, int>::type = 0)
                 {
-                    handler_ = (
-#ifdef CROW_CAN_USE_CPP14
-                      [f = std::move(f)]
-#else
-                      [f]
-#endif
-                      (const request&, response& res, Args... args) {
-                          res = response(f(args...));
-                          res.end();
-                      });
+                    handler_ = ([f = std::move(f)](const request&, response& res, Args... args) {
+                        res = response(f(args...));
+                        res.end();
+                    });
                 }
 
                 template<typename Req, typename... Args>
@@ -354,16 +348,10 @@ namespace crow // NOTE: Already documented in "crow/app.h"
             static_assert(!std::is_same<void, decltype(f())>::value,
                           "Handler function cannot have void return type; valid return types: string, int, crow::response, crow::returnable");
 
-            handler_ = (
-#ifdef CROW_CAN_USE_CPP14
-              [f = std::move(f)]
-#else
-              [f]
-#endif
-              (const request&, response& res) {
-                  res = response(f());
-                  res.end();
-              });
+            handler_ = ([f = std::move(f)](const request&, response& res) {
+                res = response(f());
+                res.end();
+            });
         }
 
         template<typename Func>
@@ -376,16 +364,10 @@ namespace crow // NOTE: Already documented in "crow/app.h"
             static_assert(!std::is_same<void, decltype(f(std::declval<crow::request>()))>::value,
                           "Handler function cannot have void return type; valid return types: string, int, crow::response, crow::returnable");
 
-            handler_ = (
-#ifdef CROW_CAN_USE_CPP14
-              [f = std::move(f)]
-#else
-              [f]
-#endif
-              (const crow::request& req, crow::response& res) {
-                  res = response(f(req));
-                  res.end();
-              });
+            handler_ = ([f = std::move(f)](const request& req, response& res) {
+                res = response(f(req));
+                res.end();
+            });
         }
 
         template<typename Func>
@@ -398,15 +380,9 @@ namespace crow // NOTE: Already documented in "crow/app.h"
         {
             static_assert(std::is_same<void, decltype(f(std::declval<crow::response&>()))>::value,
                           "Handler function with response argument should have void return type");
-            handler_ = (
-#ifdef CROW_CAN_USE_CPP14
-              [f = std::move(f)]
-#else
-              [f]
-#endif
-              (const crow::request&, crow::response& res) {
-                  f(res);
-              });
+            handler_ = ([f = std::move(f)](const request&, response& res) {
+                f(res);
+            });
         }
 
         template<typename Func>
@@ -681,15 +657,9 @@ namespace crow // NOTE: Already documented in "crow/app.h"
         template<typename Func>
         void operator()(Func&& f)
         {
-            handler_ = (
-#ifdef CROW_CAN_USE_CPP14
-              [f = std::move(f)]
-#else
-              [f]
-#endif
-              (crow::request& req, crow::response& res, Args... args) {
-                  detail::wrapped_handler_call(req, res, f, std::forward<Args>(args)...);
-              });
+            handler_ = ([f = std::move(f)](request& req, response& res, Args... args) {
+                detail::wrapped_handler_call(req, res, f, std::forward<Args>(args)...);
+            });
         }
 
         template<typename Func>

--- a/include/crow/settings.h
+++ b/include/crow/settings.h
@@ -33,35 +33,11 @@
 #endif
 
 // compiler flags
-#if defined(_MSVC_LANG) && _MSVC_LANG >= 201402L
-#define CROW_CAN_USE_CPP14
-#endif
-#if __cplusplus >= 201402L
-#define CROW_CAN_USE_CPP14
-#endif
-
-#if defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
-#define CROW_CAN_USE_CPP17
-#endif
-#if __cplusplus >= 201703L
-#define CROW_CAN_USE_CPP17
-#if defined(__GNUC__) && __GNUC__ < 8
-#define CROW_FILESYSTEM_IS_EXPERIMENTAL
-#endif
-#endif
 
 #if defined(_MSC_VER)
 #if _MSC_VER < 1900
 #define CROW_MSVC_WORKAROUND
 #define constexpr const
 #define noexcept throw()
-#endif
-#endif
-
-#if defined(__GNUC__) && __GNUC__ == 8 && __GNUC_MINOR__ < 4
-#if __cplusplus > 201103L
-#define CROW_GCC83_WORKAROUND
-#else
-#error "GCC 8.1 - 8.3 has a bug that prevents Crow from compiling with C++11. Please update GCC to > 8.3 or use C++ > 11."
 #endif
 #endif

--- a/include/crow/utility.h
+++ b/include/crow/utility.h
@@ -16,9 +16,7 @@
 
 #include "crow/settings.h"
 
-#if defined(CROW_CAN_USE_CPP17) && !defined(CROW_FILESYSTEM_IS_EXPERIMENTAL)
 #include <filesystem>
-#endif
 
 // TODO(EDev): Adding C++20's [[likely]] and [[unlikely]] attributes might be useful
 #if defined(__GNUG__) || defined(__clang__)
@@ -291,21 +289,12 @@ namespace crow
         };
 
         // Extract element from forward tuple or get default
-#ifdef CROW_CAN_USE_CPP14
         template<typename T, typename Tup>
         typename std::enable_if<has_type<T&, Tup>::value, typename std::decay<T>::type&&>::type
           tuple_extract(Tup& tup)
         {
             return std::move(std::get<T&>(tup));
         }
-#else
-        template<typename T, typename Tup>
-        typename std::enable_if<has_type<T&, Tup>::value, T&&>::type
-          tuple_extract(Tup& tup)
-        {
-            return std::move(std::get<tuple_index<T&, Tup>::value>(tup));
-        }
-#endif
 
         template<typename T, typename Tup>
         typename std::enable_if<!has_type<T&, Tup>::value, T>::type
@@ -812,14 +801,7 @@ namespace crow
 
         inline static std::string join_path(std::string path, const std::string& fname)
         {
-#if defined(CROW_CAN_USE_CPP17) && !defined(CROW_FILESYSTEM_IS_EXPERIMENTAL)
             return (std::filesystem::path(path) / fname).string();
-#else
-            if (!(path.back() == '/' || path.back() == '\\'))
-                path += '/';
-            path += fname;
-            return path;
-#endif
         }
 
         /**


### PR DESCRIPTION
Remove legacy configuration macros

They are no longer needed since Crow requires C++17

Removed:
- `CROW_CAN_USE_CPP14` and `CROW_CAN_USE_CPP17` – C++17 required
- `CROW_FILESYSTEM_IS_EXPERIMENTAL` – C++17 includes `std::filesystem`
- `CROW_GCC83_WORKAROUND` – that was only for C++11