### PR TITLE
Adds SBOM generation using cmake-sbom

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,8 @@ option(CROW_BUILD_TESTS        "Build the tests in the project"         ${CROW_I
 option(CROW_BUILD_FUZZER       "Instrument and build Crow fuzzer"       OFF)
 option(CROW_AMALGAMATE         "Combine all headers into one"           OFF)
 option(CROW_INSTALL            "Add install step for Crow"              ON )
-option(CROW_USE_BOOST          "Use Asio for Crow"                			OFF)
-option(CROW_GENERATE_SBOM      "Generate SBOM file" 										OFF)
+option(CROW_USE_BOOST          "Use Boost.Asio for Crow"                OFF)
+option(CROW_GENERATE_SBOM      "Generate SBOM file"                     OFF)
 option(CROW_RETURNS_OK_ON_HTTP_OPTIONS_REQUEST
 		"Returns HTTP status code OK (200) instead of 204 for OPTIONS request"
 		OFF )


### PR DESCRIPTION
This PR implements the generation of SBOM as request in https://github.com/CrowCpp/Crow/issues/1043.

It adds https://github.com/DEMCON/cmake-sbom as a submodule and uses it to create the SBOM file which contains all the dependencies.
To control whether to generate the SBOM or not, a new compilation flag has been added.