### PR TITLE
Add option to search for boost if enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,6 +299,12 @@ if(CROW_INSTALL)
 		DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Crow"
 	)
 
+	if(CROW_USE_BOOST)
+		set(CROW_ASIO_PROVIDER "Boost 1.64 COMPONENTS system date_time REQUIRED")
+	else()
+		set(CROW_ASIO_PROVIDER "asio")
+	endif()
+
 	include(CMakePackageConfigHelpers)
 	configure_package_config_file(
 		"${CMAKE_CURRENT_SOURCE_DIR}/cmake/CrowConfig.cmake.in"

--- a/cmake/CrowConfig.cmake.in
+++ b/cmake/CrowConfig.cmake.in
@@ -5,7 +5,7 @@ include(CMakeFindDependencyMacro)
 get_filename_component(CROW_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
 list(APPEND CMAKE_MODULE_PATH ${CROW_CMAKE_DIR})
-find_dependency(asio)
+find_dependency(@CROW_ASIO_PROVIDER@)
 list(REMOVE_AT CMAKE_MODULE_PATH -1)
 
 set(CROW_INSTALLED_FEATURES "@CROW_FEATURES@")


### PR DESCRIPTION
This changes is relative to find dependencies, it sets to find asio relative to the chosen build, if you choose to build with boost, is expected to not find asio. So, if boost is chosen as asio provider, boost will be required to be found on the cmake target. 