### PR TITLE
Feature/issue #1077 Add TCP Socket Options for HTTP and WebSocket Connections

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -478,6 +478,13 @@ namespace crow
             return *this;
         }
 
+        /// \brief Enable or disable TCP_NODELAY for accepted TCP connections.
+        self_t& tcp_nodelay(bool enabled = true)
+        {
+            tcp_socket_options_.no_delay = enabled;
+            return *this;
+        }
+
         /// \brief Set the response body size (in bytes) beyond which Crow automatically streams responses (Default is 1MiB)
         ///
         /// Any streamed response is unaffected by Crow's timer, and therefore won't timeout before a response is fully sent.
@@ -612,7 +619,7 @@ namespace crow
                 }
                 tcp::endpoint endpoint(addr, port_);
                 router_.using_ssl = true;
-                ssl_server_ = std::move(std::unique_ptr<ssl_server_t>(new ssl_server_t(this, endpoint, server_name_, &middlewares_, concurrency_, timeout_, &ssl_context_)));
+                ssl_server_ = std::move(std::unique_ptr<ssl_server_t>(new ssl_server_t(this, endpoint, server_name_, &middlewares_, concurrency_, timeout_, &ssl_context_, tcp_socket_options_)));
                 ssl_server_->set_tick_function(tick_interval_, tick_function_);
                 ssl_server_->signal_clear();
                 for (auto snum : signals_)
@@ -646,7 +653,7 @@ namespace crow
                         return;
                     }
                     TCPAcceptor::endpoint endpoint(addr, port_);
-                    server_ = std::move(std::unique_ptr<server_t>(new server_t(this, endpoint, server_name_, &middlewares_, concurrency_, timeout_, nullptr)));
+                    server_ = std::move(std::unique_ptr<server_t>(new server_t(this, endpoint, server_name_, &middlewares_, concurrency_, timeout_, nullptr, tcp_socket_options_)));
                     server_->set_tick_function(tick_interval_, tick_function_);
                     for (auto snum : signals_)
                     {
@@ -890,6 +897,7 @@ namespace crow
         std::string server_name_ = std::string("Crow/") + VERSION;
         std::string bindaddr_ = "0.0.0.0";
         bool use_unix_ = false;
+        detail::socket::tcp_socket_options tcp_socket_options_{};
         size_t res_stream_threshold_ = 1048576;
         Router router_;
         bool static_routes_added_{false};

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -485,6 +485,12 @@ namespace crow
             return *this;
         }
 
+        /// \brief Get the TCP_NODELAY setting for HTTP connections.
+        detail::socket::tcp_socket_options tcp_socket_options() const
+        {
+            return tcp_socket_options_;
+        }
+
         /// \brief Enable or disable TCP_NODELAY for WebSocket connections.
         /// We also have to differentiate between socket options for http server socket and websocket server socket.
         self_t& websocket_tcp_nodelay(bool enabled = true)
@@ -494,7 +500,7 @@ namespace crow
         }
 
         /// \brief Get the TCP_NODELAY setting for WebSocket connections.
-        detail::socket::tcp_socket_options websocket_tcp_nodelay_options() const
+        detail::socket::tcp_socket_options websocket_tcp_socket_options() const
         {
             return websocket_tcp_socket_options_;
         }

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -485,6 +485,20 @@ namespace crow
             return *this;
         }
 
+        /// \brief Enable or disable TCP_NODELAY for WebSocket connections.
+        /// We also have to differentiate between socket options for http server socket and websocket server socket.
+        self_t& websocket_tcp_nodelay(bool enabled = true)
+        {
+            websocket_tcp_socket_options_.no_delay = enabled;
+            return *this;
+        }
+
+        /// \brief Get the TCP_NODELAY setting for WebSocket connections.
+        detail::socket::tcp_socket_options websocket_tcp_nodelay_options() const
+        {
+            return websocket_tcp_socket_options_;
+        }
+
         /// \brief Set the response body size (in bytes) beyond which Crow automatically streams responses (Default is 1MiB)
         ///
         /// Any streamed response is unaffected by Crow's timer, and therefore won't timeout before a response is fully sent.
@@ -898,6 +912,7 @@ namespace crow
         std::string bindaddr_ = "0.0.0.0";
         bool use_unix_ = false;
         detail::socket::tcp_socket_options tcp_socket_options_{};
+        detail::socket::tcp_socket_options websocket_tcp_socket_options_{};
         size_t res_stream_threshold_ = 1048576;
         Router router_;
         bool static_routes_added_{false};

--- a/include/crow/http_server.h
+++ b/include/crow/http_server.h
@@ -28,6 +28,7 @@
 #include "crow/logging.h"
 #include "crow/task_timer.h"
 #include "crow/socket_acceptors.h"
+#include "crow/tcp_socket_options.h"
 
 
 namespace crow // NOTE: Already documented in "crow/app.h"
@@ -51,7 +52,8 @@ namespace crow // NOTE: Already documented in "crow/app.h"
              std::tuple<Middlewares...>* middlewares = nullptr,
              unsigned int concurrency = 1,
              uint8_t timeout = 5,
-             typename Adaptor::context* adaptor_ctx = nullptr):
+             typename Adaptor::context* adaptor_ctx = nullptr,
+             detail::socket::tcp_socket_options tcp_socket_options = {}):
           concurrency_(concurrency),
           task_queue_length_pool_(concurrency_ - 1),
           acceptor_(io_context_),
@@ -61,7 +63,8 @@ namespace crow // NOTE: Already documented in "crow/app.h"
           timeout_(timeout),
           server_name_(server_name),
           middlewares_(middlewares),
