### PR TITLE
Refactor routing_params test and isolate HTTP response tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,10 +19,18 @@ CPMAddPackage(Catch2
   
 enable_testing()
 
+# Explicitly list the top-level test sources
 set(TEST_SRCS
   unittest.cpp
   query_string_tests.cpp
 )
+
+# Automatically add all sources under unit_tests/
+file(GLOB_RECURSE UNIT_TEST_SRCS
+  "${CMAKE_CURRENT_SOURCE_DIR}/unit_tests/*.cpp"
+)
+
+list(APPEND TEST_SRCS ${UNIT_TEST_SRCS})
 
 add_executable(unittest ${TEST_SRCS})
 target_link_libraries(unittest Crow::Crow Catch2::Catch2WithMain)

--- a/tests/unit_tests/test_http_response.cpp
+++ b/tests/unit_tests/test_http_response.cpp
@@ -1,0 +1,47 @@
+#include "catch2/catch_all.hpp"
+
+#include "crow.h"
+
+using namespace crow;
+
+TEST_CASE("custom_content_types")
+{
+    // standard behaviour: content type is a key of mime_types
+    CHECK("text/html" == response("html", "").get_header_value("Content-Type"));
+    CHECK("image/jpeg" == response("jpg", "").get_header_value("Content-Type"));
+    CHECK("video/mpeg" == response("mpg", "").get_header_value("Content-Type"));
+
+    // content type is already a valid mime type
+    CHECK("text/csv" == response("text/csv", "").get_header_value("Content-Type"));
+    CHECK("application/xhtml+xml" == response("application/xhtml+xml", "").get_header_value("Content-Type"));
+    CHECK("font/custom;parameters=ok" == response("font/custom;parameters=ok", "").get_header_value("Content-Type"));
+
+    // content type looks like a mime type, but is invalid
+    // note: RFC6838 only allows a limited set of parent types:
+    // https://datatracker.ietf.org/doc/html/rfc6838#section-4.2.7
+    //
+    // These types are: application, audio, font, example, image, message,
+    //                  model, multipart, text, video
+
+    CHECK("text/plain" == response("custom/type", "").get_header_value("Content-Type"));
+
+    // content type does not look like a mime type.
+    CHECK("text/plain" == response("notarealextension", "").get_header_value("Content-Type"));
+    CHECK("text/plain" == response("image/", "").get_header_value("Content-Type"));
+    CHECK("text/plain" == response("/json", "").get_header_value("Content-Type"));
+
+} // custom_content_types
+
+TEST_CASE("simple_response")
+{
+    CHECK(100 == response(100).code);
+    CHECK(200 == response("Hello there").code);
+    CHECK(500 == response(500, "Internal Error?").code);
+
+    CHECK(100 == response(100, "xml", "").code);
+    CHECK("text/xml" == response(100, "xml", "").get_header_value("Content-Type"));
+    CHECK(200 == response(200, "html", "").code);
+    CHECK("text/html" == response(200, "html", "").get_header_value("Content-Type"));
+    CHECK(500 == response(500, "html", "Internal Error?").code);
+    CHECK("text/css" == response(500, "css", "Internal Error?").get_header_value("Content-Type"));
+}

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -341,19 +341,8 @@ TEST_CASE("RoutingTest")
     }
 } // RoutingTest
 
