### PR TITLE
Fix potential use-after-free of Connection from Asio thread

### DIFF
--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -257,22 +257,22 @@ namespace crow // NOTE: Already documented in "crow/app.h"
             /// Sets a flag to destroy the object once the message is sent.
             void close(std::string const& msg, uint16_t status_code) override
             {
-                dispatch([this, shared_this = this->shared_from_this(), msg, status_code]() mutable {
-                    has_sent_close_ = true;
-                    if (has_recv_close_ && !is_close_handler_called_)
+                dispatch([shared_this = this->shared_from_this(), msg, status_code]() mutable {
+                    shared_this->has_sent_close_ = true;
+                    if (shared_this->has_recv_close_ && !shared_this->is_close_handler_called_)
                     {
-                        is_close_handler_called_ = true;
-                        if (close_handler_)
-                            close_handler_(*this, msg, status_code);
+                        shared_this->is_close_handler_called_ = true;
+                        if (shared_this->close_handler_)
+                            shared_this->close_handler_(*shared_this, msg, status_code);
                     }
-                    auto header = build_header(0x8, msg.size() + 2);
+                    auto header = shared_this->build_header(0x8, msg.size() + 2);
                     char status_buf[2];
                     *(uint16_t*)(status_buf) = htons(status_code);
 
-                    write_buffers_.emplace_back(std::move(header));
-                    write_buffers_.emplace_back(std::string(status_buf, 2));
-                    write_buffers_.emplace_back(msg);
-                    do_write();
+                    shared_this->write_buffers_.emplace_back(std::move(header));
+                    shared_this->write_buffers_.emplace_back(std::string(status_buf, 2));
+                    shared_this->write_buffers_.emplace_back(msg);
+                    shared_this->do_write();
                 });
             }
 
@@ -371,15 +371,15 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                         //asio::async_read(adaptor_.socket(), asio::buffer(&mini_header_, 1),
                         adaptor_.socket().async_read_some(
                           asio::buffer(&mini_header_, 2),
-                          [this, shared_this = this->shared_from_this()](const error_code& ec, std::size_t
+                          [shared_this = this->shared_from_this()](const error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
                                                                bytes_transferred
 #endif
                           )
 
                           {
-                              is_reading = false;
-                              mini_header_ = ntohs(mini_header_);
+                              shared_this->is_reading = false;
+                              shared_this->mini_header_ = ntohs(shared_this->mini_header_);
 #ifdef CROW_ENABLE_DEBUG
 
                               if (!ec && bytes_transferred != 2)
@@ -390,45 +390,45 @@ namespace crow // NOTE: Already documented in "crow/app.h"
 
                               if (!ec)
                               {
-                                  if ((mini_header_ & 0x80) == 0x80)
-                                      has_mask_ = true;
+                                  if ((shared_this->mini_header_ & 0x80) == 0x80)
+                                      shared_this->has_mask_ = true;
                                   else //if the websocket specification is enforced and the message isn't masked, terminate the connection
                                   {
 #ifndef CROW_ENFORCE_WS_SPEC
-                                      has_mask_ = false;
+                                      shared_this->has_mask_ = false;
 #else
-                                      close_connection_ = true;
-                                      adaptor_.shutdown_readwrite();
-                                      adaptor_.close();
-                                      if (error_handler_)
-                                          error_handler_(*this, "Client connection not masked.");
-                                      check_destroy(CloseStatusCode::UnacceptableData);
+                                      shared_this->close_connection_ = true;
+                                      shared_this->adaptor_.shutdown_readwrite();
+                                      shared_this->adaptor_.close();
+                                      if (shared_this->error_handler_)
+                                          shared_this->error_handler_(*shared_this, "Client connection not masked.");
+                                      shared_this->check_destroy(CloseStatusCode::UnacceptableData);
 #endif
                                   }
 
-                                  if ((mini_header_ & 0x7f) == 127)
+                                  if ((shared_this->mini_header_ & 0x7f) == 127)
                                   {
-                                      state_ = WebSocketReadState::Len64;
+                                      shared_this->state_ = WebSocketReadState::Len64;
                                   }
-                                  else if ((mini_header_ & 0x7f) == 126)
+                                  else if ((shared_this->mini_header_ & 0x7f) == 126)
                                   {
-                                      state_ = WebSocketReadState::Len16;
+                                      shared_this->state_ = WebSocketReadState::Len16;
                                   }
                                   else
                                   {
-                                      remaining_length_ = mini_header_ & 0x7f;
-                                      state_ = WebSocketReadState::Mask;
+                                      shared_this->remaining_length_ = shared_this->mini_header_ & 0x7f;
+                                      shared_this->state_ = WebSocketReadState::Mask;
                                   }
-                                  do_read();
+                                  shared_this->do_read();
                               }
                               else
                               {
-                                  close_connection_ = true;
-                                  adaptor_.shutdown_readwrite();
-                                  adaptor_.close();
-                                  if (error_handler_)
-                                      error_handler_(*this, ec.message());
-                                  check_destroy();
+                                  shared_this->close_connection_ = true;
+                                  shared_this->adaptor_.shutdown_readwrite();
+                                  shared_this->adaptor_.close();
+                                  if (shared_this->error_handler_)
+                                      shared_this->error_handler_(*shared_this, ec.message());
+                                  shared_this->check_destroy();
                               }
                           });
                     }
@@ -439,14 +439,14 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                         remaining_length16_ = 0;
                         asio::async_read(
                           adaptor_.socket(), asio::buffer(&remaining_length16_, 2),
-                          [this, shared_this = this->shared_from_this()](const error_code& ec, std::size_t
+                          [shared_this = this->shared_from_this()](const error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
                                                                bytes_transferred
 #endif
                           ) {
-                              is_reading = false;
-                              remaining_length16_ = ntohs(remaining_length16_);
-                              remaining_length_ = remaining_length16_;
+                              shared_this->is_reading = false;
+                              shared_this->remaining_length16_ = ntohs(shared_this->remaining_length16_);
+                              shared_this->remaining_length_ = shared_this->remaining_length16_;
 #ifdef CROW_ENABLE_DEBUG
                               if (!ec && bytes_transferred != 2)
                               {
@@ -456,17 +456,17 @@ namespace crow // NOTE: Already documented in "crow/app.h"
 
                               if (!ec)
                               {
-                                  state_ = WebSocketReadState::Mask;
-                                  do_read();
+                                  shared_this->state_ = WebSocketReadState::Mask;
+                                  shared_this->do_read();
                               }
                               else
                               {
-                                  close_connection_ = true;
-                                  adaptor_.shutdown_readwrite();
-                                  adaptor_.close();
-                                  if (error_handler_)
-                                      error_handler_(*this, ec.message());
-                                  check_destroy();
+                                  shared_this->close_connection_ = true;
+                                  shared_this->adaptor_.shutdown_readwrite();
+                                  shared_this->adaptor_.close();
+                                  if (shared_this->error_handler_)
+                                      shared_this->error_handler_(*shared_this, ec.message());
+                                  shared_this->check_destroy();
                               }
                           });
                     }
@@ -475,13 +475,13 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                     {
                         asio::async_read(
                           adaptor_.socket(), asio::buffer(&remaining_length_, 8),
-                          [this, shared_this = this->shared_from_this()](const error_code& ec, std::size_t
+                          [shared_this = this->shared_from_this()](const error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
                                                                bytes_transferred
 #endif
                           ) {
-                              is_reading = false;
-                              remaining_length_ = ((1 == ntohl(1)) ? (remaining_length_) : (static_cast<uint64_t>(ntohl((remaining_length_)&0xFFFFFFFF)) << 32) | ntohl((remaining_length_) >> 32));
+                              shared_this->is_reading = false;
+                              shared_this->remaining_length_ = ((1 == ntohl(1)) ? (shared_this->remaining_length_) : (static_cast<uint64_t>(ntohl((shared_this->remaining_length_)&0xFFFFFFFF)) << 32) | ntohl((shared_this->remaining_length_) >> 32));
 #ifdef CROW_ENABLE_DEBUG
                               if (!ec && bytes_transferred != 8)
                               {
@@ -491,17 +491,17 @@ namespace crow // NOTE: Already documented in "crow/app.h"
 
                               if (!ec)
                               {
-                                  state_ = WebSocketReadState::Mask;
-                                  do_read();
+                                  shared_this->state_ = WebSocketReadState::Mask;
+                                  shared_this->do_read();
                               }
                               else
                               {
-                                  close_connection_ = true;
-                                  adaptor_.shutdown_readwrite();
-                                  adaptor_.close();
-                                  if (error_handler_)
-                                      error_handler_(*this, ec.message());
-                                  check_destroy();
+                                  shared_this->close_connection_ = true;
+                                  shared_this->adaptor_.shutdown_readwrite();
+                                  shared_this->adaptor_.close();
+                                  if (shared_this->error_handler_)
+                                      shared_this->error_handler_(*shared_this, ec.message());
+                                  shared_this->check_destroy();
                               }
                           });
                     }
@@ -519,12 +519,12 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                         {
                             asio::async_read(
                               adaptor_.socket(), asio::buffer((char*)&mask_, 4),
-                              [this, shared_this = this->shared_from_this()](const error_code& ec, std::size_t
+                              [shared_this = this->shared_from_this()](const error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
                                                                    bytes_transferred
 #endif
                               ) {
-                                  is_reading = false;
+                                  shared_this->is_reading = false;
 #ifdef CROW_ENABLE_DEBUG
                                   if (!ec && bytes_transferred != 4)
                                   {
@@ -534,17 +534,17 @@ namespace crow // NOTE: Already documented in "crow/app.h"
 
                                   if (!ec)
                                   {
-                                      state_ = WebSocketReadState::Payload;
-                                      do_read();
+                                      shared_this->state_ = WebSocketReadState::Payload;
+                                      shared_this->do_read();
                                   }
                                   else
                                   {
-                                      close_connection_ = true;
-                                      if (error_handler_)
-                                          error_handler_(*this, ec.message());
-                                      adaptor_.shutdown_readwrite();
-                                      adaptor_.close();
-                                      check_destroy();
+                                      shared_this->close_connection_ = true;
+                                      if (shared_this->error_handler_)
+                                          shared_this->error_handler_(*shared_this, ec.message());
+                                      shared_this->adaptor_.shutdown_readwrite();
+                                      shared_this->adaptor_.close();
+                                      shared_this->check_destroy();
                                   }
                               });
                         }
@@ -561,32 +561,32 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                             to_read = remaining_length_;
                         adaptor_.socket().async_read_some(
                           asio::buffer(buffer_, static_cast<std::size_t>(to_read)),
-                          [this, shared_this = this->shared_from_this()](const error_code& ec, std::size_t bytes_transferred) {
-                              is_reading = false;
+                          [shared_this = this->shared_from_this()](const error_code& ec, std::size_t bytes_transferred) {
+                              shared_this->is_reading = false;
 
                               if (!ec)
                               {
-                                  fragment_.insert(fragment_.end(), buffer_.begin(), buffer_.begin() + bytes_transferred);
-                                  remaining_length_ -= bytes_transferred;
-                                  if (remaining_length_ == 0)
+                                  shared_this->fragment_.insert(shared_this->fragment_.end(), shared_this->buffer_.begin(), shared_this->buffer_.begin() + bytes_transferred);
+                                  shared_this->remaining_length_ -= bytes_transferred;
+                                  if (shared_this->remaining_length_ == 0)
                                   {
-                                      if (handle_fragment())
+                                      if (shared_this->handle_fragment())
                                       {
-                                          state_ = WebSocketReadState::MiniHeader;
-                                          do_read();
+                                          shared_this->state_ = WebSocketReadState::MiniHeader;
+                                          shared_this->do_read();
                                       }
                                   }
                                   else
-                                      do_read();
+                                      shared_this->do_read();
                               }
                               else
                               {
-                                  close_connection_ = true;
-                                  if (error_handler_)
-                                      error_handler_(*this, ec.message());
-                                  adaptor_.shutdown_readwrite();
-                                  adaptor_.close();
-                                  check_destroy();
+                                  shared_this->close_connection_ = true;
+                                  if (shared_this->error_handler_)
+                                      shared_this->error_handler_(*shared_this, ec.message());
+                                  shared_this->adaptor_.shutdown_readwrite();
+                                  shared_this->adaptor_.close();
+                                  shared_this->check_destroy();
                               }
                           });
                     }
@@ -728,24 +728,24 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                 auto watch = std::weak_ptr<void>{anchor_};
                 asio::async_write(
                     adaptor_.socket(), buffers,
-                    [this, shared_this = this->shared_from_this(), watch](const error_code& ec, std::size_t /*bytes_transferred*/) {
+                    [shared_this = this->shared_from_this(), watch](const error_code& ec, std::size_t /*bytes_transferred*/) {
                         auto anchor = watch.lock();
                         if (anchor == nullptr)
                             return;
 
-                        if (!ec && !close_connection_)
+                        if (!ec && !shared_this->close_connection_)
                         {
-                            sending_buffers_.clear();
-                            if (!write_buffers_.empty())
-                                do_write();
-                            if (has_sent_close_)
-                                close_connection_ = true;
+                            shared_this->sending_buffers_.clear();
+                            if (!shared_this->write_buffers_.empty())
+                                shared_this->do_write();
+                            if (shared_this->has_sent_close_)
+                                shared_this->close_connection_ = true;
                         }
                         else
                         {
-                            sending_buffers_.clear();
-                            close_connection_ = true;
-                            check_destroy();
+                            shared_this->sending_buffers_.clear();
+                            shared_this->close_connection_ = true;
+                            shared_this->check_destroy();
                         }
                     });
             }


### PR DESCRIPTION
A segmentation fault occurs under certain conditions when stopping a crow app that uses websocket.
I am unable to provide minimal reproduction code, but it appears to be related to the timing of closing the websocket connection.
The stack trace is below.

<details>

```
Thread 4 "webcface-test" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7f316aea9640 (LWP 32901)]
0x0000562b906c9927 in asio::detail::reactive_socket_service_base::close (this=0xc7c7c7c7c7c7c7f7, impl=..., ec=std::error_code = {std::_V2::error_category: 0}) at ../su
bprojects/asio-1.36.0/include/asio/detail/impl/reactive_socket_service_base.ipp:109
109         reactor_.deregister_descriptor(impl.socket_, impl.reactor_data_,
(gdb) bt
#0  0x0000562b906c9927 in asio::detail::reactive_socket_service_base::close (this=0xc7c7c7c7c7c7c7f7, impl=..., ec=std::error_code = {std::_V2::error_category: 0})
    at ../subprojects/asio-1.36.0/include/asio/detail/impl/reactive_socket_service_base.ipp:109
#1  0x0000562b906df720 in asio::basic_socket<asio::ip::tcp, asio::any_io_executor>::close (this=0x7f3160001e30, ec=std::error_code = {std::_V2::error_category: 0})
    at ../subprojects/asio-1.36.0/include/asio/basic_socket.hpp:541
#2  0x0000562b906cd3b0 in crow::SocketAdaptor::close (this=0x7f3160001e30) at ../subprojects/crow/include/crow/socket_adaptors.h:81
#3  0x0000562b90772452 in crow::websocket::Connection<crow::SocketAdaptor, crow::Crow<> >::do_read()::{lambda(std::error_code const&, unsigned long)#1}::operator()(std:
:error_code const&, unsigned long) const (__closure=0x7f316aea82a0, ec=std::error_code = {std::_V2::error_category: 125})
    at ../subprojects/crow/include/crow/websocket.h:415
#4  0x0000562b90780c10 in asio::detail::binder2<crow::websocket::Connection<crow::SocketAdaptor, crow::Crow<> >::do_read()::{lambda(std::error_code const&, unsigned lon
g)#1}, std::error_code, unsigned long>::operator()() (this=0x7f316aea82a0) at ../subprojects/asio-1.36.0/include/asio/detail/bind_handler.hpp:180
#5  0x0000562b9077fd55 in asio::detail::handler_work<crow::websocket::Connection<crow::SocketAdaptor, crow::Crow<> >::do_read()::{lambda(std::error_code const&, unsigne
d long)#1}, asio::any_io_executor, void>::complete<asio::detail::binder2<crow::websocket::Connection<crow::SocketAdaptor, crow::Crow<> >::do_read()::{lambda(std::error_
code const&, unsigned long)#1}, std::error_code, unsigned long> >(asio::detail::binder2<crow::websocket::Connection<crow::SocketAdaptor, crow::Crow<> >::do_read()::{lam
bda(std::error_code const&, unsigned long)#1}, std::error_code, unsigned long>&, crow::websocket::Connection<crow::SocketAdaptor, crow::Crow<> >::do_read()::{lambda(std
::error_code const&, unsigned long)#1}&) (this=0x7f316aea82c0, function=..., handler=...) at ../subprojects/asio-1.36.0/include/asio/detail/handler_work.hpp:469
#6  0x0000562b9077e798 in asio::detail::reactive_socket_recv_op<asio::mutable_buffer, crow::websocket::Connection<crow::SocketAdaptor, crow::Crow<> >::do_read()::{lambd
a(std::error_code const&, unsigned long)#1}, asio::any_io_executor>::do_complete(void*, asio::detail::scheduler_operation*, std::error_code const&, unsigned long) (
    owner=0x7f315c0039e0, base=0x7f3160001810) at ../subprojects/asio-1.36.0/include/asio/detail/reactive_socket_recv_op.hpp:150
--Type <RET> for more, q to quit, c to continue without paging--c
#7  0x0000562b906c2972 in asio::detail::scheduler_operation::complete (this=0x7f3160001810, owner=0x7f315c0039e0, ec=std::error_code = {std::_V2::error_category: 0}, by
tes_transferred=0) at ../subprojects/asio-1.36.0/include/asio/detail/scheduler_operation.hpp:39
#8  0x0000562b906c7687 in asio::detail::scheduler::do_run_one (this=0x7f315c0039e0, lock=..., this_thread=..., ec=std::error_code = {std::_V2::error_category: 0}) at ..
/subprojects/asio-1.36.0/include/asio/detail/impl/scheduler.ipp:500
#9  0x0000562b906c6f2b in asio::detail::scheduler::run (this=0x7f315c0039e0, ec=std::error_code = {std::_V2::error_category: 0}) at ../subprojects/asio-1.36.0/include/a
sio/detail/impl/scheduler.ipp:216
#10 0x0000562b906c7a8a in asio::io_context::run (this=0x7f315c003940) at ../subprojects/asio-1.36.0/include/asio/impl/io_context.ipp:62
#11 0x0000562b906f4a0f in crow::Server<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}::operator()() const (__closure=0x7f315c003bc8) at ../s
ubprojects/crow/include/crow/http_server.h:179
#12 0x0000562b90761009 in std::__invoke_impl<void, crow::Server<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}>(std::__invoke_other, crow::S
erver<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}&&) (__f=...) at /usr/include/c++/11/bits/invoke.h:61
#13 0x0000562b90760821 in std::__invoke<crow::Server<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}>(crow::Server<crow::Crow<>, crow::TCPAcc
eptor, crow::SocketAdaptor>::run()::{lambda()#1}&&) (__fn=...) at /usr/include/c++/11/bits/invoke.h:96
#14 0x0000562b9075fc92 in std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >::_M_invoke<0ul>(st
d::_Index_tuple<0ul>) (this=0x7f315c003bc8) at /usr/include/c++/11/bits/std_thread.h:259
#15 0x0000562b9075ee1c in std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >::operator()() (thi
s=0x7f315c003bc8) at /usr/include/c++/11/bits/std_thread.h:266
#16 0x0000562b9075d920 in std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::thread::
_Invoker<std::tuple<crow::Server<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >, void>::operator()() const (this=0x7f316aea8cf0) at /usr/
include/c++/11/future:1409
#17 0x0000562b9075c097 in std::__invoke_impl<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::__future_base::_Task_s
etter<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>, crow::
TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >, void>&>(std::__invoke_other, std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<voi
d>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1
}> >, void>&) (__f=...) at /usr/include/c++/11/bits/invoke.h:61
#18 0x0000562b90759fee in std::__invoke_r<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter>, std::__future_base::_Task_sette
r<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>, crow::TCPA
cceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >, void>&>(std::__future_base::_Task_setter<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_
Result_base::_Deleter>, std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >, void>&) (__fn=...)
at /usr/include/c++/11/bits/invoke.h:116
#19 0x0000562b907575d4 in std::_Function_handler<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> (), std::__future_base::_
Task_setter<std::unique_ptr<std::__future_base::_Result<void>, std::__future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>,
crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >, void> >::_M_invoke(std::_Any_data const&) (__functor=...) at /usr/include/c++/11/bits/std_function.h:29
1
#20 0x0000562b906573f8 in std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>::operator()() const (this=0x7f
316aea8cf0) at /usr/include/c++/11/bits/std_function.h:590
#21 0x0000562b90655192 in std::__future_base::_State_baseV2::_M_do_set(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base:
:_Deleter> ()>*, bool*) (this=0x7f315c003b90, __f=0x7f316aea8cf0, __did_set=0x7f316aea8c3f) at /usr/include/c++/11/future:571
#22 0x0000562b906623ee in std::__invoke_impl<void, void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__fu
ture_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base:
:_Result_base::_Deleter> ()>*, bool*>(std::__invoke_memfun_deref, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Resul
t_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base,
std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&) (__f=@0x7f316aea8c80: (void (std::__future_base::_State_baseV2::*)(std::__future_base::_State_baseV2 * cons
t, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter>()> *, bool *)) 0x562b90655158 <std::__future_base::_State
_baseV2::_M_do_set(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*)>, __t=@0x7f316aea8c50: 0x7f3
15c003b90) at /usr/include/c++/11/bits/invoke.h:74
#23 0x0000562b9065bda2 in std::__invoke<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::
_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_ba
se::_Deleter> ()>*, bool*>(void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_bas
e::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Dele
ter> ()>*&&, bool*&&) (__fn=@0x7f316aea8c80: (void (std::__future_base::_State_baseV2::*)(std::__future_base::_State_baseV2 * const, std::function<std::unique_ptr<std::
__future_base::_Result_base, std::__future_base::_Result_base::_Deleter>()> *, bool *)) 0x562b90655158 <std::__future_base::_State_baseV2::_M_do_set(std::function<std::
unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*)>) at /usr/include/c++/11/bits/invoke.h:96
#24 0x0000562b906572ca in std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base:
:_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_b
ase::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future
_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_
Result_base::_Deleter> ()>*&&, bool*&&)::{lambda()#1}::operator()() const (__closure=0x7f316aea8bc0) at /usr/include/c++/11/mutex:776
#25 0x0000562b9065bdd1 in std::once_flag::_Prepare_execution::_Prepare_execution<std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_pt
r<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__f
uture_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::uni
que_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<
std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&)::{lambda()#1}>(void (std::__future_base::_State_baseV2::*&)(std::function
<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*))::{lambda()#1}::operator()() const (__closure=0x0) at /usr/i
nclude/c++/11/mutex:712
#26 0x0000562b9065bde6 in std::once_flag::_Prepare_execution::_Prepare_execution<std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_pt
r<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__f
uture_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::uni
que_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<
std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*&&, bool*&&)::{lambda()#1}>(void (std::__future_base::_State_baseV2::*&)(std::function
<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*))::{lambda()#1}::_FUN() () at /usr/include/c++/11/mutex:712
#27 0x00007f316bf4aee8 in __pthread_once_slow (once_control=0x7f315c003ba8, init_routine=0x7f316c2bbd50 <__once_proxy>) at ./nptl/pthread_once.c:116
#28 0x0000562b90653d7b in __gthread_once (__once=0x7f315c003ba8, __func=0x7f316c2bbd50 <__once_proxy>) at /usr/include/x86_64-linux-gnu/c++/11/bits/gthr-default.h:700
#29 0x0000562b9065734f in std::call_once<void (std::__future_base::_State_baseV2::*)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base:
:_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_b
ase::_Deleter> ()>*, bool*>(std::once_flag&, void (std::__future_base::_State_baseV2::*&&)(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future
_base::_Result_base::_Deleter> ()>*, bool*), std::__future_base::_State_baseV2*&&, std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_
Result_base::_Deleter> ()>*&&, bool*&&) (__once=..., __f=@0x7f316aea8c80: (void (std::__future_base::_State_baseV2::*)(std::__future_base::_State_baseV2 * const, std::f
unction<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter>()> *, bool *)) 0x562b90655158 <std::__future_base::_State_baseV2::
_M_do_set(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*)>) at /usr/include/c++/11/mutex:783
#30 0x0000562b906550bb in std::__future_base::_State_baseV2::_M_set_result(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_b
ase::_Deleter> ()>, bool) (this=0x7f315c003b90, __res=..., __ignore_failure=false) at /usr/include/c++/11/future:411
#31 0x0000562b90751376 in std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run
()::{lambda()#1}> >, void>::_M_run() (this=0x7f315c003b90) at /usr/include/c++/11/future:1748
#32 0x0000562b907745dc in std::__invoke_impl<void, void (std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>, crow::TCPAcce
ptor, crow::SocketAdaptor>::run()::{lambda()#1}> >, void>::*)(), std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>, crow:
:TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >, void>*>(std::__invoke_memfun_deref, void (std::__future_base::_Async_state_impl<std::thread::_Invoker<std::t
uple<crow::Server<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >, void>::*&&)(), std::__future_base::_Async_state_impl<std::thread::_Invo
ker<std::tuple<crow::Server<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >, void>*&&) (__f=@0x7f315c003c20: (void (std::__future_base::_A
sync_state_impl<std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::<lambda()> > >, void>::*)(std::__future_base
::_Async_state_impl<std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::<lambda()> > >, void> * const)) 0x562b90
751306 <std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}>
>, void>::_M_run()>, __t=@0x7f315c003c18: 0x7f315c003b90) at /usr/include/c++/11/bits/invoke.h:74
#33 0x0000562b907712a5 in std::__invoke<void (std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>, crow::TCPAcceptor, crow:
:SocketAdaptor>::run()::{lambda()#1}> >, void>::*)(), std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>, crow::TCPAccepto
r, crow::SocketAdaptor>::run()::{lambda()#1}> >, void>*>(void (std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>, crow::T
CPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >, void>::*&&)(), std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<
>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >, void>*&&) (__fn=@0x7f315c003c20: (void (std::__future_base::_Async_state_impl<std::thread::_Invoker<
std::tuple<crow::Server<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::<lambda()> > >, void>::*)(std::__future_base::_Async_state_impl<std::thread::_Invo
ker<std::tuple<crow::Server<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::<lambda()> > >, void> * const)) 0x562b90751306 <std::__future_base::_Async_sta
te_impl<std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >, void>::_M_run()>) at /usr/include/c
++/11/bits/invoke.h:96
#34 0x0000562b9076f809 in std::thread::_Invoker<std::tuple<void (std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>, crow:
:TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >, void>::*)(), std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<
>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >, void>*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (this=0x7f315c003c18) at /usr/include/c+
+/11/bits/std_thread.h:259
#35 0x0000562b9076ccba in std::thread::_Invoker<std::tuple<void (std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<>, crow:
:TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >, void>::*)(), std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<crow::Server<crow::Crow<
>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >, void>*> >::operator()() (this=0x7f315c003c18) at /usr/include/c++/11/bits/std_thread.h:266
#36 0x0000562b907698c4 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<crow::S
erver<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >, void>::*)(), std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple
<crow::Server<crow::Crow<>, crow::TCPAcceptor, crow::SocketAdaptor>::run()::{lambda()#1}> >, void>*> > >::_M_run() (this=0x7f315c003c10) at /usr/include/c++/11/bits/std
_thread.h:211
#37 0x00007f316c2bd253 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#38 0x00007f316bf45ac3 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:442
#39 0x00007f316bfd6a74 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:100
```


</details>

Running git bisect, I found that this segmentation fault started occurring from #1080 onwards.
In #1080 the timing of destroying the Connection object changed, so I thought it was likely caused by accessing a Connection object after it had been destroyed.
There were places where the Connection object was captured as `this` despite being a shared_ptr, so I added a capture of shared_from_this() and the segmentation fault no longer occurred.