-          adaptor_ctx_(adaptor_ctx)
+          adaptor_ctx_(adaptor_ctx),
+          tcp_socket_options_(tcp_socket_options)
         {
             if (startup_failed_) {
                 CROW_LOG_ERROR << "Startup failed; not running server.";
@@ -318,6 +321,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                   [this, p, &ic](error_code ec) {
                       if (!ec)
                       {
+                          detail::socket::apply_tcp_socket_options(p->socket(), tcp_socket_options_);
                           asio::post(ic,
                             [p] {
                                 p->start();
@@ -364,5 +368,6 @@ namespace crow // NOTE: Already documented in "crow/app.h"
         std::tuple<Middlewares...>* middlewares_;
 
         typename Adaptor::context* adaptor_ctx_;
+        detail::socket::tcp_socket_options tcp_socket_options_;
     };
 } // namespace crow

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -444,19 +444,19 @@ namespace crow // NOTE: Already documented in "crow/app.h"
         void handle_upgrade(const request& req, response&, SocketAdaptor&& adaptor) override
         {
             max_payload_ = max_payload_override_ ? max_payload_ : app_->websocket_max_payload();
-            crow::websocket::Connection<SocketAdaptor, App>::create(req, std::move(adaptor), app_, max_payload_, subprotocols_, open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_, mirror_protocols_, app_->websocket_tcp_nodelay_options());
+            crow::websocket::Connection<SocketAdaptor, App>::create(req, std::move(adaptor), app_, max_payload_, subprotocols_, open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_, mirror_protocols_, app_->websocket_tcp_socket_options());
         }
 
         void handle_upgrade(const request& req, response&, UnixSocketAdaptor&& adaptor) override
         {
             max_payload_ = max_payload_override_ ? max_payload_ : app_->websocket_max_payload();
-            crow::websocket::Connection<UnixSocketAdaptor, App>::create(req, std::move(adaptor), app_, max_payload_, subprotocols_, open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_, mirror_protocols_, app_->websocket_tcp_nodelay_options());
+            crow::websocket::Connection<UnixSocketAdaptor, App>::create(req, std::move(adaptor), app_, max_payload_, subprotocols_, open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_, mirror_protocols_, app_->websocket_tcp_socket_options());
         }
 
 #ifdef CROW_ENABLE_SSL
         void handle_upgrade(const request& req, response&, SSLAdaptor&& adaptor) override
         {
-            crow::websocket::Connection<SSLAdaptor, App>::create(req, std::move(adaptor), app_, max_payload_, subprotocols_, open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_, mirror_protocols_, app_->websocket_tcp_nodelay_options());
+            crow::websocket::Connection<SSLAdaptor, App>::create(req, std::move(adaptor), app_, max_payload_, subprotocols_, open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_, mirror_protocols_, app_->websocket_tcp_socket_options());
         }
 #endif
 

--- a/include/crow/routing.h
+++ b/include/crow/routing.h
@@ -444,19 +444,19 @@ namespace crow // NOTE: Already documented in "crow/app.h"
         void handle_upgrade(const request& req, response&, SocketAdaptor&& adaptor) override
         {
             max_payload_ = max_payload_override_ ? max_payload_ : app_->websocket_max_payload();
-            crow::websocket::Connection<SocketAdaptor, App>::create(req, std::move(adaptor), app_, max_payload_, subprotocols_, open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_, mirror_protocols_);
+            crow::websocket::Connection<SocketAdaptor, App>::create(req, std::move(adaptor), app_, max_payload_, subprotocols_, open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_, mirror_protocols_, app_->websocket_tcp_nodelay_options());
         }
 
         void handle_upgrade(const request& req, response&, UnixSocketAdaptor&& adaptor) override
         {
             max_payload_ = max_payload_override_ ? max_payload_ : app_->websocket_max_payload();
-            crow::websocket::Connection<UnixSocketAdaptor, App>::create(req, std::move(adaptor), app_, max_payload_, subprotocols_, open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_, mirror_protocols_);
+            crow::websocket::Connection<UnixSocketAdaptor, App>::create(req, std::move(adaptor), app_, max_payload_, subprotocols_, open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_, mirror_protocols_, app_->websocket_tcp_nodelay_options());
         }
 
 #ifdef CROW_ENABLE_SSL
         void handle_upgrade(const request& req, response&, SSLAdaptor&& adaptor) override
         {
-            crow::websocket::Connection<SSLAdaptor, App>::create(req, std::move(adaptor), app_, max_payload_, subprotocols_, open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_, mirror_protocols_);
+            crow::websocket::Connection<SSLAdaptor, App>::create(req, std::move(adaptor), app_, max_payload_, subprotocols_, open_handler_, message_handler_, close_handler_, error_handler_, accept_handler_, mirror_protocols_, app_->websocket_tcp_nodelay_options());
         }
 #endif
 

--- a/include/crow/tcp_socket_options.h
+++ b/include/crow/tcp_socket_options.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#ifdef CROW_USE_BOOST
+#include <boost/asio.hpp>
+#else
+#ifndef ASIO_STANDALONE
+#define ASIO_STANDALONE
+#endif
+#include <asio.hpp>
+#endif
+
+#include "crow/logging.h"
+
+namespace crow
+{
+#ifdef CROW_USE_BOOST
+    namespace asio = boost::asio;
+    using error_code = boost::system::error_code;
+#else
+    using error_code = asio::error_code;
+#endif
+    using tcp = asio::ip::tcp;
+
+    namespace detail
+    {
+        namespace socket
+        {
+            struct tcp_socket_options
+            {
+                bool no_delay{false};
+            };
+
+            inline void apply_tcp_socket_options(tcp::socket& socket, const tcp_socket_options& options)
+            {
+                if (options.no_delay)
+                {
+                    error_code ec;
+                    socket.set_option(tcp::no_delay(true), ec);
+                    if (ec)
+                    {
+                        CROW_LOG_WARNING << "Failed to set TCP_NODELAY: " << ec.message();
+                    }
+                }
+            }
+
+            template<typename Socket>
+            inline void apply_tcp_socket_options(Socket&, const tcp_socket_options&)
+            {}
+        } // namespace socket
+    } // namespace detail
+} // namespace crow

--- a/include/crow/tcp_socket_options.h
+++ b/include/crow/tcp_socket_options.h
@@ -32,14 +32,11 @@ namespace crow
 
             inline void apply_tcp_socket_options(tcp::socket& socket, const tcp_socket_options& options)
             {
-                if (options.no_delay)
+                error_code ec;
+                socket.set_option(tcp::no_delay(options.no_delay), ec);
+                if (ec)
                 {
-                    error_code ec;
-                    socket.set_option(tcp::no_delay(true), ec);
-                    if (ec)
-                    {
-                        CROW_LOG_WARNING << "Failed to set TCP_NODELAY: " << ec.message();
-                    }
+                    CROW_LOG_WARNING << "Failed to set TCP_NODELAY: " << ec.message();
                 }
             }
 

--- a/include/crow/tcp_socket_options.h
+++ b/include/crow/tcp_socket_options.h
@@ -42,7 +42,9 @@ namespace crow
 
             template<typename Socket>
             inline void apply_tcp_socket_options(Socket&, const tcp_socket_options&)
-            {}
+            {
+                CROW_LOG_WARNING << "This socket type does not support set TCP_NODELAY option";
+            }
         } // namespace socket
     } // namespace detail
 } // namespace crow

--- a/include/crow/websocket.h
+++ b/include/crow/websocket.h
@@ -8,6 +8,7 @@
 #include "crow/logging.h"
 #include "crow/socket_adaptors.h"
 #include "crow/http_request.h"
+#include "crow/tcp_socket_options.h"
 #include "crow/TinySHA1.hpp"
 #include "crow/utility.h"
 
@@ -121,7 +122,8 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                                std::function<void(crow::websocket::connection&, const std::string&, uint16_t)> close_handler,
                                std::function<void(crow::websocket::connection&, const std::string&)> error_handler,
                                std::function<void(const crow::request&, std::optional<crow::response>&, void**)> accept_handler,
-                               bool mirror_protocols)
+                               bool mirror_protocols,
+                               const detail::socket::tcp_socket_options& tcp_options = {})
             {
                 auto conn = std::shared_ptr<Connection>(new Connection(std::move(adaptor), 
                                                                        handler, max_payload,
@@ -130,6 +132,9 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                                                                        std::move(close_handler),
                                                                        std::move(error_handler), 
                                                                        std::move(accept_handler)));
+                
+                // Apply TCP socket options to WebSocket connection
+                detail::socket::apply_tcp_socket_options(conn->adaptor_.socket(), tcp_options);
                 
                 // Perform handshake validation
                 if (!utility::string_equals(req.get_header_value("upgrade"), "websocket"))

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -78,6 +78,25 @@ public:
     }
 };
 
