### PR TITLE
Populate headers for HTTP OPTIONS requests

### DIFF
--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -163,7 +163,7 @@ namespace crow
                     is_invalid_request = true;
                     res = response(400);
                 }
-                else if (req_.upgrade)
+                else if (req_.upgrade && req_.method != HTTPMethod::Options)
                 {
                     // h2 or h2c headers
                     if (req_.get_header_value("upgrade").find("h2")==0)

--- a/include/crow/http_connection.h
+++ b/include/crow/http_connection.h
@@ -113,7 +113,7 @@ namespace crow
         {
             routing_handle_result_ = handler_->handle_initial(req_, res);
             // if no route is found for the request method, return the response without parsing or processing anything further.
-            if (!routing_handle_result_->rule_index)
+            if (!routing_handle_result_->rule_index && req_.method != HTTPMethod::Options)
             {
                 parser_.done();
                 need_to_call_after_handlers_ = true;
@@ -131,6 +131,12 @@ namespace crow
                 static std::string expect_100_continue = "HTTP/1.1 100 Continue\r\n\r\n";
                 buffers_.emplace_back(expect_100_continue.data(), expect_100_continue.size());
                 do_write_sync(buffers_);
+            }
+            if (!routing_handle_result_->rule_index && req_.method == HTTPMethod::Options)
+            {
+                parser_.done();
+                need_to_call_after_handlers_ = true;
+                complete_request();
             }
         }
 


### PR DESCRIPTION
When running middleware for an HTTP OPTIONS request (for CORS for example). There is a bug where the headers from the request are not populated. Also referenced here: https://github.com/CrowCpp/Crow/issues/721#issuecomment-2219910627.

The reason this occurs is because the parser will parse the URL first (before the headers) and in the `handle_url` function, it will end parsing the request early, returning the response, and triggering the middleware.


The proposed changes will prevent us from exiting early in the `handle_url` function and instead exit early at the `handle_headers` function, which is executed when all of the headers have finished parsing.

It is also important to note that OPTIONS requests are fully handled within crow, and crow will never call a user defined OPTIONS route.

I believe this Fixes #721.