### PR TITLE
No trailing zeroes in exponents - see #1042

### DIFF
--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -1890,7 +1890,8 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                             {
                                 start,
                                 decp, // Decimal point
-                                zero
+                                zero,
+                                exp // in the exponent
                             } f_state;
                             char outbuf[128];
                             if (v.nt == num_type::Double_precision_floating_point)
@@ -1911,6 +1912,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                             }
                             char* p = &outbuf[0];
                             char* pos_first_trailing_0 = nullptr;
+                            char* pos_exponent = nullptr;
                             f_state = start;
                             while (*p != '\0')
                             {
@@ -1934,20 +1936,39 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                                             f_state = zero;
                                             pos_first_trailing_0 = p;
                                         }
+                                        else if (ch == 'e')
+                                        {
+                                            pos_exponent = p;
+                                            f_state = exp;
+                                        }
                                         p++;
                                         break;
                                     case zero: // if a non 0 is found (e.g. 1.00004) remove the earlier recorded 0 position and look for more trailing 0s
-                                        if (ch != '0')
+                                        if (ch == 'e')
+                                        {
+                                            pos_exponent = p;
+                                            f_state = exp;
+                                        }
+                                        else if (ch != '0')
                                         {
                                             pos_first_trailing_0 = nullptr;
                                             f_state = decp;
                                         }
                                         p++;
                                         break;
+                                    case exp: // if an 'e' has been found, one is in the exponent; no more looking for trailing zeroes
+                                        p++;
+                                        break;
                                 }
                             }
                             if (pos_first_trailing_0 != nullptr) // if any trailing 0s are found, terminate the string where they begin
+                            {
                                 *pos_first_trailing_0 = '\0';
+                                if (pos_exponent != nullptr) // if there is an exponent, include it
+                                {
+                                    strcpy(pos_first_trailing_0, pos_exponent);
+                                }
+                            }
                             out += outbuf;
                         }
                         else if (v.nt == num_type::Signed_integer)

--- a/tests/unit_tests/test_json.cpp
+++ b/tests/unit_tests/test_json.cpp
@@ -642,12 +642,22 @@ TEST_CASE("json Incorrect move of wvalue class #953", "[json]")
     }
 }
 
-TEST_CASE("SmallNumber #1042", "[json]")
+TEST_CASE("Assorted floating points", "[json]")
 {
     crow::json::wvalue data;
-    const double smallnumber = 1e-10;
-    data["testValue"] = smallnumber;
+    const double smallnumbers[] = { 1, 1e5, 1e10, 1e20, 1e-8, 1e-10, 
+                                    1.5, 1.5e5, 1.5e10, 1.5e20, 1.5e-5, 1.5e-10, 
+                                    1.04, 1.04e5, 1.04e10, 1.04e20, 1.04e-5, 1.04e-10, 
+                                    1.008, 1.008e5, 1.008e10, 1.008e20, 1.008e-5, 1.008e-10 };
+    for (long unsigned int i = 0; i < sizeof(smallnumbers)/sizeof(double); ++i) {
+        data["testValues"][i] = smallnumbers[i];
+    }
     std::string text = data.dump( 4);
-    const auto expected_text ="{\n    \"testValue\": 1e-10\n}";
+    const auto expected_text ="{\n    \"testValues\": [\n"
+        "        1,\n        100000,\n        10000000000,\n        1e+20,\n        1e-08,\n        1e-10,\n"
+        "        1.5,\n        150000,\n        15000000000,\n        1.5e+20,\n        1.5e-05,\n        1.5e-10,\n"
+        "        1.04,\n        104000,\n        10400000000,\n        1.04e+20,\n        1.04e-05,\n        1.04e-10,\n"
+        "        1.008,\n        100800,\n        10080000000,\n        1.008e+20,\n        1.008e-05,\n        1.008e-10\n"
+        "    ]\n}";
     REQUIRE(text==expected_text);
 }


### PR DESCRIPTION
I do apologize for making a pull request without knowing the expectations regarding contributions (or even linting), and doubly so for addressing an issue which @gittiver (if I may ping them) marked as resolved, but appreciate this framework a great deal, was surprised to trace a glitch in my own work back to it, and would like to make it slightly better.

Issue #1042 as stated identifies a very particular case in which a double is serialized incorrectly, but not all cases; in my own observations, a double such as `2.4421129145381396e-10` would be rendered correctly by the lines gittiver wrote in the fix, only to be mangled by the mechanism to remove trailing zeroes, which wrongly identifies the 0 in the exponent of -10 as a trailing zero.  This does not occur in the test case added in the existing fix, `1e-10`, because no decimal point ever appears, and the mechanism does not identify zeroes as trailing without a decimal point; however, in the test case I've added in commit 4fd7407, `1.2e-10`, the failure of the current code is demonstrated; a fix is attempted in the next commit.

The fix does pass all existing tests, though few pertain to the writing of doubles; if it would be desired that a greater battery of tests be created for this matter (and of course that the fix as drafted be re-written to address any failures that may emerge), I would be glad to do so.