+bool tcp_nodelay_on_connection(const crow::detail::socket::tcp_socket_options& options)
+{
+    asio::io_context io_context;
+    asio::ip::tcp::acceptor acceptor(io_context,
+                                     asio::ip::tcp::endpoint(asio::ip::make_address(LOCALHOST_ADDRESS), 0));
+
+    asio::ip::tcp::socket client_socket(io_context);
+    client_socket.connect(acceptor.local_endpoint());
+
+    asio::ip::tcp::socket server_socket(io_context);
+    acceptor.accept(server_socket);
+
+    crow::detail::socket::apply_tcp_socket_options(server_socket, options);
+
+    asio::ip::tcp::no_delay no_delay;
+    server_socket.get_option(no_delay);
+    return no_delay.value();
+}
+
 TEST_CASE("Rule")
 {
     TaggedRule<> r("/http/");
@@ -2992,21 +3011,7 @@ TEST_CASE("TCP_NODELAY_http_api_enabled")
     auto http_options = app.tcp_socket_options();
     CHECK(http_options.no_delay == true);
 
-    asio::io_context io_context;
-    asio::ip::tcp::acceptor acceptor(io_context,
-                                     asio::ip::tcp::endpoint(asio::ip::make_address(LOCALHOST_ADDRESS), 0));
-
-    asio::ip::tcp::socket client_socket(io_context);
-    client_socket.connect(acceptor.local_endpoint());
-
-    asio::ip::tcp::socket server_socket(io_context);
-    acceptor.accept(server_socket);
-
-    crow::detail::socket::apply_tcp_socket_options(server_socket, http_options);
-
-    asio::ip::tcp::no_delay no_delay;
-    server_socket.get_option(no_delay);
-    CHECK(no_delay.value());
+    CHECK(tcp_nodelay_on_connection(http_options) == true);
 }
 
 // Tests that HTTP socket TCP_NODELAY can be disabled via tcp_nodelay(false) API
@@ -3026,21 +3031,7 @@ TEST_CASE("TCP_NODELAY_http_api_disabled")
     auto http_options = app.tcp_socket_options();
     CHECK(http_options.no_delay == false);
 
-    asio::io_context io_context;
-    asio::ip::tcp::acceptor acceptor(io_context,
-                                     asio::ip::tcp::endpoint(asio::ip::make_address(LOCALHOST_ADDRESS), 0));
-
-    asio::ip::tcp::socket client_socket(io_context);
-    client_socket.connect(acceptor.local_endpoint());
-
-    asio::ip::tcp::socket server_socket(io_context);
-    acceptor.accept(server_socket);
-
-    crow::detail::socket::apply_tcp_socket_options(server_socket, http_options);
-
-    asio::ip::tcp::no_delay no_delay;
-    server_socket.get_option(no_delay);
-    CHECK(!no_delay.value());
+    CHECK(tcp_nodelay_on_connection(http_options) == false);
 }
 
 // Tests that WebSocket socket TCP_NODELAY defaults to false (disabled)
@@ -3075,21 +3066,7 @@ TEST_CASE("TCP_NODELAY_websocket_api_enabled")
     auto ws_options = app.websocket_tcp_socket_options();
     CHECK(ws_options.no_delay == true);
 
-    asio::io_context io_context;
-    asio::ip::tcp::acceptor acceptor(io_context,
-                                     asio::ip::tcp::endpoint(asio::ip::make_address(LOCALHOST_ADDRESS), 0));
-
-    asio::ip::tcp::socket client_socket(io_context);
-    client_socket.connect(acceptor.local_endpoint());
-
-    asio::ip::tcp::socket server_socket(io_context);
-    acceptor.accept(server_socket);
-
-    crow::detail::socket::apply_tcp_socket_options(server_socket, ws_options);
-
-    asio::ip::tcp::no_delay no_delay;
-    server_socket.get_option(no_delay);
-    CHECK(no_delay.value());
+    CHECK(tcp_nodelay_on_connection(ws_options) == true);
 }
 
 // Tests that WebSocket socket TCP_NODELAY can be disabled via websocket_tcp_nodelay(false) API
@@ -3109,21 +3086,7 @@ TEST_CASE("TCP_NODELAY_websocket_api_disabled")
     auto ws_options = app.websocket_tcp_socket_options();
     CHECK(ws_options.no_delay == false);
 
-    asio::io_context io_context;
-    asio::ip::tcp::acceptor acceptor(io_context,
-                                     asio::ip::tcp::endpoint(asio::ip::make_address(LOCALHOST_ADDRESS), 0));
-
-    asio::ip::tcp::socket client_socket(io_context);
-    client_socket.connect(acceptor.local_endpoint());
-
-    asio::ip::tcp::socket server_socket(io_context);
-    acceptor.accept(server_socket);
-
-    crow::detail::socket::apply_tcp_socket_options(server_socket, ws_options);
-
-    asio::ip::tcp::no_delay no_delay;
-    server_socket.get_option(no_delay);
-    CHECK(!no_delay.value());
+    CHECK(tcp_nodelay_on_connection(ws_options) == false);
 }
 
 // Smoke test to verify HTTP server starts and handles requests correctly

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2930,53 +2930,23 @@ TEST_CASE("inject_header_via_set_haeder")
 }
 
 // Tests the low-level apply_tcp_socket_options function to verify that
