### PR TITLE
Adds Boost to ci

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -82,6 +82,12 @@ jobs:
               else
                   cmake_flags="-DCMAKE_CXX_COMPILER=g++"
               fi
+
+              if [ "${{ matrix.asio_type }}" == "boost" ]; then
+                  cmake_flags="${cmake_flags} -DCROW_USE_BOOST=ON"
+              else
+                  cmake_flags="${cmake_flags} -DCROW_USE_BOOST=OFF"
+              fi
          fi
 
          cmake \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -131,10 +131,10 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       if: matrix.os == 'ubuntu-latest'
-      with: 
+      with:
         name: packages
         path: ${{github.workspace}}/build/Crow-*
-    
+
     #- name: Source package
     #  working-directory: ${{github.workspace}}/build
     #  run: cpack --config CPackSourceConfig.cmake

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,17 +25,33 @@ jobs:
               ubuntu-22.04,
               macos-13
             ]
+        asio_type: [ standalone, boost ]
+        exclude:
+          - os: windows-latest
+            asio_type: boost
+          - os: macos-latest
+            asio_type: boost
+          - os: macos-13
+            asio_type: boost
     steps:
     - uses: actions/checkout@v4
     - name: Prepare dependencies
       run: |
          if [ "$RUNNER_OS" == "Linux" ]; then
-              sudo apt-get update && \
-              sudo apt-get install -yq \
-                libasio-dev \
-                libssl-dev zlib1g-dev \
-                cmake \
-                g++ clang
+              sudo apt-get update
+              if [ "${{ matrix.asio_type }}" == "boost" ]; then
+                  sudo apt-get install -yq \
+                    libboost-all-dev \
+                    libssl-dev zlib1g-dev \
+                    cmake \
+                    g++ clang
+              else
+                  sudo apt-get install -yq \
+                    libasio-dev \
+                    libssl-dev zlib1g-dev \
+                    cmake \
+                    g++ clang
+              fi
          elif [ "$RUNNER_OS" == "Windows" ]; then
               VCPKG_DEFAULT_TRIPLET=x64-windows vcpkg install
          elif [ "$RUNNER_OS" == "macOS" ]; then

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,13 +25,8 @@ jobs:
               ubuntu-22.04,
               macos-13
             ]
-        asio_type: [ standalone, boost ]
-        exclude:
-          - os: windows-latest
-            asio_type: boost
-          - os: macos-latest
-            asio_type: boost
-          - os: macos-13
+        include:
+          - os: ubuntu-latest
             asio_type: boost
     steps:
     - uses: actions/checkout@v4
@@ -39,7 +34,7 @@ jobs:
       run: |
          if [ "$RUNNER_OS" == "Linux" ]; then
               sudo apt-get update
-              if [ "${{ matrix.asio_type }}" == "boost" ]; then
+              if [ "${{ matrix.asio_type || 'standalone' }}" == "boost" ]; then
                   sudo apt-get install -yq \
                     libboost-all-dev \
                     libssl-dev zlib1g-dev \
@@ -83,7 +78,7 @@ jobs:
                   cmake_flags="-DCMAKE_CXX_COMPILER=g++"
               fi
 
-              if [ "${{ matrix.asio_type }}" == "boost" ]; then
+              if [ "${{ matrix.asio_type || 'standalone' }}" == "boost" ]; then
                   cmake_flags="${cmake_flags} -DCROW_USE_BOOST=ON"
               else
                   cmake_flags="${cmake_flags} -DCROW_USE_BOOST=OFF"


### PR DESCRIPTION
The compilation error reported in https://github.com/CrowCpp/Crow/issues/1069 made it to master because the the cmake variable `CROW_USE_BOOST` is set to false in all the CI combinations.

This PR adds to the CI matrix the `asio_type` option which is only populated for `ubuntu-latest`. In practice this adds an additional workflow to the CI which builds and tests using boost::asio instead of standalone asio.

This should prevent compilation or functional error to reach master when these errors only arise when using boost::asio.