### PR TITLE
Mustache: fix segmentation fault for unexpected closing tag

### DIFF
--- a/include/crow/mustache.h
+++ b/include/crow/mustache.h
@@ -542,6 +542,13 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                             while (body_[endIdx - 1] == ' ')
                                 endIdx--;
                             {
+                                if (blockPositions.empty())
+                                {
+                                    throw invalid_template_exception(
+                                             std::string("unexpected closing tag: ")
+                                             + body_.substr(idx, endIdx - idx)
+                                             );
+                                }
                                 auto& matched = actions_[blockPositions.back()];
                                 if (body_.compare(idx, endIdx - idx,
                                                   body_, matched.start, matched.end - matched.start) != 0)

--- a/tests/fuzz/template_fuzzer.cpp
+++ b/tests/fuzz/template_fuzzer.cpp
@@ -24,9 +24,9 @@ extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data, const std::size_
         auto ctx = build_context_object(fdp);
         page.render_string(ctx);
     }
-    catch (const crow::mustache::invalid_template_exception& e)
+    catch (const std::exception& e)
     {
-        return -1;
+        // No special handling for invalid inputs or rendering errors
     }
 
     return 0;

--- a/tests/template/crow_extra_mustache_tests.json
+++ b/tests/template/crow_extra_mustache_tests.json
@@ -9,6 +9,15 @@
       },
       "template": "\"{{#boolean}}{{^boolean}}\"",
       "expected": "COMPILE EXCEPTION: crow::mustache error: open tag has no matching end tag {{# {{/ pair: boolean"
+    },
+    {
+      "name": "Unexpected end-tags",
+      "desc": "Unexpected end-tags should fail to render ... and not enter infinite loops or other undefined behaviour",
+      "data": {
+        "boolean": true
+      },
+      "template": "\"{{/unexpected}}\"",
+      "expected": "COMPILE EXCEPTION: crow::mustache error: unexpected closing tag: unexpected"
     }
   ],
   "__ATTN__": "This file was hand-written"


### PR DESCRIPTION
This patch fixes a bug identified as a vulnerability by OSS-Fuzz: https://issues.oss-fuzz.com/issues/42536654

```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==259589==ERROR: AddressSanitizer: SEGV on unknown address (pc 0x55e78391e6bb bp 0x7ffc4358c4a0 sp 0x7ffc4358c160 T0)
==259589==The signal is caused by a READ memory access.
==259589==Hint: this fault was caused by a dereference of a high value address (see register values below).  Disassemble the provided pc to learn which register was used.
    #0 0x55e78391e6bb in crow::mustache::template_t::parse() Crow/include/crow/mustache.h:545:73
    #1 0x55e78391bccb in crow::mustache::template_t::template_t(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>) Crow/include/crow/mustache.h:163:17
    #2 0x55e783919bcb in crow::mustache::compile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) Crow/include/crow/mustache.h:736:20
    #3 0x55e783919bcb in LLVMFuzzerTestOneInput Crow/tests/fuzz/template_fuzzer.cpp:23:21
    #4 0x55e783820d30 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (template_fuzzer+0x65d30)
    #5 0x55e78380ae82 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (template_fuzzer+0x4fe82)
    #6 0x55e7838108c6 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (template_fuzzer+0x558c6)
    #7 0x55e783839a32 in main (template_fuzzer+0x7ea32)
    #8 0x7f0dc62cad8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #9 0x7f0dc62cae3f in __libc_start_main csu/../csu/libc-start.c:392:3
    #10 0x55e783805e64 in _start (template_fuzzer+0x4ae64)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV Crow/include/crow/mustache.h:545:73 in crow::mustache::template_t::parse()
==259589==ABORTING
```

Mustache file:

```mustache
{{/tag}}
```

There are two possible solutions: fail with an error or ignore such unexpected tags. I implemented the first one as more strict. Please let me know if you disagree.

Also there are two changes in template_fuzzer:

1. Catch `std::exception` instead of `invalid_template_exception` because `render_string` can throw `std::runtime_error`
2. Return 0 instead of -1 even for errors - for fuzzing it's a common practice. "-1" means "this input is not interesting for the fuzzer" but it's not our case here