-// TCP_NODELAY can be enabled (false -> true transition)
+// TCP_NODELAY can be enabled.
 TEST_CASE("TCP_NODELAY_socket_option_apply_enable")
 {
-    asio::io_context io_context;
-    asio::ip::tcp::acceptor acceptor(io_context,
-                                     asio::ip::tcp::endpoint(asio::ip::make_address(LOCALHOST_ADDRESS), 0));
-
-    asio::ip::tcp::socket client_socket(io_context);
-    client_socket.connect(acceptor.local_endpoint());
-
-    asio::ip::tcp::socket server_socket(io_context);
-    acceptor.accept(server_socket);
-
-    server_socket.set_option(asio::ip::tcp::no_delay(false));
-
     crow::detail::socket::tcp_socket_options enable_options;
     enable_options.no_delay = true;
-    crow::detail::socket::apply_tcp_socket_options(server_socket, enable_options);
 
-    asio::ip::tcp::no_delay no_delay_enabled;
-    server_socket.get_option(no_delay_enabled);
-    CHECK(no_delay_enabled.value());
+    CHECK(tcp_nodelay_on_connection(enable_options) == true);
 }
 
 // Tests the low-level apply_tcp_socket_options function to verify that
-// TCP_NODELAY can be disabled (true -> false transition)
+// TCP_NODELAY can be disabled.
 TEST_CASE("TCP_NODELAY_socket_option_apply_disable")
 {
-    asio::io_context io_context;
-    asio::ip::tcp::acceptor acceptor(io_context,
-                                     asio::ip::tcp::endpoint(asio::ip::make_address(LOCALHOST_ADDRESS), 0));
-
-    asio::ip::tcp::socket client_socket(io_context);
-    client_socket.connect(acceptor.local_endpoint());
-
-    asio::ip::tcp::socket server_socket(io_context);
-    acceptor.accept(server_socket);
-
-    server_socket.set_option(asio::ip::tcp::no_delay(true));
-
     crow::detail::socket::tcp_socket_options disable_options;
     disable_options.no_delay = false;
-    crow::detail::socket::apply_tcp_socket_options(server_socket, disable_options);
 
-    asio::ip::tcp::no_delay no_delay_disabled;
-    server_socket.get_option(no_delay_disabled);
-    CHECK(!no_delay_disabled.value());
+    CHECK(tcp_nodelay_on_connection(disable_options) == false);
 }
 
 // Tests that HTTP socket TCP_NODELAY defaults to false (disabled)

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2910,7 +2910,7 @@ TEST_CASE("inject_header_via_set_haeder")
     app.stop();
 }
 
-TEST_CASE("TCP_NODELAY_socket_option_apply")
+TEST_CASE("TCP_NODELAY_socket_option_apply_enable")
 {
     asio::io_context io_context;
     asio::ip::tcp::acceptor acceptor(io_context,
@@ -2931,14 +2931,29 @@ TEST_CASE("TCP_NODELAY_socket_option_apply")
     asio::ip::tcp::no_delay no_delay_enabled;
     server_socket.get_option(no_delay_enabled);
     CHECK(no_delay_enabled.value());
+}
+
+TEST_CASE("TCP_NODELAY_socket_option_apply_disable")
+{
+    asio::io_context io_context;
+    asio::ip::tcp::acceptor acceptor(io_context,
+                                     asio::ip::tcp::endpoint(asio::ip::make_address(LOCALHOST_ADDRESS), 0));
+
+    asio::ip::tcp::socket client_socket(io_context);
+    client_socket.connect(acceptor.local_endpoint());
+
+    asio::ip::tcp::socket server_socket(io_context);
+    acceptor.accept(server_socket);
+
+    server_socket.set_option(asio::ip::tcp::no_delay(true));
 
     crow::detail::socket::tcp_socket_options disable_options;
     disable_options.no_delay = false;
     crow::detail::socket::apply_tcp_socket_options(server_socket, disable_options);
 
-    asio::ip::tcp::no_delay no_delay_after_disable_call;
-    server_socket.get_option(no_delay_after_disable_call);
-    CHECK(!no_delay_after_disable_call.value());
+    asio::ip::tcp::no_delay no_delay_disabled;
+    server_socket.get_option(no_delay_disabled);
+    CHECK(!no_delay_disabled.value());
 }
 
 TEST_CASE("TCP_NODELAY_http_api_defaults")

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2963,6 +2963,7 @@ TEST_CASE("TCP_NODELAY_http_api_defaults")
     // Default should be false (no_delay disabled)
     auto http_options = app.tcp_socket_options();
     CHECK(http_options.no_delay == false);
+    CHECK(is_tcp_nodelay_enabled_for_connection_after_apply(http_options) == false);
 }
 
 // Tests that HTTP socket TCP_NODELAY can be enabled via tcp_nodelay(true) API
@@ -3018,6 +3019,7 @@ TEST_CASE("TCP_NODELAY_websocket_api_defaults")
     // Default should be false (no_delay disabled)
     auto ws_options = app.websocket_tcp_socket_options();
     CHECK(ws_options.no_delay == false);
+    CHECK(is_tcp_nodelay_enabled_for_connection_after_apply(ws_options) == false);
 }
 
 // Tests that WebSocket socket TCP_NODELAY can be enabled via websocket_tcp_nodelay(true) API

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2910,6 +2910,8 @@ TEST_CASE("inject_header_via_set_haeder")
     app.stop();
 }
 
+// Tests the low-level apply_tcp_socket_options function to verify that
+// TCP_NODELAY can be enabled (false -> true transition)
 TEST_CASE("TCP_NODELAY_socket_option_apply_enable")
 {
     asio::io_context io_context;
@@ -2933,6 +2935,8 @@ TEST_CASE("TCP_NODELAY_socket_option_apply_enable")
     CHECK(no_delay_enabled.value());
 }
 
+// Tests the low-level apply_tcp_socket_options function to verify that
+// TCP_NODELAY can be disabled (true -> false transition)
 TEST_CASE("TCP_NODELAY_socket_option_apply_disable")
 {
     asio::io_context io_context;
@@ -2956,6 +2960,7 @@ TEST_CASE("TCP_NODELAY_socket_option_apply_disable")
     CHECK(!no_delay_disabled.value());
 }
 
+// Tests that HTTP socket TCP_NODELAY defaults to false (disabled)
 TEST_CASE("TCP_NODELAY_http_api_defaults")
 {
     crow::SimpleApp app;
@@ -2971,6 +2976,7 @@ TEST_CASE("TCP_NODELAY_http_api_defaults")
     CHECK(http_options.no_delay == false);
 }
 
