### PR TITLE
fix(query): erase with the same key match the getters use in pop/pop_list/pop_dict

### DIFF
--- a/include/crow/query_string.h
+++ b/include/crow/query_string.h
@@ -415,11 +415,10 @@ namespace crow
             char* ret = get(name);
             if (ret != nullptr)
             {
-                const std::string key_name = name + '=';
                 for (unsigned int i = 0; i < key_value_pairs_.size(); i++)
                 {
-                    std::string str_item(key_value_pairs_[i]);
-                    if (str_item.find(key_name)==0)
+                    // erase with the same URL-decoding key match get() used to find it
+                    if (qs_k2v(name.c_str(), key_value_pairs_.data() + i, 1) != nullptr)
                     {
                         key_value_pairs_.erase(key_value_pairs_.begin() + i);
                         break;
@@ -454,19 +453,14 @@ namespace crow
         std::vector<char*> pop_list(const std::string& name, bool use_brackets = true)
         {
             std::vector<char*> ret = get_list(name, use_brackets);
-            const size_t name_len = name.length();
+            const std::string full_name = name + (use_brackets ? "[]" : "");
             if (!ret.empty())
             {
                 for (unsigned int i = 0; i < key_value_pairs_.size(); i++)
                 {
-                    std::string str_item(key_value_pairs_[i]);
-                    if (str_item.find(name)==0) {
-                      if (use_brackets && str_item.find("[]=",name_len)==name_len) {
+                    // erase with the same URL-decoding key match get_list() used to find it
+                    if (qs_k2v(full_name.c_str(), key_value_pairs_.data() + i, 1) != nullptr)
                         key_value_pairs_.erase(key_value_pairs_.begin() + i--);
-                      } else if (!use_brackets && str_item.find('=',name_len)==name_len ) {
-                           key_value_pairs_.erase(key_value_pairs_.begin() + i--);
-                       }
-                    }
                 }
             }
             return ret;
@@ -496,17 +490,14 @@ namespace crow
         /// Works the same as \ref get_dict() but removes the values from the query string.
         std::unordered_map<std::string, std::string> pop_dict(const std::string& name)
         {
-            const std::string name_value = name +'[';
             std::unordered_map<std::string, std::string> ret = get_dict(name);
             if (!ret.empty())
             {
                 for (unsigned int i = 0; i < key_value_pairs_.size(); i++)
                 {
-                    std::string str_item(key_value_pairs_[i]);
-                    if (str_item.find(name_value)==0)
-                    {
+                    // erase with the same key match get_dict() used to find it
+                    if (qs_dict_name2kv(name.c_str(), key_value_pairs_.data() + i, 1) != nullptr)
                         key_value_pairs_.erase(key_value_pairs_.begin() + i--);
-                    }
                 }
             }
             return ret;

--- a/tests/query_string_tests.cpp
+++ b/tests/query_string_tests.cpp
@@ -76,3 +76,57 @@ TEST_CASE( "malformed percent encoding - trailing percent" )
 
     REQUIRE(true); // Test passes if no crash/sanitizer error
 }
+TEST_CASE( "pop family removes percent-encoded keys" )
+{
+    // pop() must remove what get() found, including URL-encoded key names
+    {
+        crow::query_string qs("https://example.com/?a%20b=1&z=9");
+        REQUIRE(qs.get("a b") != nullptr);
+        REQUIRE(std::string(qs.pop("a b")) == "1");
+        REQUIRE(qs.get("a b") == nullptr);
+        REQUIRE(qs.keys().size() == 1);
+    }
+    {
+        crow::query_string qs("https://example.com/?a+b=1&z=9");
+        REQUIRE(std::string(qs.pop("a b")) == "1");
+        REQUIRE(qs.get("a b") == nullptr);
+    }
+    // a valueless key is found by get(), so pop() must remove it too
+    {
+        crow::query_string qs("https://example.com/?foo&bar=1");
+        REQUIRE(qs.get("foo") != nullptr);
+        (void)qs.pop("foo");
+        REQUIRE(qs.get("foo") == nullptr);
+        REQUIRE(qs.get("bar") != nullptr);
+    }
+    // pop_list() must remove what get_list() found
+    {
+        crow::query_string qs("https://example.com/?a+b[]=1&a+b[]=2&z=9");
+        REQUIRE(qs.get_list("a b").size() == 2);
+        REQUIRE(qs.pop_list("a b").size() == 2);
+        REQUIRE(qs.get_list("a b").empty() == true);
+        REQUIRE(qs.keys().size() == 1);
+    }
+    // pop_dict() must remove what get_dict() found, encoded brackets included
+    {
+        crow::query_string qs("https://example.com/?page%5Bsize%5D=3&page%5Bnum%5D=7&z=9");
+        REQUIRE(qs.get_dict("page").size() == 2);
+        REQUIRE(qs.pop_dict("page").size() == 2);
+        REQUIRE(qs.get_dict("page").empty() == true);
+        REQUIRE(qs.keys().size() == 1);
+    }
+    // pop() removes only the first occurrence, exactly what get() returned
+    {
+        crow::query_string qs("https://example.com/?a+b=1&z=9&a+b=2");
+        REQUIRE(std::string(qs.pop("a b")) == "1");
+        REQUIRE(std::string(qs.get("a b")) == "2");
+        REQUIRE(qs.keys().size() == 2);
+    }
+    // plain ASCII keys keep working
+    {
+        crow::query_string qs("https://example.com/?hello=world&left=right");
+        REQUIRE(std::string(qs.pop("left")) == "right");
+        REQUIRE(qs.get("left") == nullptr);
+        REQUIRE(std::string(qs.get("hello")) == "world");
+    }
+}


### PR DESCRIPTION
### Problem

`query_string`'s getters resolve a key through the URL-decoding matcher, but the matching `pop*` erasers compare the raw, still-encoded bytes. So `pop()` can return the right value and then fail to erase the entry it just returned.

The odd-one-out: your own `get()` at `include/crow/query_string.h:406` already does this correctly -- it calls `qs_k2v()` (`:185`), which compares with `qs_strncmp()` (`:52`) and therefore URL-decodes both sides before comparing. `pop()` at `:413` builds `const std::string key_name = name + '=';` (`:418`) and erases on `str_item.find(key_name) == 0` (`:422`), a raw byte prefix test on the undecoded pair. The same asymmetry repeats twice more:

| finder | matches with | eraser | matches with |
| --- | --- | --- | --- |
| `get()` `:406` | `qs_k2v` `:185` -> `qs_strncmp` `:52` (decodes) | `pop()` `:413` | `find(name + '=')` `:418`,`:422` (raw) |
| `get_list()` `:436` | `qs_k2v` `:445` (decodes) | `pop_list()` `:454` | `find(name)`/`find("[]=", name_len)` `:463`,`:464`,`:466` (raw) |
| `get_dict()` `:481` | `qs_dict_name2kv` `:488` (decodes, incl. `%5B`/`%5D`) | `pop_dict()` `:497` | `find(name + '[')` `:499`,`:506` (raw) |

`pop_dict()`'s own doc comment at `:496` states the contract that is broken:

> `/// Works the same as \ref get_dict() but removes the values from the query string.`

The dict row is a leftover from a half-fix. Merged PR #1223 ("decode %5B/%5D dict keys like literal brackets", issue #1109) taught `qs_dict_name2kv()` to understand percent-encoded brackets (`:249-251`), which fixed `get_dict("page")` for `?page%5Bsize%5D=3`. `pop_dict()` was not touched -- its patch contains zero occurrences of `pop_dict` -- so after that PR `get_dict()` finds those entries and `pop_dict()` still cannot erase them.

### Reproduction (run against pristine `master`)

```
                                   PRISTINE                      WITH THIS PATCH
CASE 1 ?my%20key=1&other=2
  get("my key")                    1                             1
  pop("my key")                    1                             1
  get after pop                    1   <-- NOT REMOVED           (null)
  remaining keys                   [my%20key] [other]            [other]
CASE 2 ?my+key=1&other=2
  get after pop                    1   <-- NOT REMOVED           (null)
CASE 3 ?my%20list[]=a&my%20list[]=b&other=2
  pop_list().size()                2                             2
  get_list after pop               2   <-- NOT REMOVED           0
CASE 4 ?page%5Bsize%5D=3&page%5Bnum%5D=7&other=2   (the #1223 seam)
  pop_dict().size()                2                             2
  get_dict after pop               2   <-- NOT REMOVED           0
CASE 5 ?a=1&b[]=x&b[]=y&c[k]=v     (plain ASCII control)
  pop/pop_list/pop_dict            1 / 2 / 1, keys left: none    IDENTICAL
```

`pop()` returns the correct value in every case; only the erase misses. A caller that pops a key to consume it and then re-reads the query string sees the entry still there.

### Fix

Route each eraser through the same matcher its getter uses, on a one-element window of the pair vector:

- `pop()` -> `qs_k2v(name.c_str(), key_value_pairs_.data() + i, 1)`
- `pop_list()` -> `qs_k2v(full_name.c_str(), ...)` where `full_name` is `name` plus `"[]"` when `use_brackets`
- `pop_dict()` -> `qs_dict_name2kv(name.c_str(), ...)`

This is a net `+7/-16` and deletes the three hand-rolled prefix tests.

It is not a widening. `qs_strncmp()`'s terminator (`:52`) is `if (CROW_QS_ISQSCHR(*qs)) return -1; else return 0;`, i.e. the key must end exactly where the search key ends, so `get("foo")` still does not match `foobar=1`. Both `qs_k2v` (`:185`) and `qs_dict_name2kv` (`:215`) are pure readers -- `qs_decode()` (`:154`), the only mutating helper, is called solely at `:143` and `:312`, neither of which is on this path -- so calling them from `pop*` has no side effect on the buffer.

Behaviour deliberately preserved: `pop()` still erases only the first match and keeps its `break`; `pop_list()`/`pop_dict()` still erase every match and keep the `i--`.

### Tests

`tests/query_string_tests.cpp` gains one `TEST_CASE` with 7 blocks / 23 assertions covering `%20` and `+` encodings, a valueless key (`?foo&bar=1` -- `get()` finds it, so `pop()` must remove it), the bracketed-list and encoded-dict forms, first-occurrence-only semantics on a separated duplicate (`?a+b=1&z=9&a+b=2`), and a plain-ASCII regression control.

Red/green plus a both-direction mutation matrix (each mutant applied to the fixed source alone):

| case | result |
| --- | --- |
| GREEN (patch + new tests) | pass, 23 assertions, 0 warnings |
| RED (pristine header + new tests) | fail at `query_string_tests.cpp:86` |
| MUT-A revert `pop` to raw `find` | killed |
| MUT-B `pop_list` uses `name` not `full_name` | killed |
| MUT-C revert `pop_dict` to raw `find` | killed |
| MUT-D drop the `break` in `pop` | killed |
| MUT-E drop the `i--` in `pop_list` | killed |
| MUT-F drop the `i--` in `pop_dict` | killed |

Built with the repo's own warning flags (`-Wall -Wextra -Wpedantic -Wsuggest-override -Wshadow` from `cmake/compiler_options.cmake:3-51`) at `-std=c++17` (`CMakeLists.txt:24`): zero warnings attributable to `query_string.h`. Also run under `-fsanitize=address,undefined` with the exact `ASAN_OPTIONS`/`UBSAN_OPTIONS` from the `sanitize` job in `.github/workflows/build_and_test.yml`: clean.

The whole test suite passes: 1019 assertions in 130 test cases.

Build note: `cmake` is not available in my environment, so I compiled the eight `TEST_SRCS` directly with `g++ -std=c++17` against a prebuilt Catch2 v3.15.1 amalgamation and standalone asio rather than through the project's presets. The CI matrix (clang, libc++, boost asio, macOS, MSVC) is the real check.

### AI disclosure

This patch was prepared with AI assistance (Claude). I reviewed the diff, wrote and ran the reproduction and the mutation matrix myself, and take responsibility for the change.
