### PR TITLE
Add content type to set static file info

### DIFF
--- a/include/crow/http_response.h
+++ b/include/crow/http_response.h
@@ -284,15 +284,16 @@ namespace crow
             int statResult;
         };
 
-        /// Return a static file as the response body
-        void set_static_file_info(std::string path)
+        /// Return a static file as the response body, the content_type may be specified explicitly.
+        void set_static_file_info(std::string path, std::string content_type = "")
         {
             utility::sanitize_filename(path);
-            set_static_file_info_unsafe(path);
+            set_static_file_info_unsafe(path, content_type);
         }
 
-        /// Return a static file as the response body without sanitizing the path (use set_static_file_info instead)
-        void set_static_file_info_unsafe(std::string path)
+        /// Return a static file as the response body without sanitizing the path (use set_static_file_info instead),
+        /// the content_type may be specified explicitly.
+        void set_static_file_info_unsafe(std::string path, std::string content_type = "")
         {
             file_info.path = path;
             file_info.statResult = stat(file_info.path.c_str(), &file_info.statbuf);
@@ -306,9 +307,16 @@ namespace crow
                 code = 200;
                 this->add_header("Content-Length", std::to_string(file_info.statbuf.st_size));
 
-                if (!extension.empty())
+                if (content_type.empty())
                 {
-                    this->add_header("Content-Type", get_mime_type(extension));
+                    if (!extension.empty())
+                    {
+                        this->add_header("Content-Type", get_mime_type(extension));
+                    }
+                }
+                else
+                {
+                    this->add_header("Content-Type", content_type);
                 }
             }
             else

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2289,7 +2289,7 @@ TEST_CASE("simple_url_params")
     // check multiple value, multiple types
     HttpClient::request(LOCALHOST_ADDRESS, 45451,
                         "GET /params?int=100&double=123.45&boolean=1\r\n\r\n");
-    
+
     CHECK(utility::lexical_cast<int>(last_url_params.get("int")) == 100);
     REQUIRE_THAT(123.45, Catch::Matchers::WithinAbs(utility::lexical_cast<double>(last_url_params.get("double")), 1e-9));
     CHECK(utility::lexical_cast<bool>(last_url_params.get("boolean")));
@@ -2600,6 +2600,12 @@ TEST_CASE("send_file")
         res.end();
     });
 
+    CROW_ROUTE(app, "/jpg3")
+    ([](const crow::request&, crow::response& res) {
+        res.set_static_file_info("tests/img/cat.jpg", "application/octet-stream"); // Set Content-Type explicitly
+        res.end();
+    });
+
     CROW_ROUTE(app, "/filewith.badext")
     ([](const crow::request&, crow::response& res) {
         res.set_static_file_info("tests/img/filewith.badext");
@@ -2636,6 +2642,27 @@ TEST_CASE("send_file")
         CHECK(res.headers.count("Content-Type"));
         if (res.headers.count("Content-Type"))
             CHECK("image/jpeg" == res.headers.find("Content-Type")->second);
+
+        CHECK(res.headers.count("Content-Length"));
+        if (res.headers.count("Content-Length"))
+            CHECK(to_string(statbuf_cat.st_size) == res.headers.find("Content-Length")->second);
+    }
+
+    // Explicit Content-Type:
+    {
+        request req;
+        response res;
+
+        req.url = "/jpg3";
+        req.http_ver_major = 1;
+
+        app.handle_full(req, res);
+
+        CHECK(200 == res.code);
+
+        CHECK(res.headers.count("Content-Type"));
+        if (res.headers.count("Content-Type"))
+            CHECK("application/octet-stream" == res.headers.find("Content-Type")->second);
 
         CHECK(res.headers.count("Content-Length"));
         if (res.headers.count("Content-Length"))


### PR DESCRIPTION
This extension allows to set the Content-Type of a file within `set_static_file_info` and `set_static_file_info_unsafe` explicitly.
An optional argument `content_type` may be used to set the Content-Type explicitly, default is as it was before (the file extension is used to define the Content-Type)