### PR TITLE
Feature#1129-CMake Error: ALIAS target "Boost::system" name collision…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,9 @@ if(CROW_USE_BOOST)
 	if(Boost_VERSION VERSION_LESS 1.89)
 		find_package(Boost 1.64 COMPONENTS system REQUIRED)
 	else()
-		add_library(Boost::system ALIAS Boost::headers)
+		if(NOT TARGET Boost::system)
+			add_library(Boost::system ALIAS Boost::headers)
+		endif()
 	endif()
 	target_link_libraries(Crow
 		INTERFACE


### PR DESCRIPTION
I wasnt able to recreate the problem while using FetchContent on a small hello word api. 
I tried different boost versions.
I injected to the CMakeLists.txt i think i pinpointed the problem that my fixed solved