### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,4 +211,4 @@ Crow has incorporated the following libraries into its source.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=CrowCpp/Crow,oatpp/oatpp,drogonframework/drogon&type=Date)](https://www.star-history.com/#CrowCpp/Crow&oatpp/oatpp&drogonframework/drogon&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=CrowCpp/Crow,oatpp/oatpp,drogonframework/drogon&type=Date)](https://star-history.dera.page/#CrowCpp/Crow&oatpp/oatpp&drogonframework/drogon&Date)


### PR DESCRIPTION
The star history chart shown in the README is currently not rendering because the previous data source is affected by GitHub stargazer API restrictions. This change switches the chart image and its link to a working data source that requires no API token, restoring the chart for readers.