### PR TITLE
Add an option to expose headers for CORS

### DIFF
--- a/include/crow/middlewares/cors.h
+++ b/include/crow/middlewares/cors.h
@@ -51,6 +51,22 @@ namespace crow
             return *this;
         }
 
+        /// Set Access-Control-Expose-Headers. Default is none
+        CORSRules& expose(const std::string& header)
+        {
+            add_list_item(exposed_headers_, header);
+            return *this;
+        }
+
+        /// Set Access-Control-Expose-Headers. Default is none
+        template<typename... Headers>
+        CORSRules& expose(const std::string& header, Headers... header_list)
+        {
+            add_list_item(exposed_headers_, header);
+            expose(header_list...);
+            return *this;
+        }
+
         /// Set Access-Control-Max-Age. Default is none
         CORSRules& max_age(int max_age)
         {
@@ -108,6 +124,7 @@ namespace crow
             set_header_no_override("Access-Control-Allow-Origin", origin_, res);
             set_header_no_override("Access-Control-Allow-Methods", methods_, res);
             set_header_no_override("Access-Control-Allow-Headers", headers_, res);
+            set_header_no_override("Access-Control-Expose-Headers", exposed_headers_, res);
             set_header_no_override("Access-Control-Max-Age", max_age_, res);
             if (allow_credentials_) set_header_no_override("Access-Control-Allow-Credentials", "true", res);
         }
@@ -117,6 +134,7 @@ namespace crow
         std::string origin_ = "*";
         std::string methods_ = "*";
         std::string headers_ = "*";
+        std::string exposed_headers_;
         std::string max_age_;
         bool allow_credentials_ = false;
 

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1930,7 +1930,6 @@ TEST_CASE("middleware_cookieparser_format")
 
 TEST_CASE("middleware_cors")
 {
-
     App<crow::CORSHandler> app;
 
     auto& cors = app.get_middleware<crow::CORSHandler>();
@@ -1938,6 +1937,8 @@ TEST_CASE("middleware_cors")
     cors
       .prefix("/origin")
         .origin("test.test")
+      .prefix("/expose")
+        .expose("exposed-header")
       .prefix("/nocors")
         .ignore();
     // clang-format on
@@ -1948,6 +1949,11 @@ TEST_CASE("middleware_cors")
     });
 
     CROW_ROUTE(app, "/origin")
+    ([&](const request&) {
+        return "-";
+    });
+
+    CROW_ROUTE(app, "/expose")
     ([&](const request&) {
         return "-";
     });
@@ -1972,6 +1978,10 @@ TEST_CASE("middleware_cors")
     resp = HttpClient::request(LOCALHOST_ADDRESS, port,
                                "GET /origin\r\n\r\n");
     CHECK(resp.find("Access-Control-Allow-Origin: test.test") != std::string::npos);
+
+    resp = HttpClient::request(LOCALHOST_ADDRESS, port,
+                               "GET /expose\r\n\r\n");
+    CHECK(resp.find("Access-Control-Expose-Headers: exposed-header") != std::string::npos);
 
     resp = HttpClient::request(LOCALHOST_ADDRESS, port,
                                "GET /nocors/path\r\n\r\n");


### PR DESCRIPTION
According to MDN Web Docs, some headers are hidden from browser clients by default
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers

This pull request allows to specify which headers should be exposed via the CORS middleware