### PR TITLE
Credential is not supported if Allowed Origin is '*'

### DIFF
--- a/include/crow/middlewares/cors.h
+++ b/include/crow/middlewares/cors.h
@@ -118,15 +118,20 @@ namespace crow
         }
 
         /// Set response headers
-        void apply(crow::response& res)
+        void apply(const request& req, response& res)
         {
             if (ignore_) return;
-            set_header_no_override("Access-Control-Allow-Origin", origin_, res);
+
             set_header_no_override("Access-Control-Allow-Methods", methods_, res);
             set_header_no_override("Access-Control-Allow-Headers", headers_, res);
             set_header_no_override("Access-Control-Expose-Headers", exposed_headers_, res);
             set_header_no_override("Access-Control-Max-Age", max_age_, res);
             if (allow_credentials_) set_header_no_override("Access-Control-Allow-Credentials", "true", res);
+
+            if (allow_credentials_ && origin_ == "*")
+                set_header_no_override("Access-Control-Allow-Origin", req.get_header_value("Origin"), res);
+            else
+                set_header_no_override("Access-Control-Allow-Origin", origin_, res);
         }
 
         bool ignore_ = false;
@@ -158,7 +163,7 @@ namespace crow
         void after_handle(crow::request& req, crow::response& res, context& /*ctx*/)
         {
             auto& rule = find_rule(req.url);
-            rule.apply(res);
+            rule.apply(req, res);
         }
 
         /// Handle CORS on a specific prefix path

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1937,6 +1937,8 @@ TEST_CASE("middleware_cors")
     cors
       .prefix("/origin")
         .origin("test.test")
+      .prefix("/auth-origin")
+        .allow_credentials()
       .prefix("/expose")
         .expose("exposed-header")
       .prefix("/nocors")
@@ -1949,6 +1951,11 @@ TEST_CASE("middleware_cors")
     });
 
     CROW_ROUTE(app, "/origin")
+    ([&](const request&) {
+        return "-";
+    });
+
+    CROW_ROUTE(app, "/auth-origin")
     ([&](const request&) {
         return "-";
     });
@@ -1978,6 +1985,10 @@ TEST_CASE("middleware_cors")
     resp = HttpClient::request(LOCALHOST_ADDRESS, port,
                                "GET /origin\r\n\r\n");
     CHECK(resp.find("Access-Control-Allow-Origin: test.test") != std::string::npos);
+
+    resp = HttpClient::request(LOCALHOST_ADDRESS, port,
+                                    "GET /auth-origin\r\nOrigin: test-client\r\n\r\n");
+    CHECK(resp.find("Access-Control-Allow-Origin: test-client") != std::string::npos);
 
     resp = HttpClient::request(LOCALHOST_ADDRESS, port,
                                "GET /expose\r\n\r\n");


### PR DESCRIPTION
CORS disallows setting allowed origin to '*' when credentials are allowed

This pull request sets allowed origin to client origin when credentials are allowed

More info here: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSNotSupportingCredentials