### PR TITLE
Documentation Dark Mode Font/Background (Issue #695)

### DIFF
--- a/docs/stylesheets/colors.css
+++ b/docs/stylesheets/colors.css
@@ -29,7 +29,7 @@
     --md-default-fg-color--lightest: rgba(255, 255, 255, 0.07);
     --md-typeset-a-color: var(--md-accent-fg-color) !important;
     --md-default-bg-color: #1a2124;
-    --md-code-bg-color: #101010 !important; 
+    --md-code-bg-color: #282828 !important; 
     --md-code-hl-comment-color: var(--md-code-fg-color) !important;
     --md-code-hl-generic-color: var(--md-code-fg-color) !important;
     --md-code-hl-variable-color: var(--md-code-fg-color) !important;
@@ -44,7 +44,7 @@
     --md-default-tag-bg-color: var(--md-default-fg-color);
     
     .highlight .c, .highlight .c1, .highlight .ch, .highlight .cm, .highlight .cs, .highlight .sd {
-    color: #a0a0a0 !important;
+    color: #a0a0a0!important;
     }
 
 }

--- a/docs/stylesheets/colors.css
+++ b/docs/stylesheets/colors.css
@@ -29,12 +29,12 @@
     --md-default-fg-color--lightest: rgba(255, 255, 255, 0.07);
     --md-typeset-a-color: var(--md-accent-fg-color) !important;
     --md-default-bg-color: #1a2124;
-    --md-code-bg-color: #101010 !important;
+    --md-code-bg-color: #101010 !important; 
     --md-code-hl-comment-color: var(--md-code-fg-color) !important;
     --md-code-hl-generic-color: var(--md-code-fg-color) !important;
     --md-code-hl-variable-color: var(--md-code-fg-color) !important;
     --md-code-hl-operator-color: var(--md-code-fg-color) !important;
-    --md-code-fg-color: #cfcfcf !important;
+    --md-code-fg-color: #e0e0e0 !important;
     --md-code-hl-punctuation-color: #adadad !important;
     --home-border-color: #ffffff20;
     --home-shadow-color: #00000040;
@@ -42,6 +42,10 @@
     --md-admonition-bg-color: #272a2b;
     --md-code-hl-color: rgba(255, 255, 0, 0.18);
     --md-default-tag-bg-color: var(--md-default-fg-color);
+    
+    .highlight .c, .highlight .c1, .highlight .ch, .highlight .cm, .highlight .cs, .highlight .sd {
+    color: #a0a0a0 !important;
+    }
 
 }
 
@@ -66,7 +70,7 @@
 
 
 .highlight .c, .highlight .c1, .highlight .ch, .highlight .cm, .highlight .cs, .highlight .sd {
-    color: #606060 !important;
+    color: #a0a0a0 !important;
 }
 
 .linenos {

--- a/docs/stylesheets/colors.css
+++ b/docs/stylesheets/colors.css
@@ -70,7 +70,7 @@
 
 
 .highlight .c, .highlight .c1, .highlight .ch, .highlight .cm, .highlight .cs, .highlight .sd {
-    color: #a0a0a0 !important;
+    color: #606060 !important;
 }
 
 .linenos {


### PR DESCRIPTION
I added the suggested changes from the issue description.

1. changed `--md-code-bg-color` from `#101010` to `#282828`.

2.  changed `--md-code-fg-color` from `#cfcfcf` to `#e0e0e0`.

3. and `.highlight .c, .highlight .c1, .highlight .ch, .highlight .cm, .highlight .cs, .highlight .sd` from `#606060` to `#a0a0a0`. and then I will write how it improved the readability from the original to the new

4. I also tested out `#222222 `and `#282828` for the background color and I think either one of these make it a bit easier to read compared to `#282828`. I can send these over if you'd like to compare.

<img width="1080" height="509" alt="Crow before" src="https://github.com/user-attachments/assets/6bf37cf5-edf8-4fff-8b2f-bc4cd7cd913e" />
<img width="1291" height="508" alt="Crow After" src="https://github.com/user-attachments/assets/551b85cc-1a68-4f52-8ef0-ec75750dcb50" />


