### PR TITLE
disable Crow install by default for subprojects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ option(CROW_BUILD_TESTS        "Build the tests in the project"         ${CROW_I
 option(CROW_BUILD_FUZZER       "Instrument and build Crow fuzzer"       OFF)
 option(CROW_ENABLE_SANITIZERS  "Enable sanitizers (ASan, UBSan) for test builds" OFF)
 option(CROW_AMALGAMATE         "Combine all headers into one"           OFF)
-option(CROW_INSTALL            "Add install step for Crow"              ON )
+option(CROW_INSTALL            "Add install step for Crow"              ${CROW_IS_MAIN_PROJECT})
 option(CROW_USE_BOOST          "Use Boost.Asio for Crow"                OFF)
 option(CROW_GENERATE_SBOM      "Generate SBOM file"                     OFF)
 option(CROW_RETURNS_OK_ON_HTTP_OPTIONS_REQUEST


### PR DESCRIPTION
Change the default value of `CROW_INSTALL` to depend on `CROW_IS_MAIN_PROJECT`.

When Crow is included as a subproject via `add_subdirectory(crow)`, installation is now disabled by default. When Crow is built as the main project, the existing install behavior remains enabled.