+// Tests that HTTP socket TCP_NODELAY can be enabled via tcp_nodelay(true) API
 TEST_CASE("TCP_NODELAY_http_api_enabled")
 {
     crow::SimpleApp app;
@@ -2987,6 +2993,7 @@ TEST_CASE("TCP_NODELAY_http_api_enabled")
     CHECK(http_options.no_delay == true);
 }
 
+// Tests that HTTP socket TCP_NODELAY can be disabled via tcp_nodelay(false) API
 TEST_CASE("TCP_NODELAY_http_api_disabled")
 {
     crow::SimpleApp app;
@@ -3004,6 +3011,7 @@ TEST_CASE("TCP_NODELAY_http_api_disabled")
     CHECK(http_options.no_delay == false);
 }
 
+// Tests that WebSocket socket TCP_NODELAY defaults to false (disabled)
 TEST_CASE("TCP_NODELAY_websocket_api_defaults")
 {
     crow::SimpleApp app;
@@ -3019,6 +3027,7 @@ TEST_CASE("TCP_NODELAY_websocket_api_defaults")
     CHECK(ws_options.no_delay == false);
 }
 
+// Tests that WebSocket socket TCP_NODELAY can be enabled via websocket_tcp_nodelay(true) API
 TEST_CASE("TCP_NODELAY_websocket_api_enabled")
 {
     crow::SimpleApp app;
@@ -3035,6 +3044,7 @@ TEST_CASE("TCP_NODELAY_websocket_api_enabled")
     CHECK(ws_options.no_delay == true);
 }
 
+// Tests that WebSocket socket TCP_NODELAY can be disabled via websocket_tcp_nodelay(false) API
 TEST_CASE("TCP_NODELAY_websocket_api_disabled")
 {
     crow::SimpleApp app;
@@ -3052,6 +3062,8 @@ TEST_CASE("TCP_NODELAY_websocket_api_disabled")
     CHECK(ws_options.no_delay == false);
 }
 
+// Smoke test to verify HTTP server starts and handles requests correctly
+// with TCP_NODELAY enabled on HTTP sockets
 TEST_CASE("TCP_NODELAY_http_smoke_test")
 {
     crow::SimpleApp app;
@@ -3079,6 +3091,8 @@ TEST_CASE("TCP_NODELAY_http_smoke_test")
     CHECK(response.find("ok") != std::string::npos);
 }
 
+// Smoke test to verify WebSocket upgrade handshake succeeds and connections work
+// correctly with TCP_NODELAY enabled on WebSocket sockets
 TEST_CASE("TCP_NODELAY_websocket_smoke_test")
 {
     crow::SimpleApp app;

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -78,7 +78,7 @@ public:
     }
 };
 
-bool tcp_nodelay_on_connection(const crow::detail::socket::tcp_socket_options& options)
+bool is_tcp_nodelay_enabled_for_connection_after_apply(const crow::detail::socket::tcp_socket_options& options)
 {
     asio::io_context io_context;
     asio::ip::tcp::acceptor acceptor(io_context,
@@ -2936,7 +2936,7 @@ TEST_CASE("TCP_NODELAY_socket_option_apply_enable")
     crow::detail::socket::tcp_socket_options enable_options;
     enable_options.no_delay = true;
 
-    CHECK(tcp_nodelay_on_connection(enable_options) == true);
+    CHECK(is_tcp_nodelay_enabled_for_connection_after_apply(enable_options) == true);
 }
 
 // Tests the low-level apply_tcp_socket_options function to verify that
@@ -2946,7 +2946,7 @@ TEST_CASE("TCP_NODELAY_socket_option_apply_disable")
     crow::detail::socket::tcp_socket_options disable_options;
     disable_options.no_delay = false;
 
-    CHECK(tcp_nodelay_on_connection(disable_options) == false);
+    CHECK(is_tcp_nodelay_enabled_for_connection_after_apply(disable_options) == false);
 }
 
 // Tests that HTTP socket TCP_NODELAY defaults to false (disabled)
@@ -2981,7 +2981,7 @@ TEST_CASE("TCP_NODELAY_http_api_enabled")
     auto http_options = app.tcp_socket_options();
     CHECK(http_options.no_delay == true);
 
-    CHECK(tcp_nodelay_on_connection(http_options) == true);
+    CHECK(is_tcp_nodelay_enabled_for_connection_after_apply(http_options) == true);
 }
 
 // Tests that HTTP socket TCP_NODELAY can be disabled via tcp_nodelay(false) API
@@ -3001,7 +3001,7 @@ TEST_CASE("TCP_NODELAY_http_api_disabled")
     auto http_options = app.tcp_socket_options();
     CHECK(http_options.no_delay == false);
 
-    CHECK(tcp_nodelay_on_connection(http_options) == false);
+    CHECK(is_tcp_nodelay_enabled_for_connection_after_apply(http_options) == false);
 }
 
 // Tests that WebSocket socket TCP_NODELAY defaults to false (disabled)
@@ -3036,7 +3036,7 @@ TEST_CASE("TCP_NODELAY_websocket_api_enabled")
     auto ws_options = app.websocket_tcp_socket_options();
     CHECK(ws_options.no_delay == true);
 
-    CHECK(tcp_nodelay_on_connection(ws_options) == true);
+    CHECK(is_tcp_nodelay_enabled_for_connection_after_apply(ws_options) == true);
 }
 
 // Tests that WebSocket socket TCP_NODELAY can be disabled via websocket_tcp_nodelay(false) API
@@ -3056,7 +3056,7 @@ TEST_CASE("TCP_NODELAY_websocket_api_disabled")
     auto ws_options = app.websocket_tcp_socket_options();
     CHECK(ws_options.no_delay == false);
 
-    CHECK(tcp_nodelay_on_connection(ws_options) == false);
+    CHECK(is_tcp_nodelay_enabled_for_connection_after_apply(ws_options) == false);
 }
 
 // Smoke test to verify HTTP server starts and handles requests correctly

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2938,79 +2938,182 @@ TEST_CASE("TCP_NODELAY_socket_option_apply")
 
     asio::ip::tcp::no_delay no_delay_after_disable_call;
     server_socket.get_option(no_delay_after_disable_call);
-    CHECK(no_delay_after_disable_call.value());
+    CHECK(!no_delay_after_disable_call.value());
 }
 
