### PR TITLE
fix #1040:  append the last crlf  if miss for multipart data

### DIFF
--- a/include/crow/multipart.h
+++ b/include/crow/multipart.h
@@ -181,11 +181,6 @@ namespace crow
                 return std::equal(suffix.rbegin(), suffix.rend(), str.rbegin());
             }
             
-            // reload for char* suffix
-            bool ends_with(const std:: string& str, const char* suffix) {
-                return ends_with(str, std::string(suffix));
-            }
-
             void parse_body(std::string body)
             {
                 std::string delimiter = dd + boundary;


### PR DESCRIPTION
I saw the pr created

pr: https://github.com/CrowCpp/Crow/pull/1048

but I think this one is more easy and nice.