### PR TITLE
Omit Server header when server_name is empty

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -329,7 +329,7 @@ namespace crow
             return *this;
         }
 
-        /// \brief Set the server name
+        /// \brief Set the server name included in the 'Server' HTTP response header. If set to an empty string, the header will be omitted by default.
         self_t& server_name(std::string server_name)
         {
             server_name_ = server_name;

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -365,7 +365,7 @@ namespace crow
                 buffers_.emplace_back(content_length_.data(), content_length_.size());
                 buffers_.emplace_back(crlf.data(), crlf.size());
             }
-            if (!res.headers.count("server"))
+            if (!res.headers.count("server") && !server_name_.empty())
             {
                 static std::string server_tag = "Server: ";
                 buffers_.emplace_back(server_tag.data(), server_tag.size());


### PR DESCRIPTION
According to RFC 9110 Section 10.2.4, the Server header field in responses is optional (MAY be sent).

This change prevents automatically adding the 'Server' header if the application-wide `server_name` is configured to be an empty string via `app.server_name("")`.

Addresses issue #1020