### PR TITLE
Support explicit OPTIONS routes

### DIFF
--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -1644,6 +1644,17 @@ namespace crow // NOTE: Already documented in "crow/app.h"
             }
             else if (req.method == HTTPMethod::Options)
             {
+                // Prefer explicit OPTIONS routes while preserving the automatic "/*" handler.
+                if (req.url != "/*")
+                {
+                    *found = per_methods_[static_cast<int>(HTTPMethod::Options)].trie.find(req.url);
+                    if (found->rule_index)
+                    {
+                        found->method = HTTPMethod::Options;
+                        return found;
+                    }
+                }
+
                 std::string allow = "OPTIONS, HEAD";
 
                 if (req.url == "/*")


### PR DESCRIPTION
Allows explicitly registered OPTIONS routes to handle Local Network Access (LNA) preflight requests.

Currently, the automatic OPTIONS fallback is used before a concrete OPTIONS route can be matched. With this change, explicit OPTIONS routes take precedence, while the existing automatic "/*" handling is preserved.