-TEST_CASE("TCP_NODELAY_app_api_smoke")
+TEST_CASE("TCP_NODELAY_http_api_defaults")
 {
-    auto run_request = [](crow::SimpleApp& app) {
-        auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(0).run_async();
-        app.wait_for_server_start();
+    crow::SimpleApp app;
 
-        auto response = HttpClient::request(LOCALHOST_ADDRESS,
-                                            app.port(),
-                                            "GET / HTTP/1.0\r\n"
-                                            "Host: localhost\r\n"
-                                            "\r\n");
+    CROW_ROUTE(app, "/")([] {
+        return "ok";
+    });
 
-        app.stop();
-        return response;
-    };
+    app.validate();
 
-    {
-        crow::SimpleApp app;
-        CROW_ROUTE(app, "/")([] {
-            return "ok";
-        });
-        app.validate();
-
-        app.tcp_nodelay(true);
-        auto response = run_request(app);
-        CHECK(response.find("200 OK") != std::string::npos);
-    }
-
-    {
-        crow::SimpleApp app;
-        CROW_ROUTE(app, "/")([] {
-            return "ok";
-        });
-        app.validate();
-
-        app.tcp_nodelay(false);
-        auto response = run_request(app);
-        CHECK(response.find("200 OK") != std::string::npos);
-    }
+    // Default should be false (no_delay disabled)
+    auto http_options = app.tcp_socket_options();
+    CHECK(http_options.no_delay == false);
 }
 
-TEST_CASE("TCP_NODELAY_websocket_api")
+TEST_CASE("TCP_NODELAY_http_api_enabled")
+{
+    crow::SimpleApp app;
+
+    CROW_ROUTE(app, "/")([] {
+        return "ok";
+    });
+
+    app.validate();
+
+    // Enable TCP_NODELAY
+    app.tcp_nodelay(true);
+    auto http_options = app.tcp_socket_options();
+    CHECK(http_options.no_delay == true);
+}
+
+TEST_CASE("TCP_NODELAY_http_api_disabled")
+{
+    crow::SimpleApp app;
+
+    CROW_ROUTE(app, "/")([] {
+        return "ok";
+    });
+
+    app.validate();
+
+    // Enable first, then disable
+    app.tcp_nodelay(true);
+    app.tcp_nodelay(false);
+    auto http_options = app.tcp_socket_options();
+    CHECK(http_options.no_delay == false);
+}
+
+TEST_CASE("TCP_NODELAY_websocket_api_defaults")
 {
     crow::SimpleApp app;
 
     CROW_WEBSOCKET_ROUTE(app, "/ws")
-        .onopen([&](crow::websocket::connection& conn){
-            conn.send_text("Connected");
-        })
-        .onmessage([&](crow::websocket::connection& conn, const std::string& data, bool /*is_binary*/){
-            conn.send_text("Echo: " + data);
-        });
+        .onopen([&](crow::websocket::connection&){})
+        .onmessage([&](crow::websocket::connection&, const std::string&, bool){});
 
     app.validate();
 
-    // Test setting TCP_NODELAY for HTTP connections
-    app.tcp_nodelay(true);
-    auto http_options = app.tcp_socket_options();
-    CHECK(http_options.no_delay == true);
+    // Default should be false (no_delay disabled)
+    auto ws_options = app.websocket_tcp_socket_options();
+    CHECK(ws_options.no_delay == false);
+}
 
-    app.tcp_nodelay(false);
-    http_options = app.tcp_socket_options();
-    CHECK(http_options.no_delay == false);
+TEST_CASE("TCP_NODELAY_websocket_api_enabled")
+{
+    crow::SimpleApp app;
 
-    // Test setting TCP_NODELAY for WebSocket connections
+    CROW_WEBSOCKET_ROUTE(app, "/ws")
+        .onopen([&](crow::websocket::connection&){})
+        .onmessage([&](crow::websocket::connection&, const std::string&, bool){});
+
+    app.validate();
+
+    // Enable TCP_NODELAY
     app.websocket_tcp_nodelay(true);
     auto ws_options = app.websocket_tcp_socket_options();
     CHECK(ws_options.no_delay == true);
+}
 
+TEST_CASE("TCP_NODELAY_websocket_api_disabled")
+{
+    crow::SimpleApp app;
+
+    CROW_WEBSOCKET_ROUTE(app, "/ws")
+        .onopen([&](crow::websocket::connection&){})
+        .onmessage([&](crow::websocket::connection&, const std::string&, bool){});
+
+    app.validate();
+
+    // Enable first, then disable
+    app.websocket_tcp_nodelay(true);
     app.websocket_tcp_nodelay(false);
-    ws_options = app.websocket_tcp_socket_options();
+    auto ws_options = app.websocket_tcp_socket_options();
     CHECK(ws_options.no_delay == false);
+}
+
+TEST_CASE("TCP_NODELAY_http_smoke_test")
+{
+    crow::SimpleApp app;
+
+    CROW_ROUTE(app, "/")([] {
+        return "ok";
+    });
+
+    app.validate();
+
+    // Test with TCP_NODELAY enabled
+    app.tcp_nodelay(true);
+    
+    auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(0).run_async();
+    app.wait_for_server_start();
+
+    auto response = HttpClient::request(LOCALHOST_ADDRESS,
+                                        app.port(),
+                                        "GET / HTTP/1.0\r\n"
+                                        "Host: localhost\r\n"
+                                        "\r\n");
+
+    app.stop();
+    CHECK(response.find("200 OK") != std::string::npos);
+    CHECK(response.find("ok") != std::string::npos);
+}
+
+TEST_CASE("TCP_NODELAY_websocket_smoke_test")
+{
+    crow::SimpleApp app;
+
+    std::string received_message;
+
+    CROW_WEBSOCKET_ROUTE(app, "/ws")
+        .onopen([&](crow::websocket::connection& conn){
+            conn.send_text("Hello WebSocket");
+        })
+        .onmessage([&](crow::websocket::connection& conn, const std::string& data, bool /*is_binary*/){
+            received_message = data;
+            conn.send_text("Echo: " + data);
+        })
+        .onclose([&](crow::websocket::connection&, const std::string&, uint16_t){});
+
+    app.validate();
+
+    // Test with TCP_NODELAY enabled for WebSocket
+    app.websocket_tcp_nodelay(true);
+    
+    auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(0).run_async();
+    app.wait_for_server_start();
+
+    // Simple WebSocket connection test
+    asio::io_context ic;
+    asio::ip::tcp::socket socket(ic);
+    socket.connect(asio::ip::tcp::endpoint(asio::ip::make_address(LOCALHOST_ADDRESS), app.port()));
+
+    // Send WebSocket upgrade request
+    std::string upgrade_request =
+        "GET /ws HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+        "Sec-WebSocket-Version: 13\r\n"
+        "\r\n";
+
+    socket.send(asio::buffer(upgrade_request));
+
+    // Receive upgrade response
+    std::vector<char> response_buffer(4096);
+    size_t bytes_received = socket.receive(asio::buffer(response_buffer));
+    std::string response(response_buffer.begin(), response_buffer.begin() + bytes_received);
+
+    // Check if we got 101 Switching Protocols
+    CHECK(response.find("101") != std::string::npos);
+    CHECK(response.find("Upgrade") != std::string::npos);
+
+    socket.close();
+    app.stop();
 }

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2991,6 +2991,22 @@ TEST_CASE("TCP_NODELAY_http_api_enabled")
     app.tcp_nodelay(true);
     auto http_options = app.tcp_socket_options();
     CHECK(http_options.no_delay == true);