-TEST_CASE("simple_response_routing_params")
+TEST_CASE("routing_params")
 {
-    CHECK(100 == response(100).code);
-    CHECK(200 == response("Hello there").code);
-    CHECK(500 == response(500, "Internal Error?").code);
-
-    CHECK(100 == response(100, "xml", "").code);
-    CHECK("text/xml" == response(100, "xml", "").get_header_value("Content-Type"));
-    CHECK(200 == response(200, "html", "").code);
-    CHECK("text/html" == response(200, "html", "").get_header_value("Content-Type"));
-    CHECK(500 == response(500, "html", "Internal Error?").code);
-    CHECK("text/css" == response(500, "css", "Internal Error?").get_header_value("Content-Type"));
-
     routing_params rp;
     rp.int_params.push_back(1);
     rp.int_params.push_back(5);
@@ -365,35 +354,7 @@ TEST_CASE("simple_response_routing_params")
     CHECK(2 == rp.get<uint64_t>(0));
     REQUIRE_THAT(3, Catch::Matchers::WithinAbs(rp.get<double>(0), 1e-9));
     CHECK("hello" == rp.get<string>(0));
-} // simple_response_routing_params
-
-TEST_CASE("custom_content_types")
-{
-    // standard behaviour: content type is a key of mime_types
-    CHECK("text/html" == response("html", "").get_header_value("Content-Type"));
-    CHECK("image/jpeg" == response("jpg", "").get_header_value("Content-Type"));
-    CHECK("video/mpeg" == response("mpg", "").get_header_value("Content-Type"));
-
-    // content type is already a valid mime type
-    CHECK("text/csv" == response("text/csv", "").get_header_value("Content-Type"));
-    CHECK("application/xhtml+xml" == response("application/xhtml+xml", "").get_header_value("Content-Type"));
-    CHECK("font/custom;parameters=ok" == response("font/custom;parameters=ok", "").get_header_value("Content-Type"));
-
-    // content type looks like a mime type, but is invalid
-    // note: RFC6838 only allows a limited set of parent types:
-    // https://datatracker.ietf.org/doc/html/rfc6838#section-4.2.7
-    //
-    // These types are: application, audio, font, example, image, message,
-    //                  model, multipart, text, video
-
-    CHECK("text/plain" == response("custom/type", "").get_header_value("Content-Type"));
-
-    // content type does not look like a mime type.
-    CHECK("text/plain" == response("notarealextension", "").get_header_value("Content-Type"));
-    CHECK("text/plain" == response("image/", "").get_header_value("Content-Type"));
-    CHECK("text/plain" == response("/json", "").get_header_value("Content-Type"));
-
-} // custom_content_types
+} // routing_params
 
 TEST_CASE("handler_with_response")
 {


### PR DESCRIPTION
Unit tests that only depend on ```crow::response``` were moved to ```unit_tests/test_http_response.cpp```.

This is a proof-of-concept for splitting the monolithic file ```uinttest.cpp``` into multiple files that map one-to-one to files in ```include/crow```.
The aims of this refactor are to:
 - Improve the readability and maintainability of unit tests.
 -  Simplify onboarding for new developers.
 - Enable more granular testing and improve overall test coverage.

Below is a comparison between outputs before and after the refactor to validate that only the intended changes were made.

## tests/unittest:
There is one more test than before because "simple_response_routing_params" was split into "simple_response" and "routing_params".
### Before:
```
All tests passed (872 assertions in 93 test cases)
```
### After:
```
All tests passed (872 assertions in 94 test cases)
```

## test/unittest "custom_content_type"
No change.
### Before:
```
Filters: "custom_content_types"
Randomness seeded to: 1196796123
(2025-09-15 15:05:54) [WARNING ] Unable to interpret mime type for content type 'custom/type'. Defaulting to text/plain.
(2025-09-15 15:05:54) [WARNING ] Unable to interpret mime type for content type 'notarealextension'. Defaulting to text/plain.
(2025-09-15 15:05:54) [WARNING ] Unable to interpret mime type for content type 'image/'. Defaulting to text/plain.
(2025-09-15 15:05:54) [WARNING ] Unable to interpret mime type for content type '/json'. Defaulting to text/plain.
===============================================================================
All tests passed (10 assertions in 1 test case)
```
### After:
```
Filters: "custom_content_types"
Randomness seeded to: 3563733199
(2025-09-15 15:05:33) [WARNING ] Unable to interpret mime type for content type 'custom/type'. Defaulting to text/plain.
(2025-09-15 15:05:33) [WARNING ] Unable to interpret mime type for content type 'notarealextension'. Defaulting to text/plain.
(2025-09-15 15:05:33) [WARNING ] Unable to interpret mime type for content type 'image/'. Defaulting to text/plain.
(2025-09-15 15:05:33) [WARNING ] Unable to interpret mime type for content type '/json'. Defaulting to text/plain.
===============================================================================
All tests passed (10 assertions in 1 test case)
```

## test/unittest "simple_response_routing_params":
Outputs are equivalent in aggregate.
### Before:
```
Filters: "simple_response_routing_params"
Randomness seeded to: 3649381328
===============================================================================
All tests passed (14 assertions in 1 test case)
```
### After:
```
Filters: "simple_response"
Randomness seeded to: 4187677161
===============================================================================
All tests passed (9 assertions in 1 test case)
```
```
Filters: "routing_params"
Randomness seeded to: 124073252
===============================================================================
All tests passed (5 assertions in 1 test case)
```

