### PR TITLE
Synchronious write stream handling fix

### DIFF
--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -545,19 +545,25 @@ namespace crow
 
         inline void do_write_sync(std::vector<asio::const_buffer>& buffers)
         {
+            error_code ec;
+            asio::write(adaptor_.socket(), buffers, ec);
 
-            asio::write(adaptor_.socket(), buffers, [&](error_code ec, std::size_t) {
-                if (!ec)
-                {
-                    return false;
-                }
-                else
-                {
-                    CROW_LOG_ERROR << ec << " - happened while sending buffers";
-                    CROW_LOG_DEBUG << this << " from write (sync)(2)";
-                    return true;
-                }
-            });
+            this->res.clear();
+            this->res_body_copy_.clear();
+            if (!this->continue_requested)
+            {
+                this->parser_.clear();
+            }
+            else
+            {
+                this->continue_requested = false;
+            }
+
+            if (ec)
+            {
+                CROW_LOG_ERROR << ec << " - happened while sending buffers";
+                CROW_LOG_DEBUG << this << " from write (sync)(2)";
+            }
         }
 
         void cancel_deadline_timer()

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -550,13 +550,13 @@ namespace crow
 
             this->res.clear();
             this->res_body_copy_.clear();
-            if (!this->continue_requested)
+            if (this->continue_requested)
             {
-                this->parser_.clear();
+                this->continue_requested = false;
             }
             else
             {
-                this->continue_requested = false;
+                this->parser_.clear();
             }
 
             if (ec)

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2171,33 +2171,94 @@ TEST_CASE("middleware_session")
 TEST_CASE("bug_quick_repeated_request")
 {
     SimpleApp app;
+    std::uint8_t explicitTimeout = 5;
+    app.timeout(explicitTimeout);
 
-    CROW_ROUTE(app, "/")
+    std::chrono::microseconds doublingDelay;
+    const int numberOfReruns = 5;
+
+    CROW_ROUTE(app, "/fast")
     ([&] {
+        return "hello";
+    });
+
+    CROW_ROUTE(app, "/slow")
+    ([&] {
+        std::this_thread::sleep_for(doublingDelay);
         return "hello";
     });
 
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(45451).run_async();
     app.wait_for_server_start();
-    std::string sendmsg = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto start = std::chrono::high_resolution_clock::now();
+    std::string sendmsg = "GET /fast HTTP/1.1\r\nHost: localhost\r\n\r\n";
     asio::io_context ic;
+    int messageChecked = 0;
     {
         std::vector<std::future<void>> v;
-        for (int i = 0; i < 5; i++)
+        for (int i = 0; i < numberOfReruns; i++)
         {
             v.push_back(async(launch::async, [&] {
                 HttpClient c(LOCALHOST_ADDRESS, 45451);
 
-                for (int j = 0; j < 5; j++)
+                for (int j = 0; j < numberOfReruns; j++)
                 {
                     c.send(sendmsg);
 
                     auto resp = c.receive();
+                    messageChecked++;
+                    std::cout << resp;
+                    std::cout << "inside test";
                     CHECK("hello" == resp.substr(resp.length() - 5));
                 }
             }));
         }
     }
+
+    while (messageChecked < numberOfReruns * numberOfReruns)
+    {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    messageChecked = 0;
+    auto end = std::chrono::high_resolution_clock::now();
+    auto fastDuration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+
+    doublingDelay = fastDuration / (numberOfReruns * numberOfReruns);
+
+    start = std::chrono::high_resolution_clock::now();
+    sendmsg = "GET /slow HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    {
+        std::vector<std::future<void>> v;
+        for (int i = 0; i < numberOfReruns; i++)
+        {
+            v.push_back(async(launch::async, [&] {
+                HttpClient c(LOCALHOST_ADDRESS, 45451);
+
+                for (int j = 0; j < numberOfReruns; j++)
+                {
+                    c.send(sendmsg);
+
+                    auto resp = c.receive();
+                    messageChecked++;
+                    std::cout << resp;
+                    std::cout << "inside test";
+                    CHECK("hello" == resp.substr(resp.length() - 5));
+                }
+            }));
+        }
+    }
+
+    while (messageChecked < numberOfReruns * numberOfReruns)
+    {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    end = std::chrono::high_resolution_clock::now();
+    auto slowDuration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+
+    /// We allow for a great deal of random variations, since the broken case fails anyway
+    CHECK(slowDuration / fastDuration < 3);
     app.stop();
 } // bug_quick_repeated_request
 


### PR DESCRIPTION
I encountered a problem with handling sequential requests. In particular, some of the responses stalled until timeout. After some research, it was found that the reason for such a behavior was my previous pull request, that changed response handling in a way of making all such handling synchronous. While synchronicity itself has not proven problematic, it was found that some of the response management done in `do_write` is absent in `do_write_sync`. That is, clearing the response body and the http_connection parsers is not done. 

That has been fixed, and `bug_quick_repeated_request` was change in such a way as to show the problem via staling on previous version and passing on current. 