### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -3,10 +3,6 @@
 //#define CROW_JSON_NO_ERROR_CHECK
 //#define CROW_JSON_USE_MAP
 
-#ifndef DBL_DECIMAL_DIG
-#define DBL_DECIMAL_DIG 17
-#endif /* ifndef DBL_DECIMAL_DIG */
-
 #include <string>
 #ifdef CROW_JSON_USE_MAP
 #include <map>
@@ -1900,9 +1896,9 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                             if (v.nt == num_type::Double_precision_floating_point)
                             {
 #ifdef _MSC_VER
-                                sprintf_s(outbuf, sizeof(outbuf), "%.*g", DBL_DECIMAL_DIG, v.num.d);
+                                sprintf_s(outbuf, sizeof(outbuf), "%.*g", std::numeric_limits<double>::max_digits10, v.num.d);
 #else
-                                snprintf(outbuf, sizeof(outbuf), "%.*g", DBL_DECIMAL_DIG, v.num.d);
+                                snprintf(outbuf, sizeof(outbuf), "%.*g", std::numeric_limits<double>::max_digits10, v.num.d);
 #endif
                             }
                             else


### PR DESCRIPTION
OpenBSD uses a <C11 version of the C standard in some places, with the lack of DBL_DECIMAL_DIG being a problem in regards to CrowCPP.
The fix for this is is just defining it as 17, which while certainly not perfect, is as good as you can get. 17 is the value it has on x86, ARM, i386, PowerPC and RISC-V, at least. Suffice to say, it should not cause problems expect possibly with some obscure embedded architectures.
It's value is not directly tied to any other constants, so there are no fully portable fixes for this issue.
The location in code is a bit ugly and could be changed, but I am unsure as to where it should be located.