### PR TITLE
docs: document TCP_NODELAY settings for HTTP and WebSocket guides

### DIFF
--- a/docs/guides/app.md
+++ b/docs/guides/app.md
@@ -32,6 +32,26 @@ app.bindaddr("192.168.1.2")
 
     When using `run_async()`, make sure to use a variable to save the function's output (such as `#!cpp auto _a = app.run_async()`). Otherwise the app will run synchronously.
 
+## TCP socket options
+<span class="tag">[:octicons-feed-tag-16: master](https://github.com/CrowCpp/Crow)</span>
+
+Crow lets you control TCP_NODELAY for accepted connections.
+
+- `#!cpp app.tcp_nodelay(true)` enables TCP_NODELAY on HTTP server connections.
+- `#!cpp app.websocket_tcp_nodelay(true)` enables TCP_NODELAY on WebSocket connections.
+
+These settings can be configured independently.
+
+```cpp
+crow::SimpleApp app;
+
+app.tcp_nodelay(true)
+   .websocket_tcp_nodelay(true)
+   .port(18080)
+   .multithreaded()
+   .run();
+```
+
 <br><br>
 
 For more info on middlewares, check out [this page](middleware.md).<br><br>

--- a/docs/guides/app.md
+++ b/docs/guides/app.md
@@ -37,8 +37,8 @@ app.bindaddr("192.168.1.2")
 
 Crow lets you control TCP_NODELAY for accepted connections.
 
-- `#!cpp app.tcp_nodelay(true)` enables TCP_NODELAY on HTTP server connections.
-- `#!cpp app.websocket_tcp_nodelay(true)` enables TCP_NODELAY on WebSocket connections.
+- `app.tcp_nodelay(true)` enables TCP_NODELAY on HTTP server connections.
+- `app.websocket_tcp_nodelay(true)` enables TCP_NODELAY on WebSocket connections.
 
 These settings can be configured independently.
 

--- a/docs/guides/websockets.md
+++ b/docs/guides/websockets.md
@@ -50,6 +50,27 @@ The maximum payload size that a connection accepts can be adjusted either global
 
 Specifies the possible subprotocols that are available for the client. If specified, the first match with the client's requested subprotocols will be returned in the "Sec-WebSocket-Protocol" header of the handshake response. Otherwise, the connection will be closed. If no subprotocol are specified on both the client and the server side, the connection process will continue normally. It can be specified by using `#!cpp CROW_WEBSOCKET_ROUTE(app, "/url").subprotocols(<values>)`.
 
+## TCP_NODELAY for WebSocket sockets
+<span class="tag">[:octicons-feed-tag-16: master](https://github.com/CrowCpp/Crow)</span>
+
+You can enable or disable TCP_NODELAY for WebSocket connections with:
+
+- `#!cpp app.websocket_tcp_nodelay(true)`
+
+This setting is separate from HTTP connections.
+To control HTTP sockets, use:
+
+- `#!cpp app.tcp_nodelay(true)`
+
+Example:
+
+```cpp
+crow::SimpleApp app;
+
+app.tcp_nodelay(true)
+    .websocket_tcp_nodelay(true);
+```
+
 
 For more info about websocket routes go [here](../reference/classcrow_1_1_web_socket_rule.html).
 

--- a/docs/guides/websockets.md
+++ b/docs/guides/websockets.md
@@ -55,12 +55,12 @@ Specifies the possible subprotocols that are available for the client. If specif
 
 You can enable or disable TCP_NODELAY for WebSocket connections with:
 
-- `#!cpp app.websocket_tcp_nodelay(true)`
+- `app.websocket_tcp_nodelay(true)`
 
 This setting is separate from HTTP connections.
 To control HTTP sockets, use:
 
-- `#!cpp app.tcp_nodelay(true)`
+- `app.tcp_nodelay(true)`
 
 Example:
 


### PR DESCRIPTION
This PR updates the user-facing documentation to cover TCP socket options introduced for HTTP and WebSocket connections.

Refers to: #1202

- Added a new TCP socket options section in ```docs/guides/app.md```
- Added an explicit WebSocket-focused section in ```docs/guides/websockets.md```