### PR TITLE
Fixing type-limits warning/error.

### DIFF
--- a/include/crow/json.h
+++ b/include/crow/json.h
@@ -24,6 +24,11 @@
 using std::isinf;
 using std::isnan;
 
+#ifdef __CHAR_UNSIGNED__
+#define IS_CONTROL_ASCII(c) (c < 0x20)
+#else
+#define IS_CONTROL_ASCII(c) ((c >= 0) && (c < 0x20))
+#endif
 
 namespace crow // NOTE: Already documented in "crow/app.h"
 {
@@ -57,7 +62,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                     case '\r': ret += "\\r"; break;
                     case '\t': ret += "\\t"; break;
                     default:
-                        if (c >= 0 && c < 0x20)
+                        if (IS_CONTROL_ASCII(c))
                         {
                             ret += "\\u00";
                             ret += to_hex(c / 16);


### PR DESCRIPTION
Fixing the `-Wtype-limits` that can be an error on some compilers (GCC 14.3.1 20250617 (Red Hat 14.3.1-2) for ARM64v8)

ASCII Char can either be signed or unsigned on some definitions of gcc, so this check is really important, using `__CHAR_UNSIGNED__`, however this can lead to some warnings/errors if it is unsigned and that we check if its positive (which is always true).