### PR TITLE
Alternative to #1191:  Use stringstream to write floats

### DIFF
--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -1886,69 +1886,9 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                                 CROW_LOG_WARNING << "Invalid JSON value detected (" << v.num.d << "), value set to null";
                                 break;
                             }
-                            enum
-                            {
-                                start,
-                                decp, // Decimal point
-                                zero
-                            } f_state;
-                            char outbuf[128];
-                            if (v.nt == num_type::Double_precision_floating_point)
-                            {
-#ifdef _MSC_VER
-                                sprintf_s(outbuf, sizeof(outbuf), "%.*g", std::numeric_limits<double>::max_digits10, v.num.d);
-#else
-                                snprintf(outbuf, sizeof(outbuf), "%.*g", std::numeric_limits<double>::max_digits10, v.num.d);
-#endif
-                            }
-                            else
-                            {
-#ifdef _MSC_VER
-                                sprintf_s(outbuf, sizeof(outbuf), "%f", v.num.d);
-#else
-                                snprintf(outbuf, sizeof(outbuf), "%f", v.num.d);
-#endif
-                            }
-                            char* p = &outbuf[0];
-                            char* pos_first_trailing_0 = nullptr;
-                            f_state = start;
-                            while (*p != '\0')
-                            {
-                                //std::cout << *p << std::endl;
-                                char ch = *p;
-                                switch (f_state)
-                                {
-                                    case start: // Loop and lookahead until a decimal point is found
-                                        if (ch == '.')
-                                        {
-                                            char fch = *(p + 1);
-                                            // if the first character is 0, leave it be (this is so that "1.00000" becomes "1.0" and not "1.")
-                                            if (fch != '\0' && fch == '0') p++;
-                                            f_state = decp;
-                                        }
-                                        p++;
-                                        break;
-                                    case decp: // Loop until a 0 is found, if found, record its position
-                                        if (ch == '0')
-                                        {
-                                            f_state = zero;
-                                            pos_first_trailing_0 = p;
-                                        }
-                                        p++;
-                                        break;
-                                    case zero: // if a non 0 is found (e.g. 1.00004) remove the earlier recorded 0 position and look for more trailing 0s
-                                        if (ch != '0')
-                                        {
-                                            pos_first_trailing_0 = nullptr;
-                                            f_state = decp;
-                                        }
-                                        p++;
-                                        break;
-                                }
-                            }
-                            if (pos_first_trailing_0 != nullptr) // if any trailing 0s are found, terminate the string where they begin
-                                *pos_first_trailing_0 = '\0';
-                            out += outbuf;
+                            std::ostringstream oss;
+                            oss << v.num.d;
+                            out += oss.str();
                         }
                         else if (v.nt == num_type::Signed_integer)
                         {

--- a/tests/unit_tests/test_json.cpp
+++ b/tests/unit_tests/test_json.cpp
@@ -642,12 +642,22 @@ TEST_CASE("json Incorrect move of wvalue class #953", "[json]")
     }
 }
 
-TEST_CASE("SmallNumber #1042", "[json]")
+TEST_CASE("Assorted floating points", "[json]")
 {
     crow::json::wvalue data;
-    const double smallnumber = 1e-10;
-    data["testValue"] = smallnumber;
+    const double smallnumbers[] = { 1, 1e5, 1e10, 1e20, 1e-5, 1e-10, 
+                                    1.5, 1.5e5, 1.5e10, 1.5e20, 1.5e-5, 1.5e-10, 
+                                    1.04, 1.04e5, 1.04e10, 1.04e20, 1.04e-5, 1.04e-10, 
+                                    1.008, 1.008e5, 1.008e10, 1.008e20, 1.008e-5, 1.008e-10 };
+    for (long unsigned int i = 0; i < sizeof(smallnumbers)/sizeof(double); ++i) {
+        data["testValues"][i] = smallnumbers[i];
+    }
     std::string text = data.dump( 4);
-    const auto expected_text ="{\n    \"testValue\": 1e-10\n}";
+    const auto expected_text ="{\n    \"testValues\": [\n"
+        "        1,\n        100000,\n        1e+10,\n        1e+20,\n        1e-05,\n        1e-10,\n"
+        "        1.5,\n        150000,\n        1.5e+10,\n        1.5e+20,\n        1.5e-05,\n        1.5e-10,\n"
+        "        1.04,\n        104000,\n        1.04e+10,\n        1.04e+20,\n        1.04e-05,\n        1.04e-10,\n"
+        "        1.008,\n        100800,\n        1.008e+10,\n        1.008e+20,\n        1.008e-05,\n        1.008e-10\n"
+        "    ]\n}";
     REQUIRE(text==expected_text);
 }


### PR DESCRIPTION
As an alternative to the fix proposed in https://github.com/CrowCpp/Crow/pull/1191, one may remove much of the floating-point management code, including manually modifying trailing zeroes, via the use of the string-stream methods, which depend on the same logic used to write floats to the console.

In practice, such as with the provided test cases, these play nicely with values of few decimal digits.  They would not, for example, turn 1e-05 into 1.0001e-05 nor into 9.9999e-06.  However, this method does mangle other floating-point values, for example causing the failure of the test case `json::wvalue::wvalue(double)`, as it is content to render 0.036303908355795146 as 0.0363039.