+
+    asio::io_context io_context;
+    asio::ip::tcp::acceptor acceptor(io_context,
+                                     asio::ip::tcp::endpoint(asio::ip::make_address(LOCALHOST_ADDRESS), 0));
+
+    asio::ip::tcp::socket client_socket(io_context);
+    client_socket.connect(acceptor.local_endpoint());
+
+    asio::ip::tcp::socket server_socket(io_context);
+    acceptor.accept(server_socket);
+
+    crow::detail::socket::apply_tcp_socket_options(server_socket, http_options);
+
+    asio::ip::tcp::no_delay no_delay;
+    server_socket.get_option(no_delay);
+    CHECK(no_delay.value());
 }
 
 // Tests that HTTP socket TCP_NODELAY can be disabled via tcp_nodelay(false) API
@@ -3009,6 +3025,22 @@ TEST_CASE("TCP_NODELAY_http_api_disabled")
     app.tcp_nodelay(false);
     auto http_options = app.tcp_socket_options();
     CHECK(http_options.no_delay == false);
+
+    asio::io_context io_context;
+    asio::ip::tcp::acceptor acceptor(io_context,
+                                     asio::ip::tcp::endpoint(asio::ip::make_address(LOCALHOST_ADDRESS), 0));
+
+    asio::ip::tcp::socket client_socket(io_context);
+    client_socket.connect(acceptor.local_endpoint());
+
+    asio::ip::tcp::socket server_socket(io_context);
+    acceptor.accept(server_socket);
+
+    crow::detail::socket::apply_tcp_socket_options(server_socket, http_options);
+
+    asio::ip::tcp::no_delay no_delay;
+    server_socket.get_option(no_delay);
+    CHECK(!no_delay.value());
 }
 
 // Tests that WebSocket socket TCP_NODELAY defaults to false (disabled)
@@ -3042,6 +3074,22 @@ TEST_CASE("TCP_NODELAY_websocket_api_enabled")
     app.websocket_tcp_nodelay(true);
     auto ws_options = app.websocket_tcp_socket_options();
     CHECK(ws_options.no_delay == true);
+
+    asio::io_context io_context;
+    asio::ip::tcp::acceptor acceptor(io_context,
+                                     asio::ip::tcp::endpoint(asio::ip::make_address(LOCALHOST_ADDRESS), 0));
+
+    asio::ip::tcp::socket client_socket(io_context);
+    client_socket.connect(acceptor.local_endpoint());
+
+    asio::ip::tcp::socket server_socket(io_context);
+    acceptor.accept(server_socket);
+
+    crow::detail::socket::apply_tcp_socket_options(server_socket, ws_options);
+
+    asio::ip::tcp::no_delay no_delay;
+    server_socket.get_option(no_delay);
+    CHECK(no_delay.value());
 }
 
 // Tests that WebSocket socket TCP_NODELAY can be disabled via websocket_tcp_nodelay(false) API
@@ -3060,6 +3108,22 @@ TEST_CASE("TCP_NODELAY_websocket_api_disabled")
     app.websocket_tcp_nodelay(false);
     auto ws_options = app.websocket_tcp_socket_options();
     CHECK(ws_options.no_delay == false);
+
+    asio::io_context io_context;
+    asio::ip::tcp::acceptor acceptor(io_context,
+                                     asio::ip::tcp::endpoint(asio::ip::make_address(LOCALHOST_ADDRESS), 0));
+
+    asio::ip::tcp::socket client_socket(io_context);
+    client_socket.connect(acceptor.local_endpoint());
+
+    asio::ip::tcp::socket server_socket(io_context);
+    acceptor.accept(server_socket);
+
+    crow::detail::socket::apply_tcp_socket_options(server_socket, ws_options);
+
+    asio::ip::tcp::no_delay no_delay;
+    server_socket.get_option(no_delay);
+    CHECK(!no_delay.value());
 }
 
 // Smoke test to verify HTTP server starts and handles requests correctly

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2910,3 +2910,74 @@ TEST_CASE("inject_header_via_set_haeder")
     app.stop();
 }
 
+TEST_CASE("TCP_NODELAY_socket_option_apply")
+{
+    asio::io_context io_context;
+    asio::ip::tcp::acceptor acceptor(io_context,
+                                     asio::ip::tcp::endpoint(asio::ip::make_address(LOCALHOST_ADDRESS), 0));
+
+    asio::ip::tcp::socket client_socket(io_context);
+    client_socket.connect(acceptor.local_endpoint());
+
+    asio::ip::tcp::socket server_socket(io_context);
+    acceptor.accept(server_socket);
+
+    server_socket.set_option(asio::ip::tcp::no_delay(false));
+
+    crow::detail::socket::tcp_socket_options enable_options;
+    enable_options.no_delay = true;
+    crow::detail::socket::apply_tcp_socket_options(server_socket, enable_options);
+
+    asio::ip::tcp::no_delay no_delay_enabled;
+    server_socket.get_option(no_delay_enabled);
+    CHECK(no_delay_enabled.value());
+
+    crow::detail::socket::tcp_socket_options disable_options;
+    disable_options.no_delay = false;
+    crow::detail::socket::apply_tcp_socket_options(server_socket, disable_options);
+
+    asio::ip::tcp::no_delay no_delay_after_disable_call;
+    server_socket.get_option(no_delay_after_disable_call);
+    CHECK(no_delay_after_disable_call.value());
+}
+
+TEST_CASE("TCP_NODELAY_app_api_smoke")
+{
+    auto run_request = [](crow::SimpleApp& app) {
+        auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(0).run_async();
+        app.wait_for_server_start();
+
+        auto response = HttpClient::request(LOCALHOST_ADDRESS,
+                                            app.port(),
+                                            "GET / HTTP/1.0\r\n"
+                                            "Host: localhost\r\n"
+                                            "\r\n");
+
+        app.stop();
+        return response;
+    };
+
+    {
+        crow::SimpleApp app;
+        CROW_ROUTE(app, "/")([] {
+            return "ok";
+        });
+        app.validate();
+
+        app.tcp_nodelay(true);
+        auto response = run_request(app);
+        CHECK(response.find("200 OK") != std::string::npos);
+    }
+
+    {
+        crow::SimpleApp app;
+        CROW_ROUTE(app, "/")([] {
+            return "ok";
+        });
+        app.validate();
+
+        app.tcp_nodelay(false);
+        auto response = run_request(app);
+        CHECK(response.find("200 OK") != std::string::npos);
+    }
+}

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -3103,12 +3103,10 @@ TEST_CASE("TCP_NODELAY_websocket_smoke_test")
     auto _ = app.bindaddr(LOCALHOST_ADDRESS).port(0).run_async();
     app.wait_for_server_start();
 
