### PR TITLE
update OSS-Fuzz build script

### DIFF
--- a/tests/fuzz/build.sh
+++ b/tests/fuzz/build.sh
@@ -1,8 +1,7 @@
-cd $SRC/crow
-mkdir -p build
-cmake -S . -B build -DCROW_BUILD_FUZZER=ON -DCROW_BUILD_EXAMPLES=OFF -DCROW_BUILD_TESTS=OFF && cmake --build build --target install
-
-# Build the corpora
-cd tests/fuzz
+mkdir -p build && cd build
+cmake .. -DCROW_BUILD_FUZZER=ON -DCROW_BUILD_EXAMPLES=OFF -DCROW_BUILD_TESTS=ON
+cmake --build . --target install
+make -j$(nproc)
+cd ../tests/fuzz
 zip -q $OUT/template_fuzzer_seed_corpus.zip template_corpus/*
 zip -q $OUT/request_fuzzer_seed_corpus.zip html_corpus/*


### PR DESCRIPTION
I am enabling tests as part of OSS-Fuzz Chronos here: https://github.com/google/oss-fuzz/pull/13672

I have copy pasted the build script over and made the changes there, and this PR adds the changes here so Crow can revert to using its own upstream build script.