### PR TITLE
Fixed handling of origin when allow_credentials enabled

### DIFF
--- a/include/crow/middlewares/cors.h
+++ b/include/crow/middlewares/cors.h
@@ -127,7 +127,7 @@ namespace crow
             set_header_no_override("Access-Control-Allow-Headers", headers_, res);
             set_header_no_override("Access-Control-Expose-Headers", exposed_headers_, res);
             set_header_no_override("Access-Control-Max-Age", max_age_, res);
-            if (req.method != HTTPMethod::OPTIONS)
+            if (req.method != HTTPMethod::Options)
             {
                 if (allow_credentials_) set_header_no_override("Access-Control-Allow-Credentials", "true", res);
                 if (allow_credentials_ && origin_ == "*")

--- a/include/crow/middlewares/cors.h
+++ b/include/crow/middlewares/cors.h
@@ -127,16 +127,25 @@ namespace crow
             set_header_no_override("Access-Control-Allow-Headers", headers_, res);
             set_header_no_override("Access-Control-Expose-Headers", exposed_headers_, res);
             set_header_no_override("Access-Control-Max-Age", max_age_, res);
+
+            bool origin_set = false;
+
             if (req.method != HTTPMethod::Options)
             {
-                if (allow_credentials_) set_header_no_override("Access-Control-Allow-Credentials", "true", res);
-                if (allow_credentials_ && origin_ == "*")
-                    set_header_no_override("Access-Control-Allow-Origin", req.get_header_value("Origin"), res);
-                else
-                    set_header_no_override("Access-Control-Allow-Origin", origin_, res);
+                if (allow_credentials_)
+                {
+                    set_header_no_override("Access-Control-Allow-Credentials", "true", res);
+                    if (origin_ == "*")
+                    {
+                        set_header_no_override("Access-Control-Allow-Origin", req.get_header_value("Origin"), res);
+                        origin_set = true;
+                    }
+                }
             }
-            else
+
+            if( !origin_set){
                 set_header_no_override("Access-Control-Allow-Origin", origin_, res);
+            }
         }
 
         bool ignore_ = false;

--- a/include/crow/middlewares/cors.h
+++ b/include/crow/middlewares/cors.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "crow/common.h"
 #include "crow/http_request.h"
 #include "crow/http_response.h"
 #include "crow/routing.h"
@@ -126,10 +127,14 @@ namespace crow
             set_header_no_override("Access-Control-Allow-Headers", headers_, res);
             set_header_no_override("Access-Control-Expose-Headers", exposed_headers_, res);
             set_header_no_override("Access-Control-Max-Age", max_age_, res);
-            if (allow_credentials_) set_header_no_override("Access-Control-Allow-Credentials", "true", res);
-
-            if (allow_credentials_ && origin_ == "*")
-                set_header_no_override("Access-Control-Allow-Origin", req.get_header_value("Origin"), res);
+            if (req.method != HTTPMethod::OPTIONS)
+            {
+                if (allow_credentials_) set_header_no_override("Access-Control-Allow-Credentials", "true", res);
+                if (allow_credentials_ && origin_ == "*")
+                    set_header_no_override("Access-Control-Allow-Origin", req.get_header_value("Origin"), res);
+                else
+                    set_header_no_override("Access-Control-Allow-Origin", origin_, res);
+            }
             else
                 set_header_no_override("Access-Control-Allow-Origin", origin_, res);
         }

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1960,6 +1960,10 @@ TEST_CASE("middleware_cors")
         return "-";
     });
 
+    CROW_ROUTE(app, "/auth-origin").methods(crow::HTTPMethod::Post)([&](const request&) {
+        return "-";
+    });
+
     CROW_ROUTE(app, "/expose")
     ([&](const request&) {
         return "-";
@@ -1987,8 +1991,14 @@ TEST_CASE("middleware_cors")
     CHECK(resp.find("Access-Control-Allow-Origin: test.test") != std::string::npos);
 
     resp = HttpClient::request(LOCALHOST_ADDRESS, port,
-                                    "GET /auth-origin\r\nOrigin: test-client\r\n\r\n");
+                               "GET /auth-origin\r\nOrigin: test-client\r\n\r\n");
     CHECK(resp.find("Access-Control-Allow-Origin: test-client") != std::string::npos);
+    CHECK(resp.find("Access-Control-Allow-Credentials: true") != std::string::npos);
+
+    resp = HttpClient::request(LOCALHOST_ADDRESS, port,
+                               "OPTIONS /auth-origin / HTTP/1.1 \r\n\r\n");
+    CHECK(resp.find("Access-Control-Allow-Origin: *") != std::string::npos);
+    CHECK(resp.find("Access-Control-Allow-Credentials: true") == std::string::npos);
 
     resp = HttpClient::request(LOCALHOST_ADDRESS, port,
                                "GET /expose\r\n\r\n");


### PR DESCRIPTION
There are two things to start with:
 - OPTIONS requests are not expected to have `Origin` header.  
 - OPTIONS responses are not expected to have an `Access-Control-Allow-Credentials` headers.
 - No response may have **both** `Access-Control-Allow-Credentials=true` and `Access-Control-Allow-Origin=*`. ([source](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#sect))
 
Currently, the master branch's response to OPTIONS request contains an `Access-Control-Allow-Origin= `, which is interpreted incorrectly by most browsers. We can't fix it by simply checking for the presence of an `Origin` header in the request, due to the possibility of sending out both `Access-Control-Allow-Credentials=true` and `Access-Control-Allow-Origin=*`. The simple yet correct way to fix that behavior is to specifically check that the request being answered is not an `OPTIONS` one. Such a check is implemented in this pull request. There is also a test added that checks for incorrect `Origins`-`Credentials` behavior.