### PR TITLE
Refactors Build and Test CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,6 +3,8 @@ name: Build and test
 on:
   push:
     branches: [ "master" ]
+    tags:
+      - "v*"
   pull_request:
     branches: [ "master" ]
 
@@ -12,22 +14,23 @@ env:
 
 jobs:
   build:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
-        os: [ ubuntu-latest,
-              windows-latest,
-              macos-latest,
-              ubuntu-22.04,
-              macos-13
-            ]
         include:
-          - os: ubuntu-latest
-            asio_type: boost
+          - { os: ubuntu-latest, compiler: gcc,   cxx_stdlib: libstdc++, asio_type: boost }
+          - { os: ubuntu-latest, compiler: gcc,   cxx_stdlib: libstdc++, asio_type: standalone }
+          - { os: ubuntu-latest, compiler: clang, cxx_stdlib: libstdc++, asio_type: boost }
+          - { os: ubuntu-latest, compiler: clang, cxx_stdlib: libstdc++, asio_type: standalone }
+          - { os: ubuntu-latest, compiler: clang, cxx_stdlib: libc++,    asio_type: boost }
+          - { os: ubuntu-latest, compiler: clang, cxx_stdlib: libc++,    asio_type: standalone }
+          - { os: ubuntu-22.04,  compiler: gcc,   cxx_stdlib: libstdc++ }
+          - { os: macos-latest,  compiler: clang, cxx_stdlib: libstdc++ }
+          - { os: macos-latest,  compiler: clang, cxx_stdlib: libc++ }
+          - { os: macos-13,      compiler: clang, cxx_stdlib: libc++ }
+          - { os: windows-latest, compiler: msvc, cxx_stdlib: msvc }
+
     steps:
     - uses: actions/checkout@v5
     - name: Prepare dependencies
@@ -107,7 +110,7 @@ jobs:
       shell: bash
 
     - name: Generate coverage report
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc' && matrix.cxx_stdlib == 'libstdc++' && matrix.asio_type == 'boost'
       run: |
         export CI_BRANCH=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
         echo "CI_BRANCH=$CI_BRANCH" >> $GITHUB_ENV && \
@@ -130,12 +133,21 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: cmake --build . --target package
 
+    - name: Generate checksums
+      if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc' && matrix.cxx_stdlib == 'libstdc++' && matrix.asio_type == 'boost' && startsWith(github.ref, 'refs/tags/v')
+      working-directory: ${{github.workspace}}/build
+      run: |
+        for f in Crow-* crow_all.h; do
+          [ -f "$f" ] || continue
+          sha256sum "$f" | awk '{print $1}' > "$f".sha256
+          md5sum "$f"    | awk '{print $1}' > "$f".md5
+        done
+
     - uses: actions/upload-artifact@v4
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc' && matrix.cxx_stdlib == 'libstdc++' && matrix.asio_type == 'boost' && startsWith(github.ref, 'refs/tags/v')
       with:
         name: packages
-        path: ${{github.workspace}}/build/Crow-*
-
-    #- name: Source package
-    #  working-directory: ${{github.workspace}}/build
-    #  run: cpack --config CPackSourceConfig.cmake
+        path: |
+          ${{github.workspace}}/build/Crow-*
+          ${{github.workspace}}/build/crow_all.h
+          ${{github.workspace}}/build/crow_all.h.*


### PR DESCRIPTION
This PR introduces a few changes to the Build and Test CI. These changes address multiple open issues:

- Conditional execution is added to the artifacts upload step so that the artifacts are only uploaded when the workflow is started by pushing a new tag which follows the pattern `v*` (this matches the current version tags). This should solve: #935
- It adds a step which is conditionally executed for new versions which calculate the SHA256 and the MD5 for the artifacts and uploads the digest together with the artifacts. This should solve: #1031 
- Adds crow_all.h to the artifacts that are updated. This should solve: #824 
- Fixes the bug described in #1078 by modifying the execution matrix for the action.
- Removes a stale comment from the action file
