### PR TITLE
Use error_code from correct namespace

### DIFF
--- a/include/crow/socket_adaptors.h
+++ b/include/crow/socket_adaptors.h
@@ -148,32 +148,32 @@ namespace crow
 
         void close()
         {
-            asio::error_code ec;
+            error_code ec;
             socket_.close(ec);
         }
 
         void shutdown_readwrite()
         {
-            asio::error_code ec;
+            error_code ec;
             socket_.shutdown(asio::socket_base::shutdown_type::shutdown_both, ec);
         }
 
         void shutdown_write()
         {
-            asio::error_code ec;
+            error_code ec;
             socket_.shutdown(asio::socket_base::shutdown_type::shutdown_send, ec);
         }
 
         void shutdown_read()
         {
-            asio::error_code ec;
+            error_code ec;
             socket_.shutdown(asio::socket_base::shutdown_type::shutdown_receive, ec);
         }
 
         template<typename F>
         void start(F f)
         {
-            f(asio::error_code());
+            f(error_code());
         }
 
         stream_protocol::socket socket_;


### PR DESCRIPTION
When compiling with CROW_USE_BOOST crow points asio::error_code to boost::asio::error_code which is not defined. 
Commit e3ff9238a46844432f685ddaf99b69a5a76ca98e dealt with this, but commit 4fff8146f107747811b07c1424c8b6d4bbea2368 ignored these measures.