### PR TITLE
Add is_bound() helper for checking server bind state

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -323,6 +323,16 @@ namespace crow
             }
         }
 
+        /// \brief Set status variable to note that the address that Crow will handle requests on is bound
+        void address_is_bound() {
+           is_bound_ = true;
+        }
+
+        /// \brief Get whether address that Crow will handle requests on is bound
+        bool is_bound() const {
+           return is_bound_;
+        }
+
         /// \brief Set the connection timeout in seconds (default is 5)
         self_t& timeout(std::uint8_t timeout)
         {
@@ -803,6 +813,7 @@ namespace crow
         std::uint8_t timeout_{5};
         uint16_t port_ = 80;
         unsigned int concurrency_ = 2;
+        std::atomic_bool is_bound_ = false;
         uint64_t max_payload_{UINT64_MAX};
         std::string server_name_ = std::string("Crow/") + VERSION;
         std::string bindaddr_ = "0.0.0.0";

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -200,6 +200,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                   });
             }
             handler_->port(acceptor_.port());
+            handler_->address_is_bound();
             CROW_LOG_INFO << server_name_ 
                           << " server is running at " << acceptor_.url_display(handler_->ssl_used()) 
                           << " using " << concurrency_ << " threads";


### PR DESCRIPTION
I have a use case where my application passes port 0 to Crow, so that the system chooses an available port dynamically. After that, I need to determine which address and port Crow actually bound to, using bindaddr().

However, I want to avoid calling bindaddr() until I know that Crow has successfully bound the socket. To support this, this PR adds a small helper function is_bound() that lets an application check whether Crow has completed its bind step.