### PR TITLE
FIX: "bind: Address already in use"

### DIFF
--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -184,6 +184,16 @@ namespace crow // NOTE: Already documented in "crow/app.h"
         void stop()
         {
             shutting_down_ = true; // Prevent the acceptor from taking new connections
+
+            // Explicitly close the acceptor
+            // else asio will throw an exception (linux only), when trying to start server again:
+            // what():  bind: Address already in use
+            if (acceptor_.is_open())
+            {
+                CROW_LOG_INFO << "Closing acceptor. " << &acceptor_;
+                acceptor_.close();
+            }
+
             for (auto& io_context : io_context_pool_)
             {
                 if (io_context != nullptr)


### PR DESCRIPTION
There is an issue with crow on linux, when trying to call app.open() after app.close(), that you can't start the server again without restarting your executable manually.

Some issues that mentioned that exception:
https://github.com/CrowCpp/Crow/issues/511
https://github.com/CrowCpp/Crow/issues/752