### PR TITLE
Add new template project with Docker support out of the box

### DIFF
--- a/docs/getting_started/project_templates_and_applications.md
+++ b/docs/getting_started/project_templates_and_applications.md
@@ -5,14 +5,24 @@ The repositories mentioned here are 3rd party owned and are not supported or man
 # Template projects 
 
 + [https://github.com/gittiver/crow_template](https://github.com/gittiver/crow_template)
+  
   - Features: 
-    - github template repository
-    - uses CPM for including crow into project
-    - catch2 for testing
+    - Github template repository
+    - Uses CPM for including crow into project
+    - Uses catch2 for testing
 
 + [https://github.com/seobryn/corax-template](https://github.com/seobryn/corax-template)
 
-	- Features
+	- Features:
 		- `Scripts` to Make, Compile and Clean the build
 		- `Libs` Folder to store all the external Libs, Crow is set by default.
 		- Format rules using  `clang-format`
+
++ [https://github.com/landiluigi746/cpp-backend-template](https://github.com/landiluigi746/cpp-backend-template)
+
+  - Features:
+    - Github template repository
+    - Uses CMake as build system
+    - Uses vcpkg as package manager
+    - Format rules using `clang-format`
+    - Docker support out of the box


### PR DESCRIPTION
This change adds a new template project I made to the template projects documentation.
The project integrates Docker and Docker compose support alongside vcpkg as package manager and clang-format to format the code.