### PR TITLE
Clean up: Relocate Method to HTTP server

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -563,10 +563,21 @@ namespace crow
             else
 #endif
             {
-                server_->close_websockets(websockets_);
+                close_websockets(websockets_);
                 if (server_) { server_->stop(); }
             }
         }
+
+        void close_websockets(const std::vector<crow::websocket::connection*>& websockets)
+        {
+            std::vector<crow::websocket::connection*> websockets_to_close = websockets;
+            for (auto websocket : websockets_to_close)
+            {
+                CROW_LOG_INFO << "Quitting Websocket: " << websocket;
+                websocket->close("Websocket Closed");
+            }
+        }
+
 
         void add_websocket(crow::websocket::connection* conn)
         {

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -563,15 +563,14 @@ namespace crow
             else
 #endif
             {
-                close_websockets(websockets_);
+                close_websockets();
                 if (server_) { server_->stop(); }
             }
         }
 
-        void close_websockets(const std::vector<crow::websocket::connection*>& websockets)
+        void close_websockets()
         {
-            std::vector<crow::websocket::connection*> websockets_to_close = websockets;
-            for (auto websocket : websockets_to_close)
+            for (auto websocket : websockets_)
             {
                 CROW_LOG_INFO << "Quitting Websocket: " << websocket;
                 websocket->close("Websocket Closed");

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -563,13 +563,7 @@ namespace crow
             else
 #endif
             {
-                // TODO(EDev): Move these 6 lines to a method in http_server.
-                std::vector<crow::websocket::connection*> websockets_to_close = websockets_;
-                for (auto websocket : websockets_to_close)
-                {
-                    CROW_LOG_INFO << "Quitting Websocket: " << websocket;
-                    websocket->close("Server Application Terminated");
-                }
+                server_->close_websockets(websockets_);
                 if (server_) { server_->stop(); }
             }
         }

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -251,18 +251,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
             io_context_.stop(); // Close main io_service
         }
 
-        void close_websockets(const std::vector<crow::websocket::connection*>& websockets,
-                              const std::string& reason = "Server Application Terminated")
-        {
-            // Make a copy to avoid issues if closing modifies the original collection
-            std::vector<crow::websocket::connection*> websockets_to_close = websockets;
-            for (auto websocket : websockets_to_close)
-            {
-                CROW_LOG_INFO << "Quitting Websocket: " << websocket;
-                websocket->close(reason);
-            }
-        }
-
+        
         uint16_t port() const {
             return acceptor_.local_endpoint().port();
         }

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -251,6 +251,18 @@ namespace crow // NOTE: Already documented in "crow/app.h"
             io_context_.stop(); // Close main io_service
         }
 
+        void close_websockets(const std::vector<crow::websocket::connection*>& websockets,
+                              const std::string& reason = "Server Application Terminated")
+        {
+            // Make a copy to avoid issues if closing modifies the original collection
+            std::vector<crow::websocket::connection*> websockets_to_close = websockets;
+            for (auto websocket : websockets_to_close)
+            {
+                CROW_LOG_INFO << "Quitting Websocket: " << websocket;
+                websocket->close(reason);
+            }
+        }
+
         uint16_t port() const {
             return acceptor_.local_endpoint().port();
         }


### PR DESCRIPTION
This PR addresses the Todo comment :  
// TODO(EDev): Move these 6 lines to a method in http_server.