-    // Simple WebSocket connection test
     asio::io_context ic;
     asio::ip::tcp::socket socket(ic);
     socket.connect(asio::ip::tcp::endpoint(asio::ip::make_address(LOCALHOST_ADDRESS), app.port()));
 
-    // Send WebSocket upgrade request
     std::string upgrade_request =
         "GET /ws HTTP/1.1\r\n"
         "Host: localhost\r\n"
@@ -3120,12 +3118,10 @@ TEST_CASE("TCP_NODELAY_websocket_smoke_test")
 
     socket.send(asio::buffer(upgrade_request));
 
-    // Receive upgrade response
     std::vector<char> response_buffer(4096);
     size_t bytes_received = socket.receive(asio::buffer(response_buffer));
     std::string response(response_buffer.begin(), response_buffer.begin() + bytes_received);
 
-    // Check if we got 101 Switching Protocols
     CHECK(response.find("101") != std::string::npos);
     CHECK(response.find("Upgrade") != std::string::npos);
 

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2996,14 +2996,21 @@ TEST_CASE("TCP_NODELAY_websocket_api")
 
     app.validate();
 
+    // Test setting TCP_NODELAY for HTTP connections
+    app.tcp_nodelay(true);
+    auto http_options = app.tcp_socket_options();
+    CHECK(http_options.no_delay == true);
+
+    app.tcp_nodelay(false);
+    http_options = app.tcp_socket_options();
+    CHECK(http_options.no_delay == false);
+
     // Test setting TCP_NODELAY for WebSocket connections
     app.websocket_tcp_nodelay(true);
-    
-    auto options = app.websocket_tcp_nodelay_options();
-    CHECK(options.no_delay == true);
+    auto ws_options = app.websocket_tcp_socket_options();
+    CHECK(ws_options.no_delay == true);
 
     app.websocket_tcp_nodelay(false);
-    
-    options = app.websocket_tcp_nodelay_options();
-    CHECK(options.no_delay == false);
+    ws_options = app.websocket_tcp_socket_options();
+    CHECK(ws_options.no_delay == false);
 }

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -2981,3 +2981,29 @@ TEST_CASE("TCP_NODELAY_app_api_smoke")
         CHECK(response.find("200 OK") != std::string::npos);
     }
 }
+
+TEST_CASE("TCP_NODELAY_websocket_api")
+{
+    crow::SimpleApp app;
+
+    CROW_WEBSOCKET_ROUTE(app, "/ws")
+        .onopen([&](crow::websocket::connection& conn){
+            conn.send_text("Connected");
+        })
+        .onmessage([&](crow::websocket::connection& conn, const std::string& data, bool /*is_binary*/){
+            conn.send_text("Echo: " + data);
+        });
+
+    app.validate();
+
+    // Test setting TCP_NODELAY for WebSocket connections
+    app.websocket_tcp_nodelay(true);
+    
+    auto options = app.websocket_tcp_nodelay_options();
+    CHECK(options.no_delay == true);
+
+    app.websocket_tcp_nodelay(false);
+    
+    options = app.websocket_tcp_nodelay_options();
+    CHECK(options.no_delay == false);
+}


### PR DESCRIPTION
This PR implements independent TCP socket option configuration for HTTP and WebSocket servers, resolving the requirement to differentiate between socket options for different server types.

HTTP and WebSocket connections have fundamentally different traffic patterns:
- **HTTP**: Request-response pattern → benefits from TCP_NODELAY enabled (low latency)
- **WebSocket**: Streaming pattern → benefits from TCP_NODELAY disabled (higher throughput via packet batching)

Previously, both protocols shared the same socket options. This implementation allows independent configuration while maintaining a clean, symmetric API.

Changes

- **`include/crow/tcp_socket_options.h`**
  - `struct tcp_socket_options` - container for TCP options
  - `apply_tcp_socket_options()` - applies options to TCP sockets with error handling
  - Generic template specialization for non-TCP sockets (no-op)
  - Supports both Boost.ASIO and standalone ASIO

API Extensions
- **`include/crow/app.h`**
  - `tcp_nodelay(bool enabled = true)` - configure HTTP TCP_NODELAY
  - `tcp_socket_options()` - retrieve HTTP TCP settings
  - `websocket_tcp_nodelay(bool enabled = true)` - configure WebSocket TCP_NODELAY
  - `websocket_tcp_socket_options()` - retrieve WebSocket TCP settings
  - Private fields: `tcp_socket_options_` and `websocket_tcp_socket_options_`

Integration
- **`include/crow/websocket.h`**
  - Added `tcp_options` parameter to `Connection::create()`
  - Options applied immediately after connection creation, before handshake

- **`include/crow/routing.h`**
  - All WebSocket upgrade handlers pass `websocket_tcp_socket_options()` to connection factory
  - Supports SocketAdaptor, UnixSocketAdaptor, and SSLAdaptor

Test Coverage
- **`tests/unittest.cpp`** 
  - 2 low-level infrastructure tests (enable/disable transitions)
  - 6 API tests (HTTP and WebSocket defaults, enable, disable)
  - 2 integration/smoke tests (HTTP server and WebSocket handshake)
  
Test Cases
- TCP_NODELAY_socket_option_apply_enable - Low-level: enable transition
- TCP_NODELAY_socket_option_apply_disable - Low-level: disable transition
- TCP_NODELAY_http_api_defaults - HTTP defaults to disabled
- TCP_NODELAY_http_api_enabled - HTTP can be enabled
- TCP_NODELAY_http_api_disabled - HTTP can be disabled
- TCP_NODELAY_websocket_api_defaults - WebSocket defaults to disabled
- TCP_NODELAY_websocket_api_enabled - WebSocket can be enabled
- TCP_NODELAY_websocket_api_disabled - WebSocket can be disabled
- TCP_NODELAY_http_smoke_test - HTTP server integration test
- TCP_NODELAY_websocket_smoke_test - WebSocket handshake integration test

Compatibility / Impact
None. This is a purely additive feature with sensible defaults (TCP_NODELAY disabled for both).