### PR TITLE
Bumped the minimum C++ version from 11 to 17 in docs

### DIFF
--- a/docs/getting_started/setup/linux.md
+++ b/docs/getting_started/setup/linux.md
@@ -2,7 +2,7 @@ Here's how you can install Crow on your favorite GNU/Linux distro.
 ## Getting Crow
 
 ### Requirements
- - C++ compiler with at least C++11 support.
+ - C++ compiler with at least C++17 support.
  - Asio development headers (1.10.9 or later).
  - **(optional)** ZLib for HTTP Compression.
  - **(optional)** OpenSSL for HTTPS support.

--- a/docs/getting_started/setup/macos.md
+++ b/docs/getting_started/setup/macos.md
@@ -90,4 +90,4 @@ g++ main.cpp -lpthread
 
 You can use arguments like `-DCROW_ENABLE_DEBUG`, `-DCROW_ENABLE_COMPRESSION -lz` for HTTP Compression, or `-DCROW_ENABLE_SSL -lssl` for HTTPS support, or even replace g++ with clang++.
 
-If GCC throws errors and your program does not compile, you may be using C++03 instead of ≥C++11. Use the flag `-std=c++11`.
+If GCC throws errors and your program does not compile, you may be using C++03 instead of ≥C++17. Use the flag `-std=c++17`.


### PR DESCRIPTION
In the getting started guide for Linux:

> C++ compiler with at least C++~11~17 support.

In the getting started guide for MacOS:

> If GCC throws errors and your program does not compile, you may be using C++03 instead of ≥C++~11~17. Use the flag `-std=c++~11~17`.