### PR TITLE
include CPM via CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(Crow
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-include(${CMAKE_SOURCE_DIR}/cmake/CPM.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CPM.cmake)
 
 # Make sure Findasio.cmake module is found
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)


### PR DESCRIPTION
This again allows crow to be used as a CMake subproject. This broke in #1066, as CMAKE_SOURCE_DIR refers to the directory of the root CMakeLists.txt. And when being used from a toplevel project, ${CMAKE_SOURCE_DIR}/cmake/CPM.cmake would not refer to crow's copy of CPM. This change makes the reference relative to the location of the CMakeLists.txt requiring the include.