### PR TITLE
[doc] Default CMake Build Requires Linking Against OpenSSL and Zlib

### DIFF
--- a/docs/getting_started/setup/linux.md
+++ b/docs/getting_started/setup/linux.md
@@ -51,6 +51,24 @@ You can also download the `crow_all.h` file and simply include that into your pr
 
 !!! note
 
+    By default, Crow sets `CROW_ENABLE_SSL=true` and `CROW_ENABLE_COMPRESSION=true` for CMake builds. You must call `find_package` and manually link with these libraries in your build if you keep these defaults.
+
+
+    ```
+    find_package(OpenSSL REQUIRED)
+    find_package(ZLIB REQUIRED)
+
+    target_link_libraries(main
+        PRIVATE
+        OpenSSL::SSL
+        OpenSSL::Crypto
+        ZLIB::ZLIB
+        Crow::Crow
+    )
+    ```
+
+!!! note
+
     You can uninstall Crow at a later time using `make uninstall`.
 
 <br>


### PR DESCRIPTION
Documents that the default CMake build enables `CROW_ENABLE_SSL` and `CROW_ENABLE_COMPRESSION`, so requires linking against `OpenSSL` and `zlib`.

Fixes https://github.com/CrowCpp/Crow/issues/1029