### PR TITLE
fix(query): decode %5B/%5D dict keys like literal brackets (#1109)

### DIFF
--- a/include/crow/query_string.h
+++ b/include/crow/query_string.h
@@ -234,6 +234,31 @@ inline std::unique_ptr<std::pair<std::string, std::string>> qs_dict_name2kv(cons
                 skip_to_brace_open++;
             skip_to_brace_close = strcspn(qs_kv[i], "]");
 
+            // Encoded brackets: page%5Bsize%5D=3 should match page[size]=3 (#1109).
+            if ( skip_to_brace_open == strlen(qs_kv[i]) )
+            {
+                const char* open = strstr(qs_kv[i] + name_len, "%5B");
+                if (!open)
+                    open = strstr(qs_kv[i] + name_len, "%5b");
+                if ( open && open == qs_kv[i] + name_len )
+                {
+                    const char* close = strstr(open + 3, "%5D");
+                    if (!close)
+                        close = strstr(open + 3, "%5d");
+                    if ( close && nth == 0 )
+                    {
+                        auto key = std::string(open + 3, static_cast<size_t>(close - (open + 3)));
+                        auto value = std::string(qs_kv[i] + skip_to_eq);
+                        return std::unique_ptr<std::pair<std::string, std::string>>(new std::pair<std::string, std::string>(key, value));
+                    }
+                    else if ( close )
+                    {
+                        --nth;
+                        continue;
+                    }
+                }
+            }
+
             if ( skip_to_brace_open <= skip_to_brace_close &&
                  skip_to_brace_open > 0 &&
                  skip_to_brace_close > 0 &&


### PR DESCRIPTION
﻿## Summary
Treats URL-encoded dictionary keys as equivalent to literal brackets in query parsing (#1109).

`get_dict("page")` already understood `page[size]=3`, but `page%5Bsize%5D=3` was left as a flat key because `qs_dict_name2kv` only looked for `[` / `]`.

## Change
In `qs_dict_name2kv`, when no literal `[` is present after the dict name, also accept `%5B` / `%5D` (case-insensitive hex) and return the inner key/value pair.

Closes #1109
