### PR TITLE
fix(app): keep blueprints when CROW_DISABLE_STATIC_DIR is set (#941)

### DIFF
--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -615,6 +615,9 @@ namespace crow
         /// \brief A wrapper for `validate()` in the router
         void validate()
         {
+            // Always validate blueprints so routes remain available when
+            // CROW_DISABLE_STATIC_DIR skips add_blueprint()/add_static_dir().
+            router_.validate_bp();
             router_.validate();
         }
 


### PR DESCRIPTION
## Summary
`CROW_DISABLE_STATIC_DIR` gated both `add_blueprint()` and `add_static_dir()`, so blueprint routes were never registered (`router_.validate_bp()` never ran).

This moves blueprint validation into `Crow::validate()` so blueprints stay active when the static-directory define is set. Global/blueprint static file routes remain behind `CROW_DISABLE_STATIC_DIR`.

## Test plan
- [ ] Build with `CROW_DISABLE_STATIC_DIR` and run `examples/example_blueprint.cpp` — blueprint routes respond
- [ ] `app.debug_print()` shows blueprint routes when the define is set
- [ ] Without the define, default `/static/` behavior is unchanged
- [ ] Existing blueprint unit test still passes

Fixes #941
