### PR TITLE
fix for  Security: pre-auth DoS — invalid end() iterator dereference in multipart parser -check for existence of name header before using it

### DIFF
--- a/include/crow/multipart.h
+++ b/include/crow/multipart.h
@@ -193,13 +193,17 @@ namespace crow
                     // +2 is the CRLF.
                     // We don't check it and delete it so that the same delimiter can be used for The last delimiter (--delimiter--CRLF).
                     body.erase(0, found + delimiter.length() + 2);
-                    if (!section.empty())
-                    {
+                    if (!section.empty()) {
                         part parsed_section(parse_section(section));
-                        part_map.emplace(
-                          (get_header_object(parsed_section.headers, "Content-Disposition").params.find("name")->second),
-                          parsed_section);
-                        parts.push_back(std::move(parsed_section));
+                        const auto section_params_headers = get_header_object(
+                            parsed_section.headers, "Content-Disposition").params;
+                        const auto name_header = section_params_headers.find("name");
+                        if (name_header == section_params_headers.end()) {
+                            throw bad_request("Unable to find header 'name' in multipart section. Probably ill-formed body.");
+                        } else {
+                            part_map.emplace(name_header->second, parsed_section);
+                            parts.push_back(std::move(parsed_section));
+                        }
                     }
                 }
             }

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -1757,6 +1757,54 @@ TEST_CASE("multipart")
     }
 } // multipart
 
+
+TEST_CASE("multipart_name_header_missing_issue_1192") {
+    //
+    //--CROW-BOUNDARY
+    //Content-Disposition: form-data;
+    //
+    //world
+    //--CROW-BOUNDARY
+    //Content-Disposition: form-data;
+    //
+    //hello
+    //--CROW-BOUNDARY
+    //Content-Disposition: form-data;
+    //
+    //text
+    //text
+    //text
+    //--CROW-BOUNDARY--
+    //
+
+    std::string test_string = "--CROW-BOUNDARY\r\nContent-Disposition: form-data; \r\n\r\nworld\r\n--CROW-BOUNDARY\r\nContent-Disposition: form-data; \r\n\r\nhello\r\n--CROW-BOUNDARY\r\nContent-Disposition: form-data; \r\n\r\ntext\ntext\ntext\r\n--CROW-BOUNDARY--\r\n";
+
+    SimpleApp app;
+
+    CROW_ROUTE(app, "/multipart")
+    ([](const crow::request& req, crow::response& res) {
+        multipart::message msg(req);
+        res.body = msg.dump();
+        res.end();
+    });
+
+    app.validate();
+
+    {
+        request req;
+        response res;
+
+        req.url = "/multipart";
+        req.add_header("Content-Type", "multipart/form-data; boundary=CROW-BOUNDARY");
+        req.body = test_string;
+
+        // with the above-mentioned bug we get SIGV here
+        app.handle_full(req, res);
+
+        CHECK(res.code == crow::status::BAD_REQUEST);
+    }
+}
+
 TEST_CASE("multipart_view")
 {
     //


### PR DESCRIPTION
check for existence of name header before using it, in case of error-> bad_request

added unittest with missing name header in multipart request
