### PR TITLE
Fix a regression on MacOS

### DIFF
--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <array>
 #include <memory>
+#include <thread>
 #include "crow/logging.h"
 #include "crow/socket_adaptors.h"
 #include "crow/http_request.h"


### PR DESCRIPTION
On apple cland updated as of mid august the compiler complains about std::this_thread::yeld() missing See also https://github.com/CrowCpp/Crow/pull/1094