### PR TITLE
replaced raw void* with std::any

### DIFF
--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -74,11 +74,11 @@ namespace crow // NOTE: Already documented in "crow/app.h"
             virtual std::string get_subprotocol() const = 0;
             virtual ~connection() = default;
 
-            void userdata(void* u) { userdata_ = u; }
-            void* userdata() { return userdata_; }
+            void userdata(std::any u) { userdata_ = std::move(u); }
+            std::any userdata() { return userdata_; }
 
         private:
-            void* userdata_;
+            std::any userdata_;
         };
 
         // Modified version of the illustration in RFC6455 Section-5.2

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <any>
 #include <array>
 #include <memory>
 #include <optional>


### PR DESCRIPTION
Updates the way user data is managed in the `crow::websocket::connection` class, replacing the use of raw pointers with a safer and more flexible and memory safe approach.

Improvements to user data handling:

* Changed the `userdata_` member from a `void*` to a `std::any`, allowing storage of arbitrary types and improving type safety.
* Updated the `userdata()` setter and getter methods to use `std::any` instead of `void*`, enabling safer and more flexible user data management.

Why it's important:
```cpp
CROW_WEBSOCKET_ROUTE(app, "/ws")
      .onopen([&](crow::websocket::connection& conn) {
          conn.userdata(std::make_shared<Foo>());
          CROW_LOG_INFO << "new websocket connection from " << conn.get_remote_ip();
          std::lock_guard<std::mutex> _(mtx);
          users.insert(&conn);
      })
      .onclose([&](crow::websocket::connection& conn, const std::string& reason, uint16_t) {
          CROW_LOG_INFO << "websocket connection closed: " << reason;
          std::lock_guard<std::mutex> _(mtx);
          users.erase(&conn);
      })
      .onmessage([&](crow::websocket::connection& /*conn*/, const std::string& data, bool is_binary) {
          std::lock_guard<std::mutex> _(mtx);
          for (auto u : users)
              if (is_binary)
                  u->send_binary(data);
              else
                  u->send_text(data);
      });
```
Output:
```
(2026-02-21 06:23:37) [INFO    ] Crow/master server is running at http://0.0.0.0:40080 using 28 threads
(2026-02-21 06:23:37) [INFO    ] Call `app.loglevel(crow::LogLevel::Warning)` to hide Info level logs.
Foo(): Allocated user data
(2026-02-21 06:23:38) [INFO    ] new websocket connection from 127.0.0.1
~Foo(): Deallocated user data
(2026-02-21 06:23:41) [INFO    ] websocket connection closed: 
```
You see client code can have huge  .onclose handler and you can forgot call delete on object wich leads to memory leak or you can miss-cast type into something else and get UB wich is even worse.