### PR TITLE
Fix "load balancing" not working

### DIFF
--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -69,6 +69,7 @@ namespace crow
           res_stream_threshold_(handler->stream_threshold()),
           queue_length_(queue_length)
         {
+            queue_length_++;
 #ifdef CROW_ENABLE_DEBUG
             connectionCount++;
             CROW_LOG_DEBUG << "Connection (" << this << ") allocated, total: " << connectionCount;
@@ -77,6 +78,7 @@ namespace crow
 
         ~Connection()
         {
+            queue_length_--;
 #ifdef CROW_ENABLE_DEBUG
             connectionCount--;
             CROW_LOG_DEBUG << "Connection (" << this << ") freed, total: " << connectionCount;


### PR DESCRIPTION
Fixes #1046. Perhaps the intent is clear now @gittiver?


Before this commit, the load balancing does not work. The foundation is there, but in practice, the next connection is always picked. For example, if there are 3 contexts available, it will always go: 0, 1, 2, 0, 1, 2, 0, 1, 2, etc. If 0 is a long running connection, and 1 and 2 are short, it will pick 0 for the next connection and then block waiting for that long running connection to end even though 1 and 2 are free. With this fix, the above example would result in this sequence: 0, 1, 2, 1, 2, 1, 2, 1, 2 (until 0 is done with